### PR TITLE
feat(#21): close/confirm order - add Swagger docs

### DIFF
--- a/src/orders/orders.controller.ts
+++ b/src/orders/orders.controller.ts
@@ -117,6 +117,14 @@ export class OrdersController {
   @ApiTags('orders')
   @Roles(Role.STAFF, Role.ADMIN)
   @Post(':id/confirm')
+  @ApiOperation({ summary: 'Close an order and send to checkout' })
+  @ApiResponse({ status: 200, description: 'Order closed, status PENDING' })
+  @ApiResponse({
+    status: 400,
+    description: 'Order has no items or invalid transition',
+  })
+  @ApiResponse({ status: 404, description: 'Order not found' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   confirmOrder(@Param('id') id: string) {
     return this.ordersService.confirmOrder(id);
   }


### PR DESCRIPTION
Closes #21 

## Changes
- Verify POST /orders/:id/confirm meets acceptance criteria (implemented in #23)
- Note: design uses DRAFT→PENDING→CONFIRMED (not DRAFT→CONFIRMED directly)
- Add Swagger decorators for API documentation