### PR TITLE
test(auth): add optional phone to RegisterDto (e2e)

### DIFF
--- a/src/auth/dto/register.dto.ts
+++ b/src/auth/dto/register.dto.ts
@@ -20,4 +20,9 @@ export class RegisterDto {
   @IsOptional()
   @IsString()
   lastName?: string;
+
+  @ApiPropertyOptional({ example: '+1 555 010 0199' })
+  @IsOptional()
+  @IsString()
+  phone?: string;
 }


### PR DESCRIPTION
Additive optional `phone` field on `RegisterDto` to validate the cross-repo OpenAPI pipeline: oasdiff detects the contract change -> dispatch -> restosync-web opens `chore/update-openapi`. Non-breaking; safe to revert after.