### PR TITLE
test(#38): checkout and cash-register reconciliation tests

### DIFF
--- a/src/cash-register/cash-register.service.spec.ts
+++ b/src/cash-register/cash-register.service.spec.ts
@@ -1,0 +1,194 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { PaymentMethod, PaymentStatus } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+import { CashRegisterService } from './cash-register.service';
+
+type MockPrisma = {
+  cashRegisterSession: {
+    findFirst: jest.Mock;
+    findUnique: jest.Mock;
+    create: jest.Mock;
+    update: jest.Mock;
+  };
+  payment: {
+    aggregate: jest.Mock;
+    findMany: jest.Mock;
+  };
+};
+
+function createMockPrisma(): MockPrisma {
+  return {
+    cashRegisterSession: {
+      findFirst: jest.fn(),
+      findUnique: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+    },
+    payment: {
+      aggregate: jest.fn(),
+      findMany: jest.fn(),
+    },
+  };
+}
+
+describe('CashRegisterService', () => {
+  let service: CashRegisterService;
+  let prisma: MockPrisma;
+
+  const actorId = 'user-1';
+  const sessionId = 'session-1';
+
+  beforeEach(() => {
+    prisma = createMockPrisma();
+    service = new CashRegisterService(prisma as unknown as PrismaService);
+  });
+
+  describe('openSession', () => {
+    it('creates a session with openingFloatCents and openedById', async () => {
+      prisma.cashRegisterSession.findFirst.mockResolvedValue(null);
+      const created = {
+        id: sessionId,
+        openedById: actorId,
+        openingFloatCents: 10000,
+        notes: null,
+        closedAt: null,
+      };
+      prisma.cashRegisterSession.create.mockResolvedValue(created);
+
+      const result = await service.openSession(
+        { openingFloatCents: 10000 },
+        actorId,
+      );
+
+      expect(prisma.cashRegisterSession.create).toHaveBeenCalledWith({
+        data: {
+          openedById: actorId,
+          openingFloatCents: 10000,
+          notes: null,
+        },
+      });
+      expect(result).toBe(created);
+    });
+
+    it('throws BadRequestException if a session is already open', async () => {
+      prisma.cashRegisterSession.findFirst.mockResolvedValue({
+        id: sessionId,
+        closedAt: null,
+      });
+
+      await expect(
+        service.openSession({ openingFloatCents: 10000 }, actorId),
+      ).rejects.toThrow(BadRequestException);
+      expect(prisma.cashRegisterSession.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('closeSession', () => {
+    const activeSession = {
+      id: sessionId,
+      closedAt: null,
+      notes: null,
+    };
+
+    it('computes expectedCents from SUCCEEDED payments and differenceCents', async () => {
+      prisma.cashRegisterSession.findFirst.mockResolvedValue(activeSession);
+      prisma.payment.aggregate.mockResolvedValue({
+        _sum: { amountCents: 5000 },
+      });
+      const updated = {
+        ...activeSession,
+        closedById: actorId,
+        closedAt: new Date(),
+        expectedCents: 5000,
+        countedCents: 5200,
+        differenceCents: 200,
+      };
+      prisma.cashRegisterSession.update.mockResolvedValue(updated);
+
+      const result = await service.closeSession(
+        { countedCents: 5200 },
+        actorId,
+      );
+
+      expect(prisma.payment.aggregate).toHaveBeenCalledWith({
+        _sum: { amountCents: true },
+        where: { sessionId, status: PaymentStatus.SUCCEEDED },
+      });
+      expect(prisma.cashRegisterSession.update).toHaveBeenCalledWith({
+        where: { id: sessionId },
+        data: expect.objectContaining({
+          closedById: actorId,
+          closedAt: expect.any(Date),
+          expectedCents: 5000,
+          countedCents: 5200,
+          differenceCents: 200,
+        }),
+      });
+      expect(result).toBe(updated);
+    });
+
+    it('records closedById and closedAt on the update payload', async () => {
+      prisma.cashRegisterSession.findFirst.mockResolvedValue(activeSession);
+      prisma.payment.aggregate.mockResolvedValue({ _sum: { amountCents: 0 } });
+      prisma.cashRegisterSession.update.mockResolvedValue({});
+
+      await service.closeSession({ countedCents: 0 }, actorId);
+
+      const updateCall = prisma.cashRegisterSession.update.mock.calls[0][0];
+      expect(updateCall.data.closedById).toBe(actorId);
+      expect(updateCall.data.closedAt).toBeInstanceOf(Date);
+    });
+
+    it('throws if no active session exists', async () => {
+      prisma.cashRegisterSession.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.closeSession({ countedCents: 0 }, actorId),
+      ).rejects.toThrow(BadRequestException);
+      expect(prisma.cashRegisterSession.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getSessionSummary', () => {
+    it('returns correct totalSalesCents and ticketCount', async () => {
+      prisma.cashRegisterSession.findUnique.mockResolvedValue({
+        id: sessionId,
+      });
+      prisma.payment.findMany.mockResolvedValue([
+        { method: PaymentMethod.CASH, amountCents: 1000 },
+        { method: PaymentMethod.CARD, amountCents: 2000 },
+        { method: PaymentMethod.CASH, amountCents: 500 },
+      ]);
+
+      const result = await service.getSessionSummary(sessionId);
+
+      expect(result.summary.totalSalesCents).toBe(3500);
+      expect(result.summary.ticketCount).toBe(3);
+      expect(result.summary.byMethod).toEqual({
+        CASH: 1500,
+        CARD: 2000,
+      });
+    });
+
+    it('byMethod breakdown only includes methods with amount > 0', async () => {
+      prisma.cashRegisterSession.findUnique.mockResolvedValue({
+        id: sessionId,
+      });
+      prisma.payment.findMany.mockResolvedValue([]);
+
+      const result = await service.getSessionSummary(sessionId);
+
+      expect(result.summary.totalSalesCents).toBe(0);
+      expect(result.summary.ticketCount).toBe(0);
+      expect(result.summary.byMethod).toEqual({});
+    });
+
+    it('throws NotFoundException if the session does not exist', async () => {
+      prisma.cashRegisterSession.findUnique.mockResolvedValue(null);
+
+      await expect(service.getSessionSummary(sessionId)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+});

--- a/src/payments/payments.service.spec.ts
+++ b/src/payments/payments.service.spec.ts
@@ -1,0 +1,230 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { OrderStatus, PaymentMethod, PaymentStatus } from '@prisma/client';
+import { OrdersService } from '../orders/orders.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { PaymentGateway } from './gateway/payment-gateway.interface';
+import { PaymentsService } from './payments.service';
+
+type MockPrisma = {
+  order: {
+    findUnique: jest.Mock;
+  };
+  cashRegisterSession: {
+    findFirst: jest.Mock;
+  };
+  payment: {
+    findFirst: jest.Mock;
+  };
+  $transaction: jest.Mock;
+};
+
+function createMockPrisma(): MockPrisma {
+  return {
+    order: {
+      findUnique: jest.fn(),
+    },
+    cashRegisterSession: {
+      findFirst: jest.fn(),
+    },
+    payment: {
+      findFirst: jest.fn(),
+    },
+    $transaction: jest.fn(),
+  };
+}
+
+describe('PaymentsService', () => {
+  let service: PaymentsService;
+  let prisma: MockPrisma;
+  let txOrderUpdate: jest.Mock;
+  let txPaymentCreate: jest.Mock;
+
+  const orderId = 'order-1';
+  const sessionId = 'session-1';
+  const actorId = 'user-1';
+
+  const baseOrder = {
+    id: orderId,
+    status: OrderStatus.PENDING,
+    totalCents: 1200,
+    currency: 'usd',
+  };
+
+  const activeSession = {
+    id: sessionId,
+    closedAt: null,
+  };
+
+  beforeEach(() => {
+    prisma = createMockPrisma();
+    txOrderUpdate = jest.fn().mockResolvedValue({});
+    txPaymentCreate = jest.fn().mockResolvedValue({ id: 'payment-1' });
+
+    prisma.$transaction.mockImplementation(async (callback) =>
+      callback({
+        order: { update: txOrderUpdate },
+        payment: { create: txPaymentCreate },
+      }),
+    );
+
+    service = new PaymentsService(
+      prisma as unknown as PrismaService,
+      {} as unknown as OrdersService,
+      {} as unknown as PaymentGateway,
+    );
+  });
+
+  describe('checkout', () => {
+    it('creates a CASH payment with correct method and amountCents', async () => {
+      prisma.order.findUnique.mockResolvedValue(baseOrder);
+      prisma.cashRegisterSession.findFirst.mockResolvedValue(activeSession);
+      prisma.payment.findFirst.mockResolvedValue(null);
+
+      await service.checkout(
+        {
+          orderId,
+          method: PaymentMethod.CASH,
+          amountPaidCents: 1200,
+        },
+        actorId,
+      );
+
+      expect(txOrderUpdate).toHaveBeenCalledWith({
+        where: { id: orderId },
+        data: { status: OrderStatus.CONFIRMED },
+      });
+      expect(txPaymentCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            orderId,
+            method: PaymentMethod.CASH,
+            amountCents: 1200,
+            paidCents: 1200,
+            changeCents: 0,
+            status: PaymentStatus.SUCCEEDED,
+            sessionId: activeSession.id,
+            providerRef: null,
+          }),
+        }),
+      );
+    });
+
+    it('computes changeCents correctly (amountPaid - total)', async () => {
+      prisma.order.findUnique.mockResolvedValue(baseOrder);
+      prisma.cashRegisterSession.findFirst.mockResolvedValue(activeSession);
+      prisma.payment.findFirst.mockResolvedValue(null);
+
+      await service.checkout(
+        {
+          orderId,
+          method: PaymentMethod.CASH,
+          amountPaidCents: 1500,
+        },
+        actorId,
+      );
+
+      expect(txPaymentCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            paidCents: 1500,
+            changeCents: 300,
+          }),
+        }),
+      );
+    });
+
+    it('throws BadRequestException if order not PENDING', async () => {
+      prisma.order.findUnique.mockResolvedValue({
+        ...baseOrder,
+        status: OrderStatus.CONFIRMED,
+      });
+
+      await expect(
+        service.checkout(
+          { orderId, method: PaymentMethod.CASH, amountPaidCents: 1200 },
+          actorId,
+        ),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws NotFoundException if the order does not exist', async () => {
+      prisma.order.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.checkout(
+          { orderId, method: PaymentMethod.CASH, amountPaidCents: 1200 },
+          actorId,
+        ),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws BadRequestException if no active session', async () => {
+      prisma.order.findUnique.mockResolvedValue(baseOrder);
+      prisma.cashRegisterSession.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.checkout(
+          { orderId, method: PaymentMethod.CASH, amountPaidCents: 1200 },
+          actorId,
+        ),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws BadRequestException if amountPaidCents < totalCents (CASH)', async () => {
+      prisma.order.findUnique.mockResolvedValue(baseOrder);
+      prisma.cashRegisterSession.findFirst.mockResolvedValue(activeSession);
+      prisma.payment.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.checkout(
+          { orderId, method: PaymentMethod.CASH, amountPaidCents: 1000 },
+          actorId,
+        ),
+      ).rejects.toThrow(BadRequestException);
+      expect(prisma.$transaction).not.toHaveBeenCalled();
+    });
+
+    it('returns existing payment if already SUCCEEDED (idempotency)', async () => {
+      const existingPayment = {
+        id: 'payment-existing',
+        orderId,
+        status: PaymentStatus.SUCCEEDED,
+        order: baseOrder,
+      };
+      prisma.order.findUnique.mockResolvedValue(baseOrder);
+      prisma.cashRegisterSession.findFirst.mockResolvedValue(activeSession);
+      prisma.payment.findFirst.mockResolvedValue(existingPayment);
+
+      const result = await service.checkout(
+        { orderId, method: PaymentMethod.CASH, amountPaidCents: 1200 },
+        actorId,
+      );
+
+      expect(result).toBe(existingPayment);
+      expect(prisma.$transaction).not.toHaveBeenCalled();
+    });
+
+    it('does NOT validate amountPaidCents for CARD/TRANSFER methods', async () => {
+      prisma.order.findUnique.mockResolvedValue(baseOrder);
+      prisma.cashRegisterSession.findFirst.mockResolvedValue(activeSession);
+      prisma.payment.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.checkout(
+          { orderId, method: PaymentMethod.CARD, amountPaidCents: 0 },
+          actorId,
+        ),
+      ).resolves.toBeDefined();
+
+      expect(prisma.$transaction).toHaveBeenCalled();
+      expect(txPaymentCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            method: PaymentMethod.CARD,
+            paidCents: 0,
+          }),
+        }),
+      );
+    });
+  });
+});

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -210,4 +210,193 @@ describe('RestoSync API (e2e)', () => {
         .expect(400);
     });
   });
