### PR TITLE
feat(#33): generalize Payment model with PaymentMethod enum

### DIFF
--- a/prisma/migrations/20260701000000_generalize_payment_method/migration.sql
+++ b/prisma/migrations/20260701000000_generalize_payment_method/migration.sql
@@ -1,0 +1,6 @@
+-- CreateEnum
+CREATE TYPE "PaymentMethod" AS ENUM ('CASH', 'CARD', 'TRANSFER', 'STRIPE');
+
+-- AlterTable
+ALTER TABLE "payments" ADD COLUMN     "method" "PaymentMethod" NOT NULL DEFAULT 'CASH',
+ALTER COLUMN "providerRef" DROP NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -136,6 +136,13 @@ model OrderItem {
 
 // ---------- Payments ----------
 
+enum PaymentMethod {
+  CASH
+  CARD
+  TRANSFER
+  STRIPE
+}
+
 enum PaymentStatus {
   REQUIRES_PAYMENT
   PROCESSING
@@ -148,8 +155,9 @@ model Payment {
   id            String        @id @default(uuid())
   orderId       String
   order         Order         @relation(fields: [orderId], references: [id], onDelete: Cascade)
+  method        PaymentMethod @default(CASH)
   provider      String        @default("stripe")
-  providerRef   String        @unique // Stripe PaymentIntent id
+  providerRef   String?       @unique // Stripe PaymentIntent id (null for CASH/CARD/TRANSFER)
   amountCents   Int
   currency      String        @default("usd")
   status        PaymentStatus @default(REQUIRES_PAYMENT)

--- a/src/payments/payments.service.ts
+++ b/src/payments/payments.service.ts
@@ -5,7 +5,12 @@ import {
   Logger,
   NotFoundException,
 } from '@nestjs/common';
-import { OrderStatus, PaymentStatus, Prisma } from '@prisma/client';
+import {
+  OrderStatus,
+  PaymentMethod,
+  PaymentStatus,
+  Prisma,
+} from '@prisma/client';
 import { OrdersService } from '../orders/orders.service';
 import { PrismaService } from '../prisma/prisma.service';
 import {
@@ -49,6 +54,7 @@ export class PaymentsService {
       update: { amountCents: order.totalCents },
       create: {
         orderId: order.id,
+        method: PaymentMethod.STRIPE,
         provider: 'stripe',
         providerRef: intent.id,
         amountCents: order.totalCents,


### PR DESCRIPTION
Closes #33 

## Changes
- Add PaymentMethod enum (CASH, CARD, TRANSFER, STRIPE)
- Add method field to Payment model with default CASH
- Make providerRef nullable (non-Stripe payments have no provider ref)
- Set method: STRIPE in createIntent() — Stripe flow unchanged
- Migration: generalize_payment_method