### PR TITLE
feat(#30): open cash register with starting float

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,6 +7,7 @@ import { JwtAuthGuard } from './auth/guards/jwt-auth.guard';
 import { RolesGuard } from './auth/guards/roles.guard';
 import configuration from './config/configuration';
 import { validateEnv } from './config/env.validation';
+import { CashRegisterModule } from './cash-register/cash-register.module';
 import { MenuModule } from './menu/menu.module';
 import { OrdersModule } from './orders/orders.module';
 import { PaymentsModule } from './payments/payments.module';
@@ -26,6 +27,7 @@ import { UsersModule } from './users/users.module';
     MenuModule,
     OrdersModule,
     PaymentsModule,
+    CashRegisterModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/cash-register/cash-register.controller.ts
+++ b/src/cash-register/cash-register.controller.ts
@@ -1,0 +1,30 @@
+import { Body, Controller, HttpCode, HttpStatus, Post } from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { Role } from '@prisma/client';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { CashRegisterService } from './cash-register.service';
+import { OpenSessionDto } from './dto/open-session.dto';
+
+@ApiTags('cash-register')
+@ApiBearerAuth()
+@Controller('cash-register')
+export class CashRegisterController {
+  constructor(private readonly cashRegisterService: CashRegisterService) {}
+
+  @Roles(Role.CASHIER, Role.MANAGER, Role.ADMIN)
+  @Post('open')
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: 'Open cash register with starting float' })
+  @ApiResponse({ status: 201, description: 'Session opened' })
+  @ApiResponse({ status: 400, description: 'Session already open' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  openSession(@Body() dto: OpenSessionDto, @CurrentUser('id') userId: string) {
+    return this.cashRegisterService.openSession(dto, userId);
+  }
+}

--- a/src/cash-register/cash-register.module.ts
+++ b/src/cash-register/cash-register.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { CashRegisterController } from './cash-register.controller';
+import { CashRegisterService } from './cash-register.service';
+
+@Module({
+  controllers: [CashRegisterController],
+  providers: [CashRegisterService],
+})
+export class CashRegisterModule {}

--- a/src/cash-register/cash-register.service.ts
+++ b/src/cash-register/cash-register.service.ts
@@ -1,0 +1,25 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { OpenSessionDto } from './dto/open-session.dto';
+
+@Injectable()
+export class CashRegisterService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async openSession(dto: OpenSessionDto, actorId: string) {
+    const active = await this.prisma.cashRegisterSession.findFirst({
+      where: { closedAt: null },
+    });
+    if (active) {
+      throw new BadRequestException('A register session is already open');
+    }
+
+    return this.prisma.cashRegisterSession.create({
+      data: {
+        openedById: actorId,
+        openingFloatCents: dto.openingFloatCents,
+        notes: dto.notes ?? null,
+      },
+    });
+  }
+}

--- a/src/cash-register/dto/open-session.dto.ts
+++ b/src/cash-register/dto/open-session.dto.ts
@@ -1,0 +1,17 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsInt, IsOptional, IsString, Min } from 'class-validator';
+
+export class OpenSessionDto {
+  @ApiProperty({
+    description: 'Starting float amount in cents',
+    example: 10000,
+  })
+  @IsInt()
+  @Min(0)
+  openingFloatCents!: number;
+
+  @ApiPropertyOptional({ description: 'Optional notes for the session' })
+  @IsString()
+  @IsOptional()
+  notes?: string;
+}


### PR DESCRIPTION
Closes #30 

## Changes
- New cash-register module (service, controller, dto, module)
- POST /cash-register/open — creates session with openingFloatCents
- Guards: CASHIER, MANAGER, ADMIN only
- Validates no active session exists before opening
- Register CashRegisterModule in app.module.ts