### PR TITLE
feat(#45): report endpoints with date and date-range filters

### DIFF
--- a/src/reports/dto/date-query.dto.ts
+++ b/src/reports/dto/date-query.dto.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsDateString } from 'class-validator';
+
+export class DateQueryDto {
+  @ApiProperty({
+    example: '2025-06-30',
+    description: 'Date in YYYY-MM-DD format',
+  })
+  @IsDateString()
+  date!: string;
+}

--- a/src/reports/dto/date-range-query.dto.ts
+++ b/src/reports/dto/date-range-query.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsDateString } from 'class-validator';
+
+export class DateRangeQueryDto {
+  @ApiProperty({
+    example: '2025-06-01',
+    description: 'Start date in YYYY-MM-DD format',
+  })
+  @IsDateString()
+  startDate!: string;
+
+  @ApiProperty({
+    example: '2025-06-30',
+    description: 'End date in YYYY-MM-DD format',
+  })
+  @IsDateString()
+  endDate!: string;
+}

--- a/src/reports/reports.controller.ts
+++ b/src/reports/reports.controller.ts
@@ -1,0 +1,57 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { Role } from '@prisma/client';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { DateQueryDto } from './dto/date-query.dto';
+import { DateRangeQueryDto } from './dto/date-range-query.dto';
+import { ReportsService } from './reports.service';
+
+@ApiTags('reports')
+@ApiBearerAuth()
+@Roles(Role.MANAGER, Role.ADMIN)
+@Controller('reports')
+export class ReportsController {
+  constructor(private readonly reportsService: ReportsService) {}
+
+  @Get('daily-summary')
+  @ApiOperation({ summary: 'Daily sales summary' })
+  @ApiResponse({
+    status: 200,
+    description: 'Total sales, ticket count, average ticket',
+  })
+  getDailySummary(@Query() query: DateQueryDto) {
+    return this.reportsService.getDailySummary(query.date);
+  }
+
+  @Get('payment-methods')
+  @ApiOperation({ summary: 'Sales breakdown by payment method' })
+  @ApiResponse({ status: 200, description: 'Amount per payment method' })
+  getPaymentMethodBreakdown(@Query() query: DateQueryDto) {
+    return this.reportsService.getPaymentMethodBreakdown(query.date);
+  }
+
+  @Get('best-selling')
+  @ApiOperation({ summary: 'Best selling products for the day' })
+  @ApiResponse({
+    status: 200,
+    description: 'Top products by quantity sold',
+  })
+  getBestSellingProducts(
+    @Query() query: DateQueryDto,
+    @Query('limit') limit?: number,
+  ) {
+    return this.reportsService.getBestSellingProducts(query.date, limit ?? 10);
+  }
+
+  @Get('closed-tickets')
+  @ApiOperation({ summary: 'Closed tickets in date range' })
+  @ApiResponse({ status: 200, description: 'List of closed orders' })
+  getClosedTickets(@Query() query: DateRangeQueryDto) {
+    return this.reportsService.getClosedTickets(query.startDate, query.endDate);
+  }
+}

--- a/src/reports/reports.module.ts
+++ b/src/reports/reports.module.ts
@@ -1,7 +1,9 @@
 import { Module } from '@nestjs/common';
+import { ReportsController } from './reports.controller';
 import { ReportsService } from './reports.service';
 
 @Module({
+  controllers: [ReportsController],
   providers: [ReportsService],
   exports: [ReportsService],
 })


### PR DESCRIPTION
Closes #45 

## Changes
- Add DateQueryDto and DateRangeQueryDto with @IsDateString() validation
- Add ReportsController with 4 endpoints:
  - GET /reports/daily-summary?date=
  - GET /reports/payment-methods?date=
  - GET /reports/best-selling?date=&limit=
  - GET /reports/closed-tickets?startDate=&endDate=
- All guarded by @Roles(MANAGER, ADMIN)
- Register ReportsController in ReportsModule