### PR TITLE
feat(#32): shift/day sales summary by session and payment method

### DIFF
--- a/src/cash-register/cash-register.controller.ts
+++ b/src/cash-register/cash-register.controller.ts
@@ -1,4 +1,12 @@
-import { Body, Controller, HttpCode, HttpStatus, Post } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Post,
+} from '@nestjs/common';
 import {
   ApiBearerAuth,
   ApiOperation,
@@ -44,5 +52,26 @@ export class CashRegisterController {
     @CurrentUser('id') userId: string,
   ) {
     return this.cashRegisterService.closeSession(dto, userId);
+  }
+
+  @Roles(Role.CASHIER, Role.MANAGER, Role.ADMIN)
+  @Get('sessions/:id/summary')
+  @ApiOperation({ summary: 'Get summary for a specific register session' })
+  @ApiResponse({
+    status: 200,
+    description: 'Session summary with totals by payment method',
+  })
+  @ApiResponse({ status: 404, description: 'Session not found' })
+  getSessionSummary(@Param('id') id: string) {
+    return this.cashRegisterService.getSessionSummary(id);
+  }
+
+  @Roles(Role.CASHIER, Role.MANAGER, Role.ADMIN)
+  @Get('current/summary')
+  @ApiOperation({ summary: 'Get summary for the current active session' })
+  @ApiResponse({ status: 200, description: 'Current session summary' })
+  @ApiResponse({ status: 404, description: 'No active session' })
+  getCurrentSummary() {
+    return this.cashRegisterService.getCurrentSummary();
   }
 }

--- a/src/cash-register/cash-register.service.ts
+++ b/src/cash-register/cash-register.service.ts
@@ -1,5 +1,9 @@
-import { BadRequestException, Injectable } from '@nestjs/common';
-import { PaymentStatus } from '@prisma/client';
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { PaymentMethod, PaymentStatus } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { CloseSessionDto } from './dto/close-session.dto';
 import { OpenSessionDto } from './dto/open-session.dto';
@@ -55,5 +59,51 @@ export class CashRegisterService {
         notes: dto.notes ?? session.notes,
       },
     });
+  }
+
+  async getSessionSummary(sessionId: string) {
+    const session = await this.prisma.cashRegisterSession.findUnique({
+      where: { id: sessionId },
+    });
+    if (!session) {
+      throw new NotFoundException('Session not found');
+    }
+
+    const payments = await this.prisma.payment.findMany({
+      where: { sessionId, status: PaymentStatus.SUCCEEDED },
+    });
+
+    const totalSalesCents = payments.reduce((sum, p) => sum + p.amountCents, 0);
+    const ticketCount = payments.length;
+
+    const byMethodRaw: Record<string, number> = {};
+    for (const p of payments) {
+      byMethodRaw[p.method] = (byMethodRaw[p.method] ?? 0) + p.amountCents;
+    }
+
+    const byMethod: Record<string, number> = {};
+    for (const method of Object.values(PaymentMethod)) {
+      const amount = byMethodRaw[method];
+      if (amount && amount > 0) {
+        byMethod[method] = amount;
+      }
+    }
+
+    return {
+      session,
+      summary: { totalSalesCents, ticketCount, byMethod },
+    };
+  }
+
+  async getCurrentSummary() {
+    const session = await this.prisma.cashRegisterSession.findFirst({
+      where: { closedAt: null },
+      orderBy: { openedAt: 'desc' },
+    });
+    if (!session) {
+      throw new NotFoundException('No active session');
+    }
+
+    return this.getSessionSummary(session.id);
   }
 }


### PR DESCRIPTION
Closes #32 

## Changes
- Add getSessionSummary() — totals, ticket count, breakdown by payment method
- Add getCurrentSummary() — delegates to getSessionSummary() for active session
- Add GET /cash-register/sessions/:id/summary
- Add GET /cash-register/current/summary
- Only methods with amount > 0 appear in byMethod breakdown