### PR TITLE
feat(#13): search menu items by name with pagination

### DIFF
--- a/src/menu/dto/menu-item.dto.ts
+++ b/src/menu/dto/menu-item.dto.ts
@@ -54,6 +54,14 @@ export class CreateMenuItemDto {
 export class UpdateMenuItemDto extends PartialType(CreateMenuItemDto) {}
 
 export class MenuItemQueryDto extends PaginationQueryDto {
+  @ApiPropertyOptional({
+    description: 'Filter by product name (case-insensitive)',
+    example: 'ceviche',
+  })
+  @IsOptional()
+  @IsString()
+  name?: string;
+
   @ApiPropertyOptional({ format: 'uuid' })
   @IsOptional()
   @IsUUID()

--- a/src/menu/menu-items.controller.ts
+++ b/src/menu/menu-items.controller.ts
@@ -25,6 +25,9 @@ export class MenuItemsController {
   constructor(private readonly menuItemsService: MenuItemsService) {}
 
   @Public()
+  @ApiOperation({
+    summary: 'List menu items with optional name search and pagination',
+  })
   @Get()
   findAll(@Query() query: MenuItemQueryDto) {
     return this.menuItemsService.findAll(query);

--- a/src/menu/menu-items.service.ts
+++ b/src/menu/menu-items.service.ts
@@ -25,6 +25,9 @@ export class MenuItemsService {
 
   async findAll(query: MenuItemQueryDto) {
     const where: Prisma.MenuItemWhereInput = {};
+    if (query.name) {
+      where.name = { contains: query.name, mode: 'insensitive' };
+    }
     if (query.categoryId) {
       where.categoryId = query.categoryId;
     }


### PR DESCRIPTION
Closes #13 

## Changes
- Add name filter to MenuItemQueryDto (case-insensitive via Prisma mode: insensitive)
- Update findAll() to accept name filter + pagination
- GET /menu/items supports ?name=&page=&limit=
- Endpoint remains @Public()