### PR TITLE
fix(build): exclude scripts/ from tsconfig.build.json

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # master
-      - run: flyctl deploy --config infra/fly.toml --remote-only
+      - run: flyctl deploy --config infra/fly.toml --remote-only --no-cache
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # master
-      - run: flyctl deploy --config infra/fly.toml --remote-only --no-cache
+      - run: flyctl deploy --config infra/fly.toml --remote-only
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "test", "dist", "prisma", "**/*spec.ts"]
+  "exclude": ["node_modules", "test", "dist", "prisma", "scripts", "**/*spec.ts"]
 }


### PR DESCRIPTION
## Root cause

`scripts/generate-openapi.ts` lives outside `src/` and was not excluded from `tsconfig.build.json`. When tsc included it, it inferred `rootDir` as `.` (repo root) instead of `src/`. This shifted all output paths:

- `src/main.ts` → `dist/src/main.js` ← wrong
- Expected: `src/main.ts` → `dist/main.js`

So `node dist/main` crashed with `Error: Cannot find module '/app/dist/main'` on every Fly.io deploy.

## Fix

- Add `"scripts"` to the `exclude` array in `tsconfig.build.json`
- Revert the `--no-cache` workaround from #74 (root cause is now fixed, no need to bust Depot cache every deploy)

## Test plan
- [ ] CI (Build & Test) passes
- [ ] After merge, Deploy workflow builds and `dist/main.js` exists in the image
- [ ] Fly.io machine starts successfully