### PR TITLE
ci(docs): pin wrangler v4 for assets-only Worker deploy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -62,4 +62,6 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          # v4 is required for assets-only Workers (no `main` script).
+          wranglerVersion: "4"
           command: deploy


### PR DESCRIPTION
El primer deploy del workflow Docs falló con `Missing entry-point ... main config field` porque `cloudflare/wrangler-action@v3` instala Wrangler 3.90.0 por defecto, y los Workers **assets-only** (sin script `main`) requieren **Wrangler 4.x**.

Fija `wranglerVersion: "4"` en el step de deploy. Cambio de una línea.