### PR TITLE
fix(infra): install openssl in Alpine stages for Prisma schema engine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@
 FROM node:22-alpine AS builder
 WORKDIR /app
 
+RUN apk add --no-cache openssl
+
 COPY package*.json ./
 COPY prisma ./prisma
 RUN npm ci
@@ -13,6 +15,8 @@ RUN npx prisma generate && npm run build
 FROM node:22-alpine AS runner
 WORKDIR /app
 ENV NODE_ENV=production
+
+RUN apk add --no-cache openssl
 
 COPY package*.json ./
 COPY prisma ./prisma


### PR DESCRIPTION
## Summary
- Adds `apk add --no-cache openssl` to both builder and runner stages of the Dockerfile
- Fixes the `release_command` (`npx prisma migrate deploy`) failing on Fly.io with: `Could not parse schema engine response` because Prisma couldn't detect/load libssl on Alpine

## Root cause
`node:22-alpine` doesn't ship OpenSSL by default. Prisma's schema engine requires it for both `generate` and `migrate deploy`. Switching to Debian-based images would also work but would quadruple the image size unnecessarily.

## Test plan
- [ ] CI deploy workflow completes without `release_command failed` error
- [ ] `prisma migrate deploy` exits with code 0 on the Fly Machine