### PR TITLE
feat(#24): Feature/order type migration

### DIFF
--- a/prisma/migrations/20260629204626_add_order_type_and_table/migration.sql
+++ b/prisma/migrations/20260629204626_add_order_type_and_table/migration.sql
@@ -1,0 +1,6 @@
+-- CreateEnum
+CREATE TYPE "OrderType" AS ENUM ('DINE_IN', 'TAKEAWAY');
+
+-- AlterTable
+ALTER TABLE "orders" ADD COLUMN "type" "OrderType" NOT NULL DEFAULT 'DINE_IN',
+                   ADD COLUMN "table" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -79,6 +79,11 @@ model MenuItem {
 
 // ---------- Orders ----------
 
+enum OrderType {
+  DINE_IN
+  TAKEAWAY
+}
+
 enum OrderStatus {
   PENDING
   CONFIRMED
@@ -93,7 +98,9 @@ model Order {
   number       String      @unique
   customerId   String?
   customer     User?       @relation(fields: [customerId], references: [id], onDelete: SetNull)
+  type         OrderType   @default(DINE_IN)
   status       OrderStatus @default(PENDING)
+  table        String?
   subtotalCents Int        @default(0)
   taxCents     Int         @default(0)
   totalCents   Int         @default(0)

--- a/src/orders/dto/create-order.dto.ts
+++ b/src/orders/dto/create-order.dto.ts
@@ -1,14 +1,18 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { OrderType } from '@prisma/client';
 import { Type } from 'class-transformer';
 import {
   ArrayMinSize,
   IsArray,
+  IsEnum,
   IsInt,
+  IsNotEmpty,
   IsObject,
   IsOptional,
   IsString,
   IsUUID,
   Min,
+  ValidateIf,
   ValidateNested,
 } from 'class-validator';
 
@@ -32,6 +36,16 @@ export class OrderLineDto {
 }
 
 export class CreateOrderDto {
+  @ApiProperty({ enum: OrderType, default: OrderType.DINE_IN })
+  @IsEnum(OrderType)
+  type!: OrderType;
+
+  @ApiPropertyOptional({ description: 'Table number (required for dine-in)' })
+  @ValidateIf((o) => o.type === OrderType.DINE_IN || o.table !== undefined)
+  @IsString()
+  @IsNotEmpty()
+  table?: string;
+
   @ApiProperty({ type: [OrderLineDto] })
   @IsArray()
   @ArrayMinSize(1)

--- a/src/orders/dto/create-order.dto.ts
+++ b/src/orders/dto/create-order.dto.ts
@@ -40,10 +40,10 @@ export class CreateOrderDto {
   @IsEnum(OrderType)
   type!: OrderType;
 
-  @ApiPropertyOptional({ description: 'Table number (required for dine-in)' })
-  @ValidateIf((o) => o.type === OrderType.DINE_IN || o.table !== undefined)
+  @ApiPropertyOptional()
+  @ValidateIf((o) => o.type === OrderType.DINE_IN)
   @IsString()
-  @IsNotEmpty()
+  @IsNotEmpty({ message: 'table is required for dine-in orders' })
   table?: string;
 
   @ApiProperty({ type: [OrderLineDto] })

--- a/src/orders/orders.service.ts
+++ b/src/orders/orders.service.ts
@@ -62,7 +62,9 @@ export class OrdersService {
       data: {
         number: this.generateOrderNumber(),
         customerId: customerId ?? null,
+        type: dto.type,
         status: OrderStatus.PENDING,
+        table: dto.table,
         subtotalCents,
         taxCents,
         totalCents,


### PR DESCRIPTION
closes #24 
## Changes
- Add `OrderType` enum (DINE_IN, TAKEAWAY)
- Add `type` and `table` fields to Order model
- Migration: add_order_type_and_table
- Update CreateOrderDto with conditional validation (@ValidateIf)
- Update OrdersService.create() to accept new fields 