### PR TITLE
feat(#14): image handling — URL-only policy, @IsUrl validation, Swagg…

### DIFF
--- a/src/menu/dto/menu-item.dto.ts
+++ b/src/menu/dto/menu-item.dto.ts
@@ -4,6 +4,7 @@ import {
   IsInt,
   IsOptional,
   IsString,
+  IsUrl,
   IsUUID,
   Min,
   MinLength,
@@ -31,8 +32,12 @@ export class CreateMenuItemDto {
   @IsString()
   currency?: string;
 
-  @ApiPropertyOptional()
+  @ApiPropertyOptional({
+    description: 'Public URL of the product image',
+    example: 'https://example.com/images/ceviche.jpg',
+  })
   @IsOptional()
+  @IsUrl()
   @IsString()
   imageUrl?: string;
 

--- a/src/menu/menu-items.controller.ts
+++ b/src/menu/menu-items.controller.ts
@@ -38,6 +38,9 @@ export class MenuItemsController {
 
   @ApiBearerAuth()
   @Roles(Role.ADMIN)
+  @ApiOperation({
+    summary: 'Create a menu item (imageUrl is a public URL, no file upload)',
+  })
   @Post()
   create(@Body() dto: CreateMenuItemDto) {
     return this.menuItemsService.create(dto);
@@ -45,6 +48,9 @@ export class MenuItemsController {
 
   @ApiBearerAuth()
   @Roles(Role.ADMIN)
+  @ApiOperation({
+    summary: 'Update a menu item (imageUrl accepts a public URL)',
+  })
   @Patch(':id')
   update(@Param('id') id: string, @Body() dto: UpdateMenuItemDto) {
     return this.menuItemsService.update(id, dto);

--- a/src/menu/menu-items.service.ts
+++ b/src/menu/menu-items.service.ts
@@ -12,6 +12,9 @@ import {
   UpdateMenuItemDto,
 } from './dto/menu-item.dto';
 
+// Image policy (MVP): URL-only. Admin provides a public image URL.
+// File upload (S3/Supabase Storage) is out of scope for MVP.
+// To remove an image, set imageUrl to null via PATCH.
 @Injectable()
 export class MenuItemsService {
   constructor(private readonly prisma: PrismaService) {}


### PR DESCRIPTION
Closes #14 

## Changes
- Add @IsUrl() validation to imageUrl in CreateMenuItemDto
- UpdateMenuItemDto inherits validation via PartialType
- imageUrl flows through create() and update() automatically
- Add policy comment: URL-only for MVP, no S3/storage
- Update Swagger summaries on POST/PATCH /menu/items