### PR TITLE
fix(infra): assert dist/main.js exists after builder COPY

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ COPY prisma ./prisma
 RUN npm ci --omit=dev && npx prisma generate
 
 COPY --from=builder /app/dist ./dist
+RUN test -f dist/main.js || (echo "dist/main.js missing — nest build produced no output" && exit 1)
 
 EXPOSE 3000
 CMD ["node", "dist/main"]


### PR DESCRIPTION
## Summary

- Adds a `RUN test -f dist/main.js` guard in the runner stage of the Dockerfile, immediately after `COPY --from=builder /app/dist ./dist`
- Fixes the deploy failure from [run #28337763671](https://github.com/resto-management-system-service/restosync-api/actions/runs/28337763671/job/83946823007) where the machine crashed on startup with `Cannot find module '/app/dist/main'`

**Root cause**: The previous two deploy attempts (wrong Dockerfile path, missing openssl) left a potentially stale layer in Fly's Depot cache. When the fixed build ran, the runner stage's `COPY --from=builder /app/dist` may have used a cached layer with an empty `dist/`, shipping an image with no compiled output. The machine then crash-looped until hitting Fly's max restart count (10) and was suspended.

**Why this fix works**:
1. The Dockerfile change busts all cached layers in Depot, forcing a clean rebuild
2. The guard makes any future "empty dist" scenario fail loudly at build time (`exit 1`) rather than silently deploying a broken image

## Test plan

- [ ] CI deploy workflow passes and the Fly machine reaches healthy state
- [ ] `GET /health` returns `{ status: "ok", db: "up" }` after deploy