### PR TITLE
feat(#36): checkout endpoint - close order, record payment, attach to…

### DIFF
--- a/prisma/migrations/20260701000002_add_checkout_payment_fields/migration.sql
+++ b/prisma/migrations/20260701000002_add_checkout_payment_fields/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "payments" ADD COLUMN     "changeCents" INTEGER NOT NULL DEFAULT 0,
+ADD COLUMN     "paidCents" INTEGER NOT NULL DEFAULT 0;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -161,6 +161,8 @@ model Payment {
   provider      String        @default("stripe")
   providerRef   String?       @unique // Stripe PaymentIntent id (null for CASH/CARD/TRANSFER)
   amountCents   Int
+  paidCents      Int           @default(0) // amount physically received
+  changeCents    Int           @default(0) // change given back to customer
   currency      String        @default("usd")
   status        PaymentStatus @default(REQUIRES_PAYMENT)
   lastEventId   String? // last processed webhook event id (idempotency)

--- a/src/payments/dto/checkout.dto.ts
+++ b/src/payments/dto/checkout.dto.ts
@@ -1,0 +1,30 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { PaymentMethod } from '@prisma/client';
+import {
+  IsEnum,
+  IsInt,
+  IsOptional,
+  IsString,
+  IsUUID,
+  Min,
+} from 'class-validator';
+
+export class CheckoutDto {
+  @ApiProperty({ format: 'uuid', description: 'Order to check out' })
+  @IsUUID()
+  orderId!: string;
+
+  @ApiProperty({ enum: PaymentMethod, description: 'Payment method used' })
+  @IsEnum(PaymentMethod)
+  method!: PaymentMethod;
+
+  @ApiProperty({ description: 'Amount physically received, in cents' })
+  @IsInt()
+  @Min(0)
+  amountPaidCents!: number;
+
+  @ApiPropertyOptional({ description: 'Optional notes for this payment' })
+  @IsString()
+  @IsOptional()
+  notes?: string;
+}

--- a/src/payments/payments.controller.ts
+++ b/src/payments/payments.controller.ts
@@ -9,9 +9,19 @@ import {
   RawBodyRequest,
   Req,
 } from '@nestjs/common';
-import { ApiBearerAuth, ApiExcludeEndpoint, ApiTags } from '@nestjs/swagger';
+import {
+  ApiBearerAuth,
+  ApiExcludeEndpoint,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { Role } from '@prisma/client';
 import { Request } from 'express';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { Public } from '../auth/decorators/public.decorator';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { CheckoutDto } from './dto/checkout.dto';
 import { CreateIntentDto } from './dto/create-intent.dto';
 import { PaymentsService } from './payments.service';
 
@@ -25,6 +35,26 @@ export class PaymentsController {
   @HttpCode(HttpStatus.CREATED)
   createIntent(@Body() dto: CreateIntentDto) {
     return this.paymentsService.createIntent(dto.orderId);
+  }
+
+  @ApiBearerAuth()
+  @Roles(Role.STAFF, Role.ADMIN)
+  @Post('checkout')
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: 'Checkout: close order and record payment' })
+  @ApiResponse({
+    status: 201,
+    description: 'Payment recorded, order confirmed',
+  })
+  @ApiResponse({
+    status: 400,
+    description:
+      'Order not pending, no active session, or insufficient payment',
+  })
+  @ApiResponse({ status: 404, description: 'Order not found' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  checkout(@Body() dto: CheckoutDto, @CurrentUser('id') userId: string) {
+    return this.paymentsService.checkout(dto, userId);
   }
 
   @Public()

--- a/src/payments/payments.service.ts
+++ b/src/payments/payments.service.ts
@@ -11,8 +11,10 @@ import {
   PaymentStatus,
   Prisma,
 } from '@prisma/client';
+import { canTransition } from '../orders/order-status';
 import { OrdersService } from '../orders/orders.service';
 import { PrismaService } from '../prisma/prisma.service';
+import { CheckoutDto } from './dto/checkout.dto';
 import {
   GatewayEvent,
   PAYMENT_GATEWAY,
@@ -69,6 +71,77 @@ export class PaymentsService {
       amountCents: order.totalCents,
       currency: order.currency,
     };
+  }
+
+  // POS checkout: closes the order, records a payment, and attaches it to
+  // the active cash register session — all in a single transaction.
+  async checkout(dto: CheckoutDto, actorId: string) {
+    const order = await this.prisma.order.findUnique({
+      where: { id: dto.orderId },
+    });
+    if (!order) {
+      throw new NotFoundException('Order not found');
+    }
+    if (order.status !== OrderStatus.PENDING) {
+      throw new BadRequestException(
+        `Order is ${order.status} and cannot be checked out`,
+      );
+    }
+
+    const activeSession = await this.prisma.cashRegisterSession.findFirst({
+      where: { closedAt: null },
+      orderBy: { openedAt: 'desc' },
+    });
+    if (!activeSession) {
+      throw new BadRequestException('No active cash register session');
+    }
+
+    // Idempotency: never double-charge an already-paid order.
+    const existingPayment = await this.prisma.payment.findFirst({
+      where: { orderId: order.id, status: PaymentStatus.SUCCEEDED },
+      include: { order: true },
+    });
+    if (existingPayment) {
+      return existingPayment;
+    }
+
+    // Amount comes from the order's server-computed total, never the client.
+    if (
+      dto.method === PaymentMethod.CASH &&
+      dto.amountPaidCents < order.totalCents
+    ) {
+      throw new BadRequestException('Insufficient payment amount');
+    }
+
+    this.logger.debug(`Checkout for order ${order.id} by user ${actorId}`);
+
+    return this.prisma.$transaction(async (tx) => {
+      if (!canTransition(order.status, OrderStatus.CONFIRMED)) {
+        throw new BadRequestException(
+          `Cannot transition order from ${order.status} to ${OrderStatus.CONFIRMED}`,
+        );
+      }
+      await tx.order.update({
+        where: { id: order.id },
+        data: { status: OrderStatus.CONFIRMED },
+      });
+
+      return tx.payment.create({
+        data: {
+          orderId: order.id,
+          method: dto.method,
+          provider: 'pos',
+          providerRef: null,
+          amountCents: order.totalCents,
+          paidCents: dto.amountPaidCents,
+          changeCents: Math.max(0, dto.amountPaidCents - order.totalCents),
+          currency: order.currency,
+          status: PaymentStatus.SUCCEEDED,
+          sessionId: activeSession.id,
+        },
+        include: { order: true },
+      });
+    });
   }
 
   async handleWebhook(payload: Buffer, signature: string) {


### PR DESCRIPTION
Closes #36 

## Changes
- Add CheckoutDto (orderId, method, amountPaidCents, notes)
- Add paidCents and changeCents to Payment model
- Add checkout() to PaymentsService:
  - Validates order is PENDING
  - Finds active CashRegisterSession
  - Idempotency guard (no double-charge)
  - CASH: validates amountPaidCents >= totalCents
  - Prisma $transaction: order → CONFIRMED + Payment created
- Add POST /payments/checkout endpoint
- Migration: add_checkout_payment_fields
- Stripe createIntent() flow unchanged