### PR TITLE
fix(#29): enforce required discount fields via ValidateIf pattern

### DIFF
--- a/prisma/migrations/20260703065350_add_discount_type_and_audit/migration.sql
+++ b/prisma/migrations/20260703065350_add_discount_type_and_audit/migration.sql
@@ -1,0 +1,9 @@
+-- CreateEnum
+CREATE TYPE "DiscountType" AS ENUM ('FIXED', 'PERCENTAGE');
+
+-- AlterTable
+ALTER TABLE "orders" ADD COLUMN     "discountAppliedAt" TIMESTAMP(3),
+ADD COLUMN     "discountAppliedBy" TEXT,
+ADD COLUMN     "discountPercent" INTEGER,
+ADD COLUMN     "discountReason" TEXT,
+ADD COLUMN     "discountType" "DiscountType" NOT NULL DEFAULT 'FIXED';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -91,6 +91,11 @@ enum OrderType {
   TAKEAWAY
 }
 
+enum DiscountType {
+  FIXED
+  PERCENTAGE
+}
+
 enum OrderStatus {
   DRAFT
   PENDING
@@ -113,6 +118,11 @@ model Order {
   taxCents     Int         @default(0)
   totalCents   Int         @default(0)
   discountCents Int        @default(0)
+  discountType  DiscountType @default(FIXED)
+  discountPercent   Int?
+  discountAppliedBy String?
+  discountAppliedAt DateTime?
+  discountReason    String?
   currency     String      @default("usd")
   notes        String?
   items        OrderItem[]

--- a/src/orders/dto/apply-discount.dto.ts
+++ b/src/orders/dto/apply-discount.dto.ts
@@ -1,12 +1,49 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { IsInt, Min } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { DiscountType } from '@prisma/client';
+import {
+  IsEnum,
+  IsInt,
+  IsOptional,
+  IsString,
+  Max,
+  MaxLength,
+  Min,
+  ValidateIf,
+} from 'class-validator';
 
 export class ApplyDiscountDto {
   @ApiProperty({
-    description: 'Discount amount in cents',
+    enum: DiscountType,
+    example: 'FIXED',
+  })
+  @IsEnum(DiscountType)
+  discountType!: DiscountType;
+
+  @ApiPropertyOptional({
+    description: 'Required when discountType is FIXED. Amount in cents.',
     example: 500,
   })
-  @IsInt()
+  @ValidateIf((o) => o.discountType === DiscountType.FIXED)
+  @IsInt({ message: 'discountCents is required for FIXED discounts' })
   @Min(0)
-  discountCents!: number;
+  discountCents?: number;
+
+  @ApiPropertyOptional({
+    description: 'Required when discountType is PERCENTAGE. 0-100.',
+    example: 15,
+  })
+  @ValidateIf((o) => o.discountType === DiscountType.PERCENTAGE)
+  @IsInt({ message: 'discountPercent is required for PERCENTAGE discounts' })
+  @Min(0)
+  @Max(100)
+  discountPercent?: number;
+
+  @ApiPropertyOptional({
+    description: 'Reason for the discount (audit trail)',
+    example: 'Loyal customer comp',
+  })
+  @IsString()
+  @IsOptional()
+  @MaxLength(200)
+  reason?: string;
 }

--- a/src/orders/orders.controller.ts
+++ b/src/orders/orders.controller.ts
@@ -152,18 +152,25 @@ export class OrdersController {
   @ApiTags('orders')
   @Roles(Role.CASHIER, Role.MANAGER, Role.ADMIN)
   @Patch(':id/discount')
-  @ApiOperation({ summary: 'Apply a discount to an open order' })
+  @ApiOperation({
+    summary: 'Apply a fixed or percentage discount to an open order',
+  })
   @ApiResponse({
     status: 200,
-    description: 'Discount applied, total recomputed',
+    description: 'Discount applied, total recomputed, audit recorded',
   })
   @ApiResponse({
     status: 400,
-    description: 'Order not editable or discount exceeds subtotal',
+    description:
+      'Invalid discount, order not editable, or discount exceeds subtotal',
   })
   @ApiResponse({ status: 404, description: 'Order not found' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
-  applyDiscount(@Param('id') id: string, @Body() dto: ApplyDiscountDto) {
-    return this.ordersService.applyDiscount(id, dto);
+  applyDiscount(
+    @Param('id') id: string,
+    @Body() dto: ApplyDiscountDto,
+    @CurrentUser('id') userId: string,
+  ) {
+    return this.ordersService.applyDiscount(id, dto, userId);
   }
 }

--- a/src/orders/orders.service.ts
+++ b/src/orders/orders.service.ts
@@ -4,7 +4,7 @@ import {
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
-import { OrderStatus, Prisma, Role } from '@prisma/client';
+import { DiscountType, OrderStatus, Prisma, Role } from '@prisma/client';
 import { randomBytes } from 'crypto';
 import { PrismaService } from '../prisma/prisma.service';
 import {
@@ -302,7 +302,11 @@ export class OrdersService {
     });
   }
 
-  async applyDiscount(orderId: string, dto: ApplyDiscountDto) {
+  async applyDiscount(
+    orderId: string,
+    dto: ApplyDiscountDto,
+    appliedByUserId: string,
+  ) {
     const order = await this.prisma.order.findUnique({
       where: { id: orderId },
     });
@@ -323,13 +327,28 @@ export class OrdersService {
       0,
     );
 
-    if (dto.discountCents > subtotalCents) {
+    const resolvedDiscountCents =
+      dto.discountType === DiscountType.PERCENTAGE
+        ? Math.floor((subtotalCents * (dto.discountPercent ?? 0)) / 100)
+        : (dto.discountCents ?? 0);
+
+    if (resolvedDiscountCents > subtotalCents) {
       throw new BadRequestException('Discount cannot exceed order subtotal');
     }
 
     await this.prisma.order.update({
       where: { id: orderId },
-      data: { discountCents: dto.discountCents },
+      data: {
+        discountCents: resolvedDiscountCents,
+        discountType: dto.discountType,
+        discountPercent:
+          dto.discountType === DiscountType.PERCENTAGE
+            ? dto.discountPercent
+            : null,
+        discountAppliedBy: appliedByUserId,
+        discountAppliedAt: new Date(),
+        discountReason: dto.reason ?? null,
+      },
     });
 
     return this.recalculateTotals(orderId);


### PR DESCRIPTION
Closes #29 

## Changes
- Add DiscountType enum (FIXED, PERCENTAGE) with audit fields on Order
  (discountAppliedBy, discountAppliedAt, discountReason)
- Percentage discounts resolved to discountCents at write-time using
  floor rounding (never exceeds subtotal)
- Extends #35 without modifying recalculateTotals()

## Fix included
- apply-discount.dto.ts had @IsOptional() + @ValidateIf() together,
  which silently skipped required-field validation (confirmed via
  curl: FIXED/PERCENTAGE discounts with missing amount returned 200
  instead of 400, writing bogus audit entries). Removed @IsOptional(),
  matching the existing @ValidateIf pattern in create-order.dto.ts.