### PR TITLE
feat(#34): add CashRegisterSession model with float and reconciliatio…

### DIFF
--- a/prisma/migrations/20260701000001_add_cash_register_session/migration.sql
+++ b/prisma/migrations/20260701000001_add_cash_register_session/migration.sql
@@ -1,0 +1,29 @@
+-- AlterTable
+ALTER TABLE "payments" ADD COLUMN     "sessionId" TEXT;
+
+-- CreateTable
+CREATE TABLE "cash_register_sessions" (
+    "id" TEXT NOT NULL,
+    "openedById" TEXT NOT NULL,
+    "openedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "closedById" TEXT,
+    "closedAt" TIMESTAMP(3),
+    "openingFloatCents" INTEGER NOT NULL DEFAULT 0,
+    "expectedCents" INTEGER,
+    "countedCents" INTEGER,
+    "differenceCents" INTEGER,
+    "notes" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "cash_register_sessions_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "payments" ADD CONSTRAINT "payments_sessionId_fkey" FOREIGN KEY ("sessionId") REFERENCES "cash_register_sessions"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "cash_register_sessions" ADD CONSTRAINT "cash_register_sessions_openedById_fkey" FOREIGN KEY ("openedById") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "cash_register_sessions" ADD CONSTRAINT "cash_register_sessions_closedById_fkey" FOREIGN KEY ("closedById") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -23,8 +23,10 @@ model User {
   lastName     String?
   role         Role      @default(CUSTOMER)
   active       Boolean   @default(true)
-  orders       Order[]
-  sessions     Session[]
+  orders           Order[]
+  openedSessions   CashRegisterSession[] @relation("OpenedSessions")
+  closedSessions   CashRegisterSession[] @relation("ClosedSessions")
+  sessions         Session[]
   createdAt    DateTime  @default(now())
   updatedAt    DateTime  @updatedAt
 
@@ -162,10 +164,34 @@ model Payment {
   currency      String        @default("usd")
   status        PaymentStatus @default(REQUIRES_PAYMENT)
   lastEventId   String? // last processed webhook event id (idempotency)
-  rawEvent      Json?
-  createdAt     DateTime      @default(now())
-  updatedAt     DateTime      @updatedAt
+  sessionId      String?
+  session        CashRegisterSession? @relation(fields: [sessionId], references: [id])
+  rawEvent        Json?
+  createdAt       DateTime      @default(now())
+  updatedAt       DateTime      @updatedAt
 
   @@index([orderId])
   @@map("payments")
+}
+
+// ---------- Cash Register ----------
+
+model CashRegisterSession {
+  id                String    @id @default(uuid())
+  openedById        String
+  openedBy          User      @relation("OpenedSessions", fields: [openedById], references: [id])
+  openedAt          DateTime  @default(now())
+  closedById        String?
+  closedBy          User?     @relation("ClosedSessions", fields: [closedById], references: [id])
+  closedAt          DateTime?
+  openingFloatCents Int       @default(0)
+  expectedCents     Int?      // computed from sales at close
+  countedCents      Int?      // physically counted by cashier
+  differenceCents   Int?      // countedCents - expectedCents
+  notes             String?
+  payments          Payment[]
+  createdAt         DateTime  @default(now())
+  updatedAt         DateTime  @updatedAt
+
+  @@map("cash_register_sessions")
 }


### PR DESCRIPTION
Closes #34 

## Changes
- Add CashRegisterSession model (openingFloat, expectedCents, countedCents, differenceCents)
- Add openedBy/closedBy relations to User
- Add optional sessionId to Payment model
- Migration: add_cash_register_session