### PR TITLE
feat(#22): list open orders with live total

### DIFF
--- a/src/orders/orders.controller.ts
+++ b/src/orders/orders.controller.ts
@@ -47,6 +47,18 @@ export class OrdersController {
     return this.ordersService.findAll(query, user);
   }
 
+  @Roles(Role.STAFF, Role.ADMIN)
+  @Get('open')
+  @ApiOperation({ summary: 'List open orders with current totals' })
+  @ApiResponse({
+    status: 200,
+    description: 'List of DRAFT/PENDING orders with totals',
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  findOpen() {
+    return this.ordersService.findOpen();
+  }
+
   @Get(':id')
   findOne(@Param('id') id: string, @CurrentUser() user: AuthUser) {
     return this.ordersService.findOne(id, user);

--- a/src/orders/orders.service.ts
+++ b/src/orders/orders.service.ts
@@ -111,6 +111,14 @@ export class OrdersService {
     return order;
   }
 
+  async findOpen() {
+    return this.prisma.order.findMany({
+      where: { status: { in: [OrderStatus.DRAFT, OrderStatus.PENDING] } },
+      include: orderInclude,
+      orderBy: { createdAt: 'asc' },
+    });
+  }
+
   async updateStatus(id: string, next: OrderStatus) {
     const order = await this.prisma.order.findUnique({ where: { id } });
     if (!order) {


### PR DESCRIPTION
Closes #22 

## Changes
- Add findOpen() to OrdersService — queries DRAFT/PENDING orders ordered by createdAt ASC
- Add GET /orders/open endpoint with @Roles(Role.STAFF, Role.ADMIN)
- Note: endpoint is /orders/open (not /orders) — findAll() already uses GET /orders