### PR TITLE
feat(#39/#41/#42): add date-range report endpoints for sales, payment…

### DIFF
--- a/src/reports/reports.controller.ts
+++ b/src/reports/reports.controller.ts
@@ -54,4 +54,40 @@ export class ReportsController {
   getClosedTickets(@Query() query: DateRangeQueryDto) {
     return this.reportsService.getClosedTickets(query.startDate, query.endDate);
   }
+
+  @Get('daily-summary-range')
+  @ApiOperation({ summary: 'Daily sales totals for a date range' })
+  @ApiResponse({
+    status: 200,
+    description: 'Array of daily sales summaries',
+  })
+  getDailySummaryRange(@Query() query: DateRangeQueryDto) {
+    return this.reportsService.getDailySummaryRange(
+      query.startDate,
+      query.endDate,
+    );
+  }
+
+  @Get('payment-methods-range')
+  @ApiOperation({ summary: 'Payment method breakdown for a date range' })
+  @ApiResponse({ status: 200, description: 'Amount per payment method' })
+  getPaymentMethodBreakdownRange(@Query() query: DateRangeQueryDto) {
+    return this.reportsService.getPaymentMethodBreakdownRange(
+      query.startDate,
+      query.endDate,
+    );
+  }
+
+  @Get('tickets-by-day')
+  @ApiOperation({ summary: 'Closed ticket count grouped by day' })
+  @ApiResponse({
+    status: 200,
+    description: 'Array of daily ticket counts',
+  })
+  getTicketCountByDay(@Query() query: DateRangeQueryDto) {
+    return this.reportsService.getTicketCountByDay(
+      query.startDate,
+      query.endDate,
+    );
+  }
 }

--- a/src/reports/reports.service.ts
+++ b/src/reports/reports.service.ts
@@ -115,6 +115,102 @@ export class ReportsService {
     }));
   }
 
+  async getDailySummaryRange(startDate: string, endDate: string) {
+    const { start } = this.dayRange(startDate);
+    const { end } = this.dayRange(endDate);
+
+    const orders = await this.prisma.order.findMany({
+      where: {
+        status: { in: SALE_STATUSES },
+        createdAt: { gte: start, lt: end },
+      },
+      select: { createdAt: true, totalCents: true },
+    });
+
+    const byDay = new Map<string, { totalCents: number; count: number }>();
+
+    for (const order of orders) {
+      const day = order.createdAt.toISOString().slice(0, 10);
+      const entry = byDay.get(day) ?? { totalCents: 0, count: 0 };
+      entry.totalCents += order.totalCents;
+      entry.count += 1;
+      byDay.set(day, entry);
+    }
+
+    const result: {
+      date: string;
+      totalSalesCents: number;
+      ticketCount: number;
+      averageTicketCents: number;
+    }[] = [];
+
+    for (const [date, data] of byDay) {
+      result.push({
+        date,
+        totalSalesCents: data.totalCents,
+        ticketCount: data.count,
+        averageTicketCents: Math.round(data.totalCents / data.count),
+      });
+    }
+
+    result.sort((a, b) => a.date.localeCompare(b.date));
+    return result;
+  }
+
+  async getPaymentMethodBreakdownRange(startDate: string, endDate: string) {
+    const { start } = this.dayRange(startDate);
+    const { end } = this.dayRange(endDate);
+
+    const grouped = await this.prisma.payment.groupBy({
+      by: ['method'],
+      where: {
+        status: PaymentStatus.SUCCEEDED,
+        createdAt: { gte: start, lt: end },
+      },
+      _sum: { amountCents: true },
+    });
+
+    const byMethod: Record<string, number> = {};
+    for (const method of Object.values(PaymentMethod)) {
+      const row = grouped.find((g) => g.method === method);
+      const amount = row?._sum.amountCents ?? 0;
+      if (amount > 0) {
+        byMethod[method] = amount;
+      }
+    }
+
+    return byMethod;
+  }
+
+  async getTicketCountByDay(startDate: string, endDate: string) {
+    const { start } = this.dayRange(startDate);
+    const { end } = this.dayRange(endDate);
+
+    const orders = await this.prisma.order.findMany({
+      where: {
+        status: { in: SALE_STATUSES },
+        createdAt: { gte: start, lt: end },
+      },
+      select: { createdAt: true },
+    });
+
+    const byDay = new Map<string, number>();
+
+    for (const order of orders) {
+      const day = order.createdAt.toISOString().slice(0, 10);
+      byDay.set(day, (byDay.get(day) ?? 0) + 1);
+    }
+
+    const result: { date: string; ticketCount: number }[] = [];
+
+    for (const [date, count] of byDay) {
+      result.push({ date, ticketCount: count });
+    }
+
+    result.sort((a, b) => a.date.localeCompare(b.date));
+    return result;
+  }
+
   // Converts a 'YYYY-MM-DD' date string into a [start, end) UTC range
   // covering that whole calendar day.
   private dayRange(date: string): { start: Date; end: Date } {


### PR DESCRIPTION
Closes #39 
Closes #41 
Closes #42 

## Changes
- Add getDailySummaryRange() — daily totals for a date range
- Add getPaymentMethodBreakdownRange() — payment methods for a date range
- Add getTicketCountByDay() — ticket count grouped by day
- Add 3 new GET endpoints:
  - GET /reports/daily-summary-range?startDate=&endDate=
  - GET /reports/payment-methods-range?startDate=&endDate=
  - GET /reports/tickets-by-day?startDate=&endDate=
- Reuses dayRange(), SALE_STATUSES and existing patterns