### PR TITLE
feat(#31): close cash register with reconciliation

### DIFF
--- a/src/cash-register/cash-register.controller.ts
+++ b/src/cash-register/cash-register.controller.ts
@@ -9,6 +9,7 @@ import { Role } from '@prisma/client';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { CashRegisterService } from './cash-register.service';
+import { CloseSessionDto } from './dto/close-session.dto';
 import { OpenSessionDto } from './dto/open-session.dto';
 
 @ApiTags('cash-register')
@@ -26,5 +27,22 @@ export class CashRegisterController {
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   openSession(@Body() dto: OpenSessionDto, @CurrentUser('id') userId: string) {
     return this.cashRegisterService.openSession(dto, userId);
+  }
+
+  @Roles(Role.CASHIER, Role.MANAGER, Role.ADMIN)
+  @Post('close')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Close cash register with reconciliation' })
+  @ApiResponse({
+    status: 200,
+    description: 'Session closed with expected vs counted reconciliation',
+  })
+  @ApiResponse({ status: 400, description: 'No active session' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  closeSession(
+    @Body() dto: CloseSessionDto,
+    @CurrentUser('id') userId: string,
+  ) {
+    return this.cashRegisterService.closeSession(dto, userId);
   }
 }

--- a/src/cash-register/cash-register.service.ts
+++ b/src/cash-register/cash-register.service.ts
@@ -1,5 +1,7 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
+import { PaymentStatus } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
+import { CloseSessionDto } from './dto/close-session.dto';
 import { OpenSessionDto } from './dto/open-session.dto';
 
 @Injectable()
@@ -19,6 +21,38 @@ export class CashRegisterService {
         openedById: actorId,
         openingFloatCents: dto.openingFloatCents,
         notes: dto.notes ?? null,
+      },
+    });
+  }
+
+  async closeSession(dto: CloseSessionDto, actorId: string) {
+    const session = await this.prisma.cashRegisterSession.findFirst({
+      where: { closedAt: null },
+      orderBy: { openedAt: 'desc' },
+    });
+    if (!session) {
+      throw new BadRequestException('No active cash register session');
+    }
+
+    const paymentsAgg = await this.prisma.payment.aggregate({
+      _sum: { amountCents: true },
+      where: {
+        sessionId: session.id,
+        status: PaymentStatus.SUCCEEDED,
+      },
+    });
+    const expectedCents = paymentsAgg._sum.amountCents ?? 0;
+    const differenceCents = dto.countedCents - expectedCents;
+
+    return this.prisma.cashRegisterSession.update({
+      where: { id: session.id },
+      data: {
+        closedById: actorId,
+        closedAt: new Date(),
+        expectedCents,
+        countedCents: dto.countedCents,
+        differenceCents,
+        notes: dto.notes ?? session.notes,
       },
     });
   }

--- a/src/cash-register/dto/close-session.dto.ts
+++ b/src/cash-register/dto/close-session.dto.ts
@@ -1,0 +1,17 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsInt, IsOptional, IsString, Min } from 'class-validator';
+
+export class CloseSessionDto {
+  @ApiProperty({
+    description: 'Physically counted amount in cents',
+    example: 25000,
+  })
+  @IsInt()
+  @Min(0)
+  countedCents!: number;
+
+  @ApiPropertyOptional({ description: 'Optional notes for the session' })
+  @IsString()
+  @IsOptional()
+  notes?: string;
+}


### PR DESCRIPTION
Closes #31 

## Changes
- Add CloseSessionDto (countedCents, notes)
- Add closeSession() to CashRegisterService:
  - Finds active session
  - Computes expectedCents from SUCCEEDED payments in session
  - Computes differenceCents = countedCents - expectedCents
  - Records closedById, closedAt, reconciliation fields
- Add POST /cash-register/close endpoint