### PR TITLE
feat(#53): inventory CRUD, stock adjustment and low-stock endpoints

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -8,6 +8,7 @@ import { RolesGuard } from './auth/guards/roles.guard';
 import configuration from './config/configuration';
 import { validateEnv } from './config/env.validation';
 import { CashRegisterModule } from './cash-register/cash-register.module';
+import { InventoryModule } from './inventory/inventory.module';
 import { MenuModule } from './menu/menu.module';
 import { OrdersModule } from './orders/orders.module';
 import { PaymentsModule } from './payments/payments.module';
@@ -30,6 +31,7 @@ import { UsersModule } from './users/users.module';
     PaymentsModule,
     CashRegisterModule,
     ReportsModule,
+    InventoryModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/inventory/dto/adjust-stock.dto.ts
+++ b/src/inventory/dto/adjust-stock.dto.ts
@@ -1,0 +1,23 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { AdjustmentType } from '@prisma/client';
+import { IsEnum, IsNumber, IsOptional, IsString } from 'class-validator';
+
+export class AdjustStockDto {
+  @ApiProperty({
+    enum: AdjustmentType,
+    description: 'Type of stock adjustment',
+  })
+  @IsEnum(AdjustmentType)
+  type!: AdjustmentType;
+
+  @ApiProperty({
+    description: 'Quantity change (positive = in, negative = out)',
+  })
+  @IsNumber()
+  quantityDelta!: number;
+
+  @ApiPropertyOptional({ description: 'Reason for the adjustment' })
+  @IsString()
+  @IsOptional()
+  reason?: string;
+}

--- a/src/inventory/dto/create-inventory-item.dto.ts
+++ b/src/inventory/dto/create-inventory-item.dto.ts
@@ -1,0 +1,44 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsString,
+  IsUUID,
+  Min,
+} from 'class-validator';
+
+export class CreateInventoryItemDto {
+  @ApiProperty({ description: 'Name of the inventory item' })
+  @IsString()
+  @IsNotEmpty()
+  name!: string;
+
+  @ApiPropertyOptional({
+    description: 'Unit of measurement (unit, kg, l, etc.)',
+    default: 'unit',
+  })
+  @IsString()
+  @IsOptional()
+  unit?: string;
+
+  @ApiPropertyOptional({ description: 'Current quantity on hand', default: 0 })
+  @IsNumber()
+  @Min(0)
+  @IsOptional()
+  quantityOnHand?: number;
+
+  @ApiPropertyOptional({ description: 'Low stock alert threshold', default: 0 })
+  @IsNumber()
+  @Min(0)
+  @IsOptional()
+  lowStockThreshold?: number;
+
+  @ApiPropertyOptional({
+    format: 'uuid',
+    description: 'Link to a menu item',
+  })
+  @IsUUID()
+  @IsOptional()
+  menuItemId?: string;
+}

--- a/src/inventory/inventory.controller.ts
+++ b/src/inventory/inventory.controller.ts
@@ -1,0 +1,93 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { Role } from '@prisma/client';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { AdjustStockDto } from './dto/adjust-stock.dto';
+import { CreateInventoryItemDto } from './dto/create-inventory-item.dto';
+import { InventoryService } from './inventory.service';
+
+@ApiTags('inventory')
+@ApiBearerAuth()
+@Roles(Role.MANAGER, Role.ADMIN)
+@Controller('inventory')
+export class InventoryController {
+  constructor(private readonly inventoryService: InventoryService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'List all inventory items' })
+  @ApiResponse({ status: 200, description: 'List of inventory items' })
+  findAll() {
+    return this.inventoryService.findAll();
+  }
+
+  @Get('low-stock')
+  @ApiOperation({ summary: 'List items with low stock' })
+  @ApiResponse({
+    status: 200,
+    description: 'Items where quantityOnHand <= lowStockThreshold',
+  })
+  findLowStock() {
+    return this.inventoryService.findLowStock();
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get a single inventory item' })
+  @ApiResponse({ status: 200, description: 'Inventory item details' })
+  @ApiResponse({ status: 404, description: 'Item not found' })
+  findOne(@Param('id') id: string) {
+    return this.inventoryService.findOne(id);
+  }
+
+  @Post()
+  @ApiOperation({ summary: 'Create a new inventory item' })
+  @ApiResponse({ status: 201, description: 'Inventory item created' })
+  @ApiResponse({ status: 400, description: 'Validation error' })
+  create(@Body() dto: CreateInventoryItemDto) {
+    return this.inventoryService.create(dto);
+  }
+
+  @Patch(':id')
+  @ApiOperation({ summary: 'Update an inventory item' })
+  @ApiResponse({ status: 200, description: 'Inventory item updated' })
+  @ApiResponse({ status: 404, description: 'Item not found' })
+  update(
+    @Param('id') id: string,
+    @Body() dto: Partial<CreateInventoryItemDto>,
+  ) {
+    return this.inventoryService.update(id, dto);
+  }
+
+  @Delete(':id')
+  @ApiOperation({ summary: 'Delete an inventory item' })
+  @ApiResponse({ status: 200, description: 'Inventory item deleted' })
+  @ApiResponse({ status: 404, description: 'Item not found' })
+  remove(@Param('id') id: string) {
+    return this.inventoryService.remove(id);
+  }
+
+  @Post(':id/adjust')
+  @ApiOperation({ summary: 'Adjust stock quantity' })
+  @ApiResponse({ status: 201, description: 'Stock adjustment recorded' })
+  @ApiResponse({ status: 404, description: 'Item not found' })
+  adjust(
+    @Param('id') id: string,
+    @Body() dto: AdjustStockDto,
+    @CurrentUser('id') userId: string,
+  ) {
+    return this.inventoryService.adjust(id, dto, userId);
+  }
+}

