### PR TITLE
feat(#52): add InventoryItem and StockAdjustment models

### DIFF
--- a/prisma/migrations/20260702000000_add_inventory_models/migration.sql
+++ b/prisma/migrations/20260702000000_add_inventory_models/migration.sql
@@ -1,0 +1,44 @@
+-- CreateEnum
+CREATE TYPE "AdjustmentType" AS ENUM ('RESTOCK', 'SALE', 'WASTE', 'CORRECTION');
+
+-- CreateTable
+CREATE TABLE "inventory_items" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "unit" TEXT NOT NULL DEFAULT 'unit',
+    "quantityOnHand" DOUBLE PRECISION NOT NULL DEFAULT 0,
+    "lowStockThreshold" DOUBLE PRECISION NOT NULL DEFAULT 0,
+    "menuItemId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "inventory_items_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "stock_adjustments" (
+    "id" TEXT NOT NULL,
+    "inventoryItemId" TEXT NOT NULL,
+    "type" "AdjustmentType" NOT NULL,
+    "quantityDelta" DOUBLE PRECISION NOT NULL,
+    "reason" TEXT,
+    "performedById" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "stock_adjustments_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "inventory_items_menuItemId_key" ON "inventory_items"("menuItemId");
+
+-- CreateIndex
+CREATE INDEX "stock_adjustments_inventoryItemId_idx" ON "stock_adjustments"("inventoryItemId");
+
+-- AddForeignKey
+ALTER TABLE "inventory_items" ADD CONSTRAINT "inventory_items_menuItemId_fkey" FOREIGN KEY ("menuItemId") REFERENCES "menu_items"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "stock_adjustments" ADD CONSTRAINT "stock_adjustments_inventoryItemId_fkey" FOREIGN KEY ("inventoryItemId") REFERENCES "inventory_items"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "stock_adjustments" ADD CONSTRAINT "stock_adjustments_performedById_fkey" FOREIGN KEY ("performedById") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,6 +28,7 @@ model User {
   orders           Order[]
   openedSessions   CashRegisterSession[] @relation("OpenedSessions")
   closedSessions   CashRegisterSession[] @relation("ClosedSessions")
+  stockAdjustments StockAdjustment[]
   sessions         Session[]
   createdAt    DateTime  @default(now())
   updatedAt    DateTime  @updatedAt
@@ -74,6 +75,7 @@ model MenuItem {
   categoryId  String
   category    Category    @relation(fields: [categoryId], references: [id], onDelete: Restrict)
   orderItems  OrderItem[]
+  inventoryItem  InventoryItem?
   createdAt   DateTime    @default(now())
   updatedAt   DateTime    @updatedAt
 
@@ -198,4 +200,43 @@ model CashRegisterSession {
   updatedAt         DateTime  @updatedAt
 
   @@map("cash_register_sessions")
+}
+
+// ---------- Inventory ----------
+
+enum AdjustmentType {
+  RESTOCK
+  SALE
+  WASTE
+  CORRECTION
+}
+
+model InventoryItem {
+  id                String            @id @default(uuid())
+  name              String
+  unit              String            @default("unit")
+  quantityOnHand    Float             @default(0)
+  lowStockThreshold Float             @default(0)
+  menuItemId        String?           @unique
+  menuItem          MenuItem?         @relation(fields: [menuItemId], references: [id], onDelete: SetNull)
+  adjustments       StockAdjustment[]
+  createdAt         DateTime          @default(now())
+  updatedAt         DateTime          @updatedAt
+
+  @@map("inventory_items")
+}
+
+model StockAdjustment {
+  id              String         @id @default(uuid())
+  inventoryItemId String
+  inventoryItem   InventoryItem  @relation(fields: [inventoryItemId], references: [id], onDelete: Cascade)
+  type            AdjustmentType
+  quantityDelta   Float
+  reason          String?
+  performedById   String
+  performedBy     User           @relation(fields: [performedById], references: [id])
+  createdAt       DateTime       @default(now())
+
+  @@index([inventoryItemId])
+  @@map("stock_adjustments")
 }


### PR DESCRIPTION
Closes #52 

## Changes
- Add AdjustmentType enum (RESTOCK, SALE, WASTE, CORRECTION)
- Add InventoryItem model (name, unit, quantityOnHand, lowStockThreshold, optional MenuItem link)
- Add StockAdjustment model (type, quantityDelta, reason, performedById)
- Add reverse relations to User and MenuItem models
- Migration: add_inventory_models