### PR TITLE
feat(#20): notes per item and per order - schema, DTOs, service updated

### DIFF
--- a/prisma/migrations/20260702000002_add_order_item_notes/migration.sql
+++ b/prisma/migrations/20260702000002_add_order_item_notes/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "order_items" ADD COLUMN IF NOT EXISTS "notes" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -135,6 +135,7 @@ model OrderItem {
   priceCents    Int
   quantity      Int
   modifiers     Json?
+  notes         String?
   lineTotalCents Int
 
   @@index([orderId])

--- a/src/orders/dto/add-order-item.dto.ts
+++ b/src/orders/dto/add-order-item.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsInt, IsObject, IsOptional, IsUUID, Min } from 'class-validator';
+import { IsInt, IsObject, IsOptional, IsUUID, Min, IsString } from 'class-validator';
+
 
 export class AddOrderItemDto {
   @ApiProperty({ format: 'uuid' })
@@ -18,4 +19,9 @@ export class AddOrderItemDto {
   @IsOptional()
   @IsObject()
   modifiers?: Record<string, unknown>;
+
+  @ApiPropertyOptional({ description: 'Kitchen instructions for this item' })
+  @IsOptional()
+  @IsString()
+  notes?: string;
 }

--- a/src/orders/dto/create-order.dto.ts
+++ b/src/orders/dto/create-order.dto.ts
@@ -33,6 +33,11 @@ export class OrderLineDto {
   @IsOptional()
   @IsObject()
   modifiers?: Record<string, unknown>;
+
+  @ApiPropertyOptional({ description: 'Kitchen instructions for this item' })
+  @IsOptional()
+  @IsString()
+  notes?: string;
 }
 
 export class CreateOrderDto {

--- a/src/orders/dto/update-order-item.dto.ts
+++ b/src/orders/dto/update-order-item.dto.ts
@@ -1,9 +1,15 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { IsInt, Min } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsInt, IsOptional, IsString, Min } from 'class-validator';
 
 export class UpdateOrderItemDto {
   @ApiProperty({ example: 2, minimum: 1 })
+  @IsOptional()
   @IsInt()
   @Min(1)
-  quantity!: number;
+  quantity?: number;
+
+  @ApiPropertyOptional({ description: 'Kitchen instructions for this item' })
+  @IsOptional()
+  @IsString()
+  notes?: string;
 }

--- a/src/orders/orders.controller.ts
+++ b/src/orders/orders.controller.ts
@@ -35,7 +35,9 @@ export class OrdersController {
 
   @Post()
   @Roles(Role.WAITER, Role.CASHIER, Role.MANAGER, Role.ADMIN)
-  @ApiOperation({ summary: 'Open a new order' })
+  @ApiOperation({
+    summary: 'Open a new order (supports notes per order and per line)',
+  })
   @ApiResponse({ status: 201, description: 'Order created in DRAFT status' })
   @ApiResponse({ status: 400, description: 'Validation error' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
@@ -76,7 +78,9 @@ export class OrdersController {
   @ApiTags('orders')
   @Roles(Role.WAITER, Role.CASHIER, Role.MANAGER, Role.ADMIN)
   @Post(':id/items')
-  @ApiOperation({ summary: 'Add a product to an open order' })
+  @ApiOperation({
+    summary: 'Add a product to an open order (supports per-line kitchen notes)',
+  })
   @ApiResponse({
     status: 201,
     description: 'Item added with price snapshot, total recomputed',
@@ -95,7 +99,7 @@ export class OrdersController {
   @ApiTags('orders')
   @Roles(Role.WAITER, Role.CASHIER, Role.MANAGER, Role.ADMIN)
   @Patch(':id/items/:itemId')
-  @ApiOperation({ summary: 'Change quantity of an order line' })
+  @ApiOperation({ summary: 'Change quantity or notes of an order line' })
   @ApiResponse({
     status: 200,
     description: 'Quantity updated, total recomputed',

--- a/src/orders/orders.service.ts
+++ b/src/orders/orders.service.ts
@@ -56,6 +56,7 @@ export class OrdersService {
         priceCents: item.priceCents,
         quantity: line.quantity,
         modifiers: (line.modifiers ?? undefined) as Prisma.InputJsonValue,
+        notes: line.notes,
         lineTotalCents,
       };
     });
@@ -177,6 +178,7 @@ export class OrdersService {
         priceCents: menuItem.priceCents,
         quantity: dto.quantity,
         modifiers: (dto.modifiers ?? null) as Prisma.InputJsonValue,
+        notes: dto.notes,
         lineTotalCents,
       },
     });
@@ -208,11 +210,20 @@ export class OrdersService {
       throw new NotFoundException('Order item not found');
     }
 
-    const lineTotalCents = orderItem.priceCents * dto.quantity;
+    const effectiveQuantity = dto.quantity ?? orderItem.quantity;
+    const lineTotalCents = orderItem.priceCents * effectiveQuantity;
+
+    const updateData: Prisma.OrderItemUpdateInput = {
+      quantity: effectiveQuantity,
+      lineTotalCents,
+    };
+    if (dto.notes !== undefined) {
+      updateData.notes = dto.notes;
+    }
 
     await this.prisma.orderItem.update({
       where: { id: orderItemId },
-      data: { quantity: dto.quantity, lineTotalCents },
+      data: updateData,
     });
 
     return this.recalculateTotals(orderId);


### PR DESCRIPTION
Closes #20 

## Changes
- Add notes String? to OrderItem model
- Migration: add_order_item_notes
- Add notes field to CreateOrderDto, AddOrderItemDto, UpdateOrderItemDto
- notes flows through create() and addItem() to Prisma
- Fix: isString → IsString typo in add-order-item.dto.ts
- Fix: migration history desync resolved via prisma migrate resolve