--- a/src/inventory/inventory.module.ts
+++ b/src/inventory/inventory.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { InventoryController } from './inventory.controller';
+import { InventoryService } from './inventory.service';
+
+@Module({
+  controllers: [InventoryController],
+  providers: [InventoryService],
+})
+export class InventoryModule {}

--- a/src/inventory/inventory.service.ts
+++ b/src/inventory/inventory.service.ts
@@ -1,0 +1,105 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { AdjustStockDto } from './dto/adjust-stock.dto';
+import { CreateInventoryItemDto } from './dto/create-inventory-item.dto';
+
+@Injectable()
+export class InventoryService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  findAll() {
+    return this.prisma.inventoryItem.findMany({
+      include: { menuItem: true },
+      orderBy: { name: 'asc' },
+    });
+  }
+
+  async findOne(id: string) {
+    const item = await this.prisma.inventoryItem.findUnique({
+      where: { id },
+      include: { menuItem: true, adjustments: true },
+    });
+    if (!item) {
+      throw new NotFoundException('Inventory item not found');
+    }
+    return item;
+  }
+
+  create(dto: CreateInventoryItemDto) {
+    return this.prisma.inventoryItem.create({
+      data: {
+        name: dto.name,
+        unit: dto.unit ?? 'unit',
+        quantityOnHand: dto.quantityOnHand ?? 0,
+        lowStockThreshold: dto.lowStockThreshold ?? 0,
+        menuItemId: dto.menuItemId ?? null,
+      },
+    });
+  }
+
+  async update(id: string, dto: Partial<CreateInventoryItemDto>) {
+    await this.ensureExists(id);
+    return this.prisma.inventoryItem.update({
+      where: { id },
+      data: {
+        name: dto.name,
+        unit: dto.unit,
+        quantityOnHand: dto.quantityOnHand,
+        lowStockThreshold: dto.lowStockThreshold,
+        menuItemId: dto.menuItemId,
+      },
+      include: { menuItem: true },
+    });
+  }
+
+  async remove(id: string) {
+    await this.ensureExists(id);
+    return this.prisma.inventoryItem.delete({ where: { id } });
+  }
+
+  async adjust(id: string, dto: AdjustStockDto, actorId: string) {
+    const item = await this.prisma.inventoryItem.findUnique({
+      where: { id },
+    });
+    if (!item) {
+      throw new NotFoundException('Inventory item not found');
+    }
+
+    return this.prisma.$transaction(async (tx) => {
+      await tx.stockAdjustment.create({
+        data: {
+          inventoryItemId: id,
+          type: dto.type,
+          quantityDelta: dto.quantityDelta,
+          reason: dto.reason ?? null,
+          performedById: actorId,
+        },
+      });
+
+      const newQty = Math.max(0, item.quantityOnHand + dto.quantityDelta);
+
+      return tx.inventoryItem.update({
+        where: { id },
+        data: { quantityOnHand: newQty },
+        include: { adjustments: true, menuItem: true },
+      });
+    });
+  }
+
+  async findLowStock() {
+    const items = await this.prisma.inventoryItem.findMany({
+      where: { lowStockThreshold: { gt: 0 } },
+      orderBy: { name: 'asc' },
+    });
+    return items.filter((i) => i.quantityOnHand <= i.lowStockThreshold);
+  }
+
+  private async ensureExists(id: string) {
+    const exists = await this.prisma.inventoryItem.findUnique({
+      where: { id },
+    });
+    if (!exists) {
+      throw new NotFoundException('Inventory item not found');
+    }
+  }
+}


### PR DESCRIPTION
Closes #53 

## Changes
- New inventory module with 7 endpoints
- CreateInventoryItemDto + AdjustStockDto
- InventoryService:
  - CRUD completo (findAll, findOne, create, update, remove)
  - adjust() — $transaction: StockAdjustment + quantityOnHand clamped at 0
  - findLowStock() — JS filter (Prisma no soporta column-to-column where)
- GET /inventory/low-stock, POST /inventory/:id/adjust
- All guarded by @Roles(MANAGER, ADMIN)
- Register InventoryModule in app.module.ts