### PR TITLE
feat(#23): editable order model with DRAFT status and line-item endpoints

### DIFF
--- a/prisma/migrations/20260630000000_add_draft_status/migration.sql
+++ b/prisma/migrations/20260630000000_add_draft_status/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "OrderStatus" ADD VALUE 'DRAFT';

--- a/prisma/migrations/20260630000001_default_draft_status/migration.sql
+++ b/prisma/migrations/20260630000001_default_draft_status/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "orders" ALTER COLUMN "status" SET DEFAULT 'DRAFT';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -80,6 +80,7 @@ model MenuItem {
 // ---------- Orders ----------
 
 enum OrderStatus {
+  DRAFT
   PENDING
   CONFIRMED
   PREPARING
@@ -93,7 +94,7 @@ model Order {
   number       String      @unique
   customerId   String?
   customer     User?       @relation(fields: [customerId], references: [id], onDelete: SetNull)
-  status       OrderStatus @default(PENDING)
+  status       OrderStatus @default(DRAFT)
   subtotalCents Int        @default(0)
   taxCents     Int         @default(0)
   totalCents   Int         @default(0)

--- a/src/orders/dto/add-order-item.dto.ts
+++ b/src/orders/dto/add-order-item.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsInt, IsObject, IsOptional, IsUUID, Min } from 'class-validator';
+
+export class AddOrderItemDto {
+  @ApiProperty({ format: 'uuid' })
+  @IsUUID()
+  menuItemId!: string;
+
+  @ApiProperty({ example: 2, minimum: 1 })
+  @IsInt()
+  @Min(1)
+  quantity!: number;
+
+  @ApiPropertyOptional({
+    description:
+      'Free-form modifiers (e.g. { "size": "L", "extras": ["bacon"] })',
+  })
+  @IsOptional()
+  @IsObject()
+  modifiers?: Record<string, unknown>;
+}

--- a/src/orders/dto/update-order-item.dto.ts
+++ b/src/orders/dto/update-order-item.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsInt, Min } from 'class-validator';
+
+export class UpdateOrderItemDto {
+  @ApiProperty({ example: 2, minimum: 1 })
+  @IsInt()
+  @Min(1)
+  quantity!: number;
+}

--- a/src/orders/order-status.ts
+++ b/src/orders/order-status.ts
@@ -2,6 +2,7 @@ import { OrderStatus } from '@prisma/client';
 
 // Allowed status transitions for an order. Anything not listed is rejected.
 export const ORDER_STATUS_TRANSITIONS: Record<OrderStatus, OrderStatus[]> = {
+  [OrderStatus.DRAFT]: [OrderStatus.PENDING, OrderStatus.CANCELLED],
   [OrderStatus.PENDING]: [OrderStatus.CONFIRMED, OrderStatus.CANCELLED],
   [OrderStatus.CONFIRMED]: [OrderStatus.PREPARING, OrderStatus.CANCELLED],
   [OrderStatus.PREPARING]: [OrderStatus.READY, OrderStatus.CANCELLED],

--- a/src/orders/orders.controller.ts
+++ b/src/orders/orders.controller.ts
@@ -1,6 +1,7 @@
 import {
   Body,
   Controller,
+  Delete,
   Get,
   Param,
   Patch,
@@ -15,7 +16,9 @@ import {
 } from '../auth/decorators/current-user.decorator';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { PaginationQueryDto } from '../common/dto/pagination-query.dto';
+import { AddOrderItemDto } from './dto/add-order-item.dto';
 import { CreateOrderDto } from './dto/create-order.dto';
+import { UpdateOrderItemDto } from './dto/update-order-item.dto';
 import { UpdateOrderStatusDto } from './dto/update-order-status.dto';
 import { OrdersService } from './orders.service';
 
@@ -44,5 +47,41 @@ export class OrdersController {
   @Patch(':id/status')
   updateStatus(@Param('id') id: string, @Body() dto: UpdateOrderStatusDto) {
     return this.ordersService.updateStatus(id, dto.status);
+  }
+
+  @ApiBearerAuth()
+  @ApiTags('orders')
+  @Roles(Role.STAFF, Role.ADMIN)
+  @Post(':id/items')
+  addItem(@Param('id') id: string, @Body() dto: AddOrderItemDto) {
+    return this.ordersService.addItem(id, dto);
+  }
+
+  @ApiBearerAuth()
+  @ApiTags('orders')
+  @Roles(Role.STAFF, Role.ADMIN)
+  @Patch(':id/items/:itemId')
+  updateItemQuantity(
+    @Param('id') id: string,
+    @Param('itemId') itemId: string,
+    @Body() dto: UpdateOrderItemDto,
+  ) {
+    return this.ordersService.updateItemQuantity(id, itemId, dto);
+  }
+
+  @ApiBearerAuth()
+  @ApiTags('orders')
+  @Roles(Role.STAFF, Role.ADMIN)
+  @Delete(':id/items/:itemId')
+  removeItem(@Param('id') id: string, @Param('itemId') itemId: string) {
+    return this.ordersService.removeItem(id, itemId);
+  }
+
+  @ApiBearerAuth()
+  @ApiTags('orders')
+  @Roles(Role.STAFF, Role.ADMIN)
+  @Post(':id/confirm')
+  confirmOrder(@Param('id') id: string) {
+    return this.ordersService.confirmOrder(id);
   }
 }

--- a/src/orders/orders.service.ts
+++ b/src/orders/orders.service.ts
@@ -13,7 +13,14 @@ import {
 } from '../common/dto/pagination-query.dto';
 import { AuthUser } from '../auth/decorators/current-user.decorator';
 import { CreateOrderDto } from './dto/create-order.dto';
+import { AddOrderItemDto } from './dto/add-order-item.dto';
+import { UpdateOrderItemDto } from './dto/update-order-item.dto';
 import { canTransition } from './order-status';
+
+const EDITABLE_STATUSES: OrderStatus[] = [
+  OrderStatus.DRAFT,
+  OrderStatus.PENDING,
+];
 
 const orderInclude = { items: true } satisfies Prisma.OrderInclude;
 
@@ -132,6 +139,156 @@ export class OrdersService {
     await this.prisma.order.update({
       where: { id },
       data: { status: OrderStatus.CONFIRMED },
+    });
+  }
+
+  async addItem(orderId: string, dto: AddOrderItemDto) {
+    const order = await this.prisma.order.findUnique({
+      where: { id: orderId },
+    });
+    if (!order) {
+      throw new NotFoundException('Order not found');
+    }
+    if (!EDITABLE_STATUSES.includes(order.status)) {
+      throw new BadRequestException(
+        `Cannot modify items on an order with status ${order.status}`,
+      );
+    }
+
+    const menuItem = await this.prisma.menuItem.findUnique({
+      where: { id: dto.menuItemId },
+    });
+    if (!menuItem || !menuItem.available) {
+      throw new NotFoundException('Menu item not found or not available');
+    }
+
+    const lineTotalCents = menuItem.priceCents * dto.quantity;
+
+    await this.prisma.orderItem.create({
+      data: {
+        orderId,
+        menuItemId: menuItem.id,
+        nameSnapshot: menuItem.name,
+        priceCents: menuItem.priceCents,
+        quantity: dto.quantity,
+        modifiers: (dto.modifiers ?? null) as Prisma.InputJsonValue,
+        lineTotalCents,
+      },
+    });
+
+    await this.recalculateTotals(orderId);
+
+    return this.prisma.order.findUnique({
+      where: { id: orderId },
+      include: orderInclude,
+    });
+  }
+
+  async updateItemQuantity(
+    orderId: string,
+    orderItemId: string,
+    dto: UpdateOrderItemDto,
+  ) {
+    const order = await this.prisma.order.findUnique({
+      where: { id: orderId },
+    });
+    if (!order) {
+      throw new NotFoundException('Order not found');
+    }
+    if (!EDITABLE_STATUSES.includes(order.status)) {
+      throw new BadRequestException(
+        `Cannot modify items on an order with status ${order.status}`,
+      );
+    }
+
+    const orderItem = await this.prisma.orderItem.findFirst({
+      where: { id: orderItemId, orderId },
+    });
+    if (!orderItem) {
+      throw new NotFoundException('Order item not found');
+    }
+
+    const lineTotalCents = orderItem.priceCents * dto.quantity;
+
+    await this.prisma.orderItem.update({
+      where: { id: orderItemId },
+      data: { quantity: dto.quantity, lineTotalCents },
+    });
+
+    await this.recalculateTotals(orderId);
+
+    return this.prisma.order.findUnique({
+      where: { id: orderId },
+      include: orderInclude,
+    });
+  }
+
+  async removeItem(orderId: string, orderItemId: string) {
+    const order = await this.prisma.order.findUnique({
+      where: { id: orderId },
+    });
+    if (!order) {
+      throw new NotFoundException('Order not found');
+    }
+    if (!EDITABLE_STATUSES.includes(order.status)) {
+      throw new BadRequestException(
+        `Cannot modify items on an order with status ${order.status}`,
+      );
+    }
+
+    const orderItem = await this.prisma.orderItem.findFirst({
+      where: { id: orderItemId, orderId },
+    });
+    if (!orderItem) {
+      throw new NotFoundException('Order item not found');
+    }
+
+    await this.prisma.orderItem.delete({ where: { id: orderItemId } });
+
+    await this.recalculateTotals(orderId);
+
+    return this.prisma.order.findUnique({
+      where: { id: orderId },
+      include: orderInclude,
+    });
+  }
+
+  async confirmOrder(orderId: string) {
+    const order = await this.prisma.order.findUnique({
+      where: { id: orderId },
+      include: orderInclude,
+    });
+    if (!order) {
+      throw new NotFoundException('Order not found');
+    }
+    if (order.items.length === 0) {
+      throw new BadRequestException('Order must have at least one item');
+    }
+    if (!canTransition(order.status, OrderStatus.PENDING)) {
+      throw new BadRequestException(
+        `Cannot transition order from ${order.status} to ${OrderStatus.PENDING}`,
+      );
+    }
+
+    return this.prisma.order.update({
+      where: { id: orderId },
+      data: { status: OrderStatus.PENDING },
+      include: orderInclude,
+    });
+  }
+
+  private async recalculateTotals(orderId: string) {
+    const items = await this.prisma.orderItem.findMany({ where: { orderId } });
+    const subtotalCents = items.reduce(
+      (sum, item) => sum + item.priceCents * item.quantity,
+      0,
+    );
+    const taxCents = 0; // Tax strategy is out of scope for v1; wire a rate here later.
+    const totalCents = subtotalCents + taxCents;
+
+    await this.prisma.order.update({
+      where: { id: orderId },
+      data: { subtotalCents, taxCents, totalCents },
     });
   }
 


### PR DESCRIPTION
Closes #23 

## Changes
- Add DRAFT status to OrderStatus enum
- Change Order.status default to DRAFT
- Add DRAFT → PENDING, CANCELLED transitions in order-status.ts
- Add addItem(), updateItemQuantity(), removeItem(), confirmOrder() to OrdersService
- Add private recalculateTotals() helper (server-side, never trusts client)
- Add POST/PATCH/DELETE /orders/:id/items and POST /orders/:id/confirm endpoints
- Add AddOrderItemDto and UpdateOrderItemDto
- Apply migrations: add_draft_status + default_draft_status