### PR TITLE
test(#55): inventory adjustments and low-stock threshold tests

### DIFF
--- a/src/inventory/inventory.service.spec.ts
+++ b/src/inventory/inventory.service.spec.ts
@@ -1,0 +1,286 @@
+import { NotFoundException } from '@nestjs/common';
+import { AdjustmentType } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+import { InventoryService } from './inventory.service';
+
+type MockPrisma = {
+  inventoryItem: {
+    findMany: jest.Mock;
+    findUnique: jest.Mock;
+    create: jest.Mock;
+    update: jest.Mock;
+    delete: jest.Mock;
+  };
+  stockAdjustment: {
+    create: jest.Mock;
+  };
+  $transaction: jest.Mock;
+};
+
+function createMockPrisma(): MockPrisma {
+  return {
+    inventoryItem: {
+      findMany: jest.fn(),
+      findUnique: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    },
+    stockAdjustment: {
+      create: jest.fn(),
+    },
+    $transaction: jest.fn(),
+  };
+}
+
+describe('InventoryService', () => {
+  let service: InventoryService;
+  let prisma: MockPrisma;
+  let txStockAdjustmentCreate: jest.Mock;
+  let txInventoryItemUpdate: jest.Mock;
+
+  const itemId = 'item-1';
+  const actorId = 'user-1';
+
+  beforeEach(() => {
+    prisma = createMockPrisma();
+    txStockAdjustmentCreate = jest.fn().mockResolvedValue({});
+    txInventoryItemUpdate = jest.fn().mockResolvedValue({});
+
+    prisma.$transaction.mockImplementation(async (callback) =>
+      callback({
+        stockAdjustment: { create: txStockAdjustmentCreate },
+        inventoryItem: { update: txInventoryItemUpdate },
+      }),
+    );
+
+    service = new InventoryService(prisma as unknown as PrismaService);
+  });
+
+  describe('create', () => {
+    it('creates an item with the correct fields', async () => {
+      prisma.inventoryItem.create.mockResolvedValue({
+        id: itemId,
+        name: 'Tomato',
+        unit: 'kg',
+        quantityOnHand: 10,
+        lowStockThreshold: 3,
+        menuItemId: null,
+      });
+
+      await service.create({
+        name: 'Tomato',
+        unit: 'kg',
+        quantityOnHand: 10,
+        lowStockThreshold: 3,
+      });
+
+      expect(prisma.inventoryItem.create).toHaveBeenCalledWith({
+        data: {
+          name: 'Tomato',
+          unit: 'kg',
+          quantityOnHand: 10,
+          lowStockThreshold: 3,
+          menuItemId: null,
+        },
+      });
+    });
+
+    it('applies defaults when optional fields are omitted', async () => {
+      prisma.inventoryItem.create.mockResolvedValue({});
+
+      await service.create({ name: 'Salt' });
+
+      expect(prisma.inventoryItem.create).toHaveBeenCalledWith({
+        data: {
+          name: 'Salt',
+          unit: 'unit',
+          quantityOnHand: 0,
+          lowStockThreshold: 0,
+          menuItemId: null,
+        },
+      });
+    });
+  });
+
+  describe('findOne', () => {
+    it('returns the item with its relations', async () => {
+      const item = {
+        id: itemId,
+        name: 'Tomato',
+        menuItem: null,
+        adjustments: [],
+      };
+      prisma.inventoryItem.findUnique.mockResolvedValue(item);
+
+      const result = await service.findOne(itemId);
+
+      expect(prisma.inventoryItem.findUnique).toHaveBeenCalledWith({
+        where: { id: itemId },
+        include: { menuItem: true, adjustments: true },
+      });
+      expect(result).toBe(item);
+    });
+
+    it('throws NotFoundException if the item does not exist', async () => {
+      prisma.inventoryItem.findUnique.mockResolvedValue(null);
+
+      await expect(service.findOne(itemId)).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('adjust', () => {
+    it('increases quantityOnHand for a RESTOCK adjustment', async () => {
+      prisma.inventoryItem.findUnique.mockResolvedValue({
+        id: itemId,
+        quantityOnHand: 10,
+      });
+
+      await service.adjust(
+        itemId,
+        { type: AdjustmentType.RESTOCK, quantityDelta: 5 },
+        actorId,
+      );
+
+      expect(txInventoryItemUpdate).toHaveBeenCalledWith({
+        where: { id: itemId },
+        data: { quantityOnHand: 15 },
+        include: { adjustments: true, menuItem: true },
+      });
+    });
+
+    it('decreases quantityOnHand for a WASTE adjustment', async () => {
+      prisma.inventoryItem.findUnique.mockResolvedValue({
+        id: itemId,
+        quantityOnHand: 15,
+      });
+
+      await service.adjust(
+        itemId,
+        { type: AdjustmentType.WASTE, quantityDelta: -13 },
+        actorId,
+      );
+
+      expect(txInventoryItemUpdate).toHaveBeenCalledWith({
+        where: { id: itemId },
+        data: { quantityOnHand: 2 },
+        include: { adjustments: true, menuItem: true },
+      });
+    });
+
+    it('clamps quantityOnHand at 0 and never goes negative', async () => {
+      prisma.inventoryItem.findUnique.mockResolvedValue({
+        id: itemId,
+        quantityOnHand: 2,
+      });
+
+      await service.adjust(
+        itemId,
+        { type: AdjustmentType.WASTE, quantityDelta: -99 },
+        actorId,
+      );
+
+      expect(txInventoryItemUpdate).toHaveBeenCalledWith({
+        where: { id: itemId },
+        data: { quantityOnHand: 0 },
+        include: { adjustments: true, menuItem: true },
+      });
+    });
+
+    it('creates a StockAdjustment record with type, delta, reason and actor', async () => {
+      prisma.inventoryItem.findUnique.mockResolvedValue({
+        id: itemId,
+        quantityOnHand: 10,
+      });
+
+      await service.adjust(
+        itemId,
+        {
+          type: AdjustmentType.CORRECTION,
+          quantityDelta: -1,
+          reason: 'Recount',
+        },
+        actorId,
+      );
+
+      expect(txStockAdjustmentCreate).toHaveBeenCalledWith({
+        data: {
+          inventoryItemId: itemId,
+          type: AdjustmentType.CORRECTION,
+          quantityDelta: -1,
+          reason: 'Recount',
+          performedById: actorId,
+        },
+      });
+    });
+
+    it('throws NotFoundException if the item does not exist', async () => {
+      prisma.inventoryItem.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.adjust(
+          itemId,
+          { type: AdjustmentType.RESTOCK, quantityDelta: 5 },
+          actorId,
+        ),
+      ).rejects.toThrow(NotFoundException);
+      expect(prisma.$transaction).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('findLowStock', () => {
+    it('returns items where quantityOnHand <= lowStockThreshold', async () => {
+      prisma.inventoryItem.findMany.mockResolvedValue([
+        { id: '1', quantityOnHand: 2, lowStockThreshold: 3 },
+        { id: '2', quantityOnHand: 10, lowStockThreshold: 3 },
+      ]);
+
+      const result = await service.findLowStock();
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('1');
+    });
+
+    it('excludes items with lowStockThreshold = 0 via the where filter', async () => {
+      prisma.inventoryItem.findMany.mockResolvedValue([]);
+
+      await service.findLowStock();
+
+      expect(prisma.inventoryItem.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { lowStockThreshold: { gt: 0 } },
+        }),
+      );
+    });
+
+    it('sets alertLevel to CRITICAL when quantityOnHand is 0', async () => {
+      prisma.inventoryItem.findMany.mockResolvedValue([
+        { id: '1', quantityOnHand: 0, lowStockThreshold: 3 },
+      ]);
+
+      const result = await service.findLowStock();
+
+      expect(result[0].alertLevel).toBe('CRITICAL');
+    });
+
+    it('sets alertLevel to LOW when quantityOnHand > 0 and <= threshold', async () => {
+      prisma.inventoryItem.findMany.mockResolvedValue([
+        { id: '1', quantityOnHand: 2, lowStockThreshold: 3 },
+      ]);
+
+      const result = await service.findLowStock();
+
+      expect(result[0].alertLevel).toBe('LOW');
+    });
+
+    it('returns an empty array when there are no low-stock items', async () => {
+      prisma.inventoryItem.findMany.mockResolvedValue([
+        { id: '1', quantityOnHand: 10, lowStockThreshold: 3 },
+      ]);
+
+      const result = await service.findLowStock();
+
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -656,4 +656,176 @@ describe('RestoSync API (e2e)', () => {
         .expect(403);
     });
   });
+
+  describe('inventory: adjustments + thresholds', () => {
+    let managerToken: string;
+    let cashierToken: string;
+    let itemId: string;
+    const itemName = `Tomato_${Date.now()}`;
+
+    beforeAll(async () => {
+      const managerLogin = await request(app.getHttpServer())
+        .post('/api/auth/login')
+        .send({ email: 'manager@restosync.local', password: 'Manager123!' })
+        .expect(200);
+      managerToken = managerLogin.body.accessToken;
+
+      const cashierLogin = await request(app.getHttpServer())
+        .post('/api/auth/login')
+        .send({ email: 'cashier@restosync.local', password: 'Cashier123!' })
+        .expect(200);
+      cashierToken = cashierLogin.body.accessToken;
+    });
+
+    it('POST /api/inventory creates an item', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/api/inventory')
+        .set('Authorization', `Bearer ${managerToken}`)
+        .send({
+          name: itemName,
+          unit: 'kg',
+          quantityOnHand: 10,
+          lowStockThreshold: 3,
+        })
+        .expect(201);
+
+      expect(res.body.name).toBe(itemName);
+      expect(res.body.unit).toBe('kg');
+      expect(res.body.quantityOnHand).toBe(10);
+      expect(res.body.lowStockThreshold).toBe(3);
+      itemId = res.body.id;
+    });
+
+    it('GET /api/inventory/:id verifies the created item', async () => {
+      const res = await request(app.getHttpServer())
+        .get(`/api/inventory/${itemId}`)
+        .set('Authorization', `Bearer ${managerToken}`)
+        .expect(200);
+
+      expect(res.body.id).toBe(itemId);
+      expect(res.body.quantityOnHand).toBe(10);
+    });
+
+    it('POST /api/inventory/:id/adjust RESTOCK increases quantityOnHand', async () => {
+      const res = await request(app.getHttpServer())
+        .post(`/api/inventory/${itemId}/adjust`)
+        .set('Authorization', `Bearer ${managerToken}`)
+        .send({ type: 'RESTOCK', quantityDelta: 5, reason: 'Delivery' })
+        .expect(201);
+
+      expect(res.body.quantityOnHand).toBe(15);
+    });
+
+    it('POST /api/inventory/:id/adjust WASTE decreases quantityOnHand', async () => {
+      const res = await request(app.getHttpServer())
+        .post(`/api/inventory/${itemId}/adjust`)
+        .set('Authorization', `Bearer ${managerToken}`)
+        .send({ type: 'WASTE', quantityDelta: -13, reason: 'Spoiled' })
+        .expect(201);
+
+      expect(res.body.quantityOnHand).toBe(2);
+    });
+
+    it('GET /api/inventory/low-stock shows the item with alertLevel LOW', async () => {
+      const res = await request(app.getHttpServer())
+        .get('/api/inventory/low-stock')
+        .set('Authorization', `Bearer ${managerToken}`)
+        .expect(200);
+
+      const entry = res.body.find((i: { id: string }) => i.id === itemId);
+      expect(entry).toBeDefined();
+      expect(entry.quantityOnHand).toBe(2);
+      expect(entry.alertLevel).toBe('LOW');
+    });
+
+    it('POST /api/inventory/:id/adjust WASTE clamps quantityOnHand at 0', async () => {
+      const res = await request(app.getHttpServer())
+        .post(`/api/inventory/${itemId}/adjust`)
+        .set('Authorization', `Bearer ${managerToken}`)
+        .send({ type: 'WASTE', quantityDelta: -2, reason: 'Spoiled' })
+        .expect(201);
+
+      expect(res.body.quantityOnHand).toBe(0);
+    });
+
+    it('GET /api/inventory/low-stock shows the item with alertLevel CRITICAL', async () => {
+      const res = await request(app.getHttpServer())
+        .get('/api/inventory/low-stock')
+        .set('Authorization', `Bearer ${managerToken}`)
+        .expect(200);
+
+      const entry = res.body.find((i: { id: string }) => i.id === itemId);
+      expect(entry).toBeDefined();
+      expect(entry.quantityOnHand).toBe(0);
+      expect(entry.alertLevel).toBe('CRITICAL');
+    });
+
+    it('POST /api/inventory/:id/adjust WASTE stays clamped at 0 (never negative)', async () => {
+      const res = await request(app.getHttpServer())
+        .post(`/api/inventory/${itemId}/adjust`)
+        .set('Authorization', `Bearer ${managerToken}`)
+        .send({ type: 'WASTE', quantityDelta: -99, reason: 'Overcorrection' })
+        .expect(201);
+
+      expect(res.body.quantityOnHand).toBe(0);
+    });
+
+    it('POST /api/inventory/:id/adjust on a non-existent item returns 404', async () => {
+      await request(app.getHttpServer())
+        .post('/api/inventory/00000000-0000-4000-8000-000000000000/adjust')
+        .set('Authorization', `Bearer ${managerToken}`)
+        .send({ type: 'RESTOCK', quantityDelta: 1 })
+        .expect(404);
+    });
+
+    it('GET /api/inventory rejects non-MANAGER/ADMIN roles', async () => {
+      await request(app.getHttpServer())
+        .get('/api/inventory')
+        .set('Authorization', `Bearer ${cashierToken}`)
+        .expect(403);
+    });
+
+    it('DELETE /api/inventory/:id removes the item', async () => {
+      await request(app.getHttpServer())
+        .delete(`/api/inventory/${itemId}`)
+        .set('Authorization', `Bearer ${managerToken}`)
+        .expect(200);
+    });
+
+    it('GET /api/inventory/:id returns 404 after deletion', async () => {
+      await request(app.getHttpServer())
+        .get(`/api/inventory/${itemId}`)
+        .set('Authorization', `Bearer ${managerToken}`)
+        .expect(404);
+    });
+
+    it('GET /api/inventory/low-stock returns an empty array when no items qualify', async () => {
+      // The only low-stock item created in this suite (itemId) was deleted
+      // in the previous test, so the endpoint should report no alerts.
+      // A well-stocked item (quantity far above threshold) is also created
+      // here to confirm it never surfaces as a false positive.
+      const wellStocked = await request(app.getHttpServer())
+        .post('/api/inventory')
+        .set('Authorization', `Bearer ${managerToken}`)
+        .send({
+          name: `WellStocked_${Date.now()}`,
+          quantityOnHand: 100,
+          lowStockThreshold: 3,
+        })
+        .expect(201);
+
+      const res = await request(app.getHttpServer())
+        .get('/api/inventory/low-stock')
+        .set('Authorization', `Bearer ${managerToken}`)
+        .expect(200);
+
+      expect(res.body).toEqual([]);
+
+      // Cleanup.
+      await request(app.getHttpServer())
+        .delete(`/api/inventory/${wellStocked.body.id}`)
+        .set('Authorization', `Bearer ${managerToken}`)
+        .expect(200);
+    });
+  });
 });


### PR DESCRIPTION
Closes #55 

## Changes
- Add inventory.service.spec.ts (14 unit tests):
  - create, findOne, adjust (RESTOCK/WASTE/clamp/404), findLowStock (CRITICAL/LOW/empty)
- Add inventory e2e block (13 tests):
  - Full lifecycle: create → adjust → low-stock alerts → delete
  - Role restriction (403 for CASHIER)
  - Clamp at 0 verified
- Total: 59 unit + 42 e2e = 101 tests passing

## Note
Seed users must exist before e2e tests run.
CI already has npx prisma db seed — confirmed working.