### PR TITLE
fix(ci): bust Depot remote build cache on deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # master
-      - run: flyctl deploy --config infra/fly.toml --remote-only
+      - run: flyctl deploy --config infra/fly.toml --remote-only --no-cache
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION
## Summary
- Depot (Fly.io's remote builder) was serving a stale cached runner layer from an early failed build where `dist/` was empty
- Every subsequent deploy shipped an image without `dist/main.js`, causing `Error: Cannot find module '/app/dist/main'` at startup
- Adding `--no-cache` forces Depot to rebuild all layers clean, eliminating the cache poisoning

## Test plan
- [ ] CI (Build & Test) passes on this PR
- [ ] After merge, Deploy workflow runs with `--no-cache` and `dist/main.js` is present in the image
- [ ] Fly.io machine starts successfully