+
+  describe('cashier flow: cash register + checkout', () => {
+    const ORDER_TOTAL_CENTS = 1200;
+    const OPENING_FLOAT_CENTS = 10000;
+
+    let cashierToken: string;
+    let adminToken: string;
+    let categoryId: string;
+    let burgerId: string;
+    let orderId: string;
+    let sessionId: string;
+
+    beforeAll(async () => {
+      const cashierLogin = await request(app.getHttpServer())
+        .post('/api/auth/login')
+        .send({ email: 'cashier@restosync.local', password: 'Cashier123!' })
+        .expect(200);
+      cashierToken = cashierLogin.body.accessToken;
+
+      const adminLogin = await request(app.getHttpServer())
+        .post('/api/auth/login')
+        .send({ email: 'admin@restosync.local', password: 'Admin123!' })
+        .expect(200);
+      adminToken = adminLogin.body.accessToken;
+
+      // Clean up any register session left open by a previous test run.
+      await request(app.getHttpServer())
+        .post('/api/cash-register/close')
+        .set('Authorization', `Bearer ${cashierToken}`)
+        .send({ countedCents: 0 });
+
+      const category = await request(app.getHttpServer())
+        .post('/api/menu/categories')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ name: `Cashier_${Date.now()}` })
+        .expect(201);
+      categoryId = category.body.id;
+
+      const burger = await request(app.getHttpServer())
+        .post('/api/menu/items')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({
+          name: 'Cashier Burger',
+          priceCents: ORDER_TOTAL_CENTS,
+          categoryId,
+        })
+        .expect(201);
+      burgerId = burger.body.id;
+    });
+
+    it('POST /api/cash-register/open opens a session with the float', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/api/cash-register/open')
+        .set('Authorization', `Bearer ${cashierToken}`)
+        .send({ openingFloatCents: OPENING_FLOAT_CENTS })
+        .expect(201);
+
+      expect(res.body.openingFloatCents).toBe(OPENING_FLOAT_CENTS);
+      expect(res.body.closedAt).toBeNull();
+      sessionId = res.body.id;
+    });
+
+    it('rejects opening a second session while one is already open', async () => {
+      await request(app.getHttpServer())
+        .post('/api/cash-register/open')
+        .set('Authorization', `Bearer ${cashierToken}`)
+        .send({ openingFloatCents: 5000 })
+        .expect(400);
+    });
+
+    it('creates and confirms an order for checkout', async () => {
+      const order = await request(app.getHttpServer())
+        .post('/api/orders')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({
+          type: 'DINE_IN',
+          table: 'C1',
+          items: [{ menuItemId: burgerId, quantity: 1 }],
+        })
+        .expect(201);
+      orderId = order.body.id;
+      expect(order.body.totalCents).toBe(ORDER_TOTAL_CENTS);
+
+      const confirmed = await request(app.getHttpServer())
+        .post(`/api/orders/${orderId}/confirm`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .expect(201);
+      expect(confirmed.body.status).toBe('PENDING');
+    });
+
+    it('rejects checkout with insufficient CASH amount', async () => {
+      await request(app.getHttpServer())
+        .post('/api/payments/checkout')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({
+          orderId,
+          method: 'CASH',
+          amountPaidCents: ORDER_TOTAL_CENTS - 100,
+        })
+        .expect(400);
+    });
+
+    it('POST /api/payments/checkout with CASH records the payment and change', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/api/payments/checkout')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({
+          orderId,
+          method: 'CASH',
+          amountPaidCents: ORDER_TOTAL_CENTS + 300,
+        })
+        .expect(201);
+
+      expect(res.body.method).toBe('CASH');
+      expect(res.body.status).toBe('SUCCEEDED');
+      expect(res.body.amountCents).toBe(ORDER_TOTAL_CENTS);
+      expect(res.body.paidCents).toBe(ORDER_TOTAL_CENTS + 300);
+      expect(res.body.changeCents).toBe(300);
+      expect(res.body.order.status).toBe('CONFIRMED');
+      expect(res.body.id).toBeDefined();
+    });
+
+    // NOTE: checkout() validates `order.status === PENDING` before checking
+    // for an existing SUCCEEDED payment. Since the first checkout already
+    // moved the order to CONFIRMED, a second sequential call is rejected by
+    // that guard rather than returning the idempotent payment. True
+    // idempotency only protects concurrent double-submits that race before
+    // the order status update commits, not sequential retries against an
+    // already-confirmed order. This documents the current (unchanged)
+    // service behavior — flagged as a follow-up, not fixed here per the
+    // "do not modify service files" constraint of this test-only issue.
+    it('rejects a second sequential checkout of the same (now CONFIRMED) order', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/api/payments/checkout')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({
+          orderId,
+          method: 'CASH',
+          amountPaidCents: ORDER_TOTAL_CENTS + 300,
+        })
+        .expect(400);
+
+      expect(res.body.message).toMatch(/cannot be checked out/i);
+    });
+
+    it('GET /api/cash-register/current/summary reflects the sale', async () => {
+      const res = await request(app.getHttpServer())
+        .get('/api/cash-register/current/summary')
+        .set('Authorization', `Bearer ${cashierToken}`)
+        .expect(200);
+
+      expect(res.body.summary.totalSalesCents).toBe(ORDER_TOTAL_CENTS);
+      expect(res.body.summary.ticketCount).toBe(1);
+      expect(res.body.summary.byMethod.CASH).toBe(ORDER_TOTAL_CENTS);
+      expect(res.body.summary.byMethod.CARD).toBeUndefined();
+    });
+
+    it('POST /api/cash-register/close reconciles counted vs expected', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/api/cash-register/close')
+        .set('Authorization', `Bearer ${cashierToken}`)
+        .send({ countedCents: ORDER_TOTAL_CENTS })
+        .expect(200);
+
+      expect(res.body.expectedCents).toBe(ORDER_TOTAL_CENTS);
+      expect(res.body.countedCents).toBe(ORDER_TOTAL_CENTS);
+      expect(res.body.differenceCents).toBe(0);
+      expect(res.body.closedAt).not.toBeNull();
+    });
+
+    it('rejects closing when no active session exists', async () => {
+      await request(app.getHttpServer())
+        .post('/api/cash-register/close')
+        .set('Authorization', `Bearer ${cashierToken}`)
+        .send({ countedCents: 0 })
+        .expect(400);
+    });
+
+    it('GET /api/cash-register/sessions/:id/summary returns the closed session summary', async () => {
+      const res = await request(app.getHttpServer())
+        .get(`/api/cash-register/sessions/${sessionId}/summary`)
+        .set('Authorization', `Bearer ${cashierToken}`)
+        .expect(200);
+
+      expect(res.body.session.id).toBe(sessionId);
+      expect(res.body.summary.totalSalesCents).toBe(ORDER_TOTAL_CENTS);
+      expect(res.body.summary.ticketCount).toBe(1);
+    });
+  });
 });


### PR DESCRIPTION
Closes #38 

## Changes
- Add payments.service.spec.ts (8 unit tests) — checkout() happy + error paths
- Add cash-register.service.spec.ts (8 unit tests) — open/close/summary
- Add e2e cashier flow (10 tests) — full open→checkout→summary→close cycle
- Total: 59 tests passing (35 unit + 24 e2e)

## Note
Idempotency in checkout() only protects concurrent double-submits,
not sequential retries (order already CONFIRMED hits status guard first).
Follow-up recommended: reorder checks in checkout() — idempotency before status.