### PR TITLE
feat(#59): add basic audit trail with tests

### DIFF
--- a/prisma/migrations/20260703073406_add_audit_log/migration.sql
+++ b/prisma/migrations/20260703073406_add_audit_log/migration.sql
@@ -1,0 +1,21 @@
+-- CreateTable
+CREATE TABLE "audit_logs" (
+    "id" TEXT NOT NULL,
+    "entityType" TEXT NOT NULL,
+    "entityId" TEXT NOT NULL,
+    "action" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "metadata" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "audit_logs_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "audit_logs_entityType_entityId_idx" ON "audit_logs"("entityType", "entityId");
+
+-- CreateIndex
+CREATE INDEX "audit_logs_userId_idx" ON "audit_logs"("userId");
+
+-- CreateIndex
+CREATE INDEX "audit_logs_createdAt_idx" ON "audit_logs"("createdAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -253,3 +253,20 @@ model StockAdjustment {
   @@index([inventoryItemId])
   @@map("stock_adjustments")
 }
+
+// ---------- Audit ----------
+
+model AuditLog {
+  id         String   @id @default(uuid())
+  entityType String // e.g. "Order", "MenuItem", "InventoryItem"
+  entityId   String
+  action     String // e.g. "DISCOUNT_APPLIED", "PRICE_CHANGED", "STOCK_ADJUSTED"
+  userId     String
+  metadata   Json?
+  createdAt  DateTime @default(now())
+
+  @@index([entityType, entityId])
+  @@index([userId])
+  @@index([createdAt])
+  @@map("audit_logs")
+}

--- a/src/audit/audit.module.ts
+++ b/src/audit/audit.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { AuditService } from './audit.service';
+
+@Module({
+  providers: [AuditService],
+  exports: [AuditService],
+})
+export class AuditModule {}

--- a/src/audit/audit.service.spec.ts
+++ b/src/audit/audit.service.spec.ts
@@ -1,0 +1,111 @@
+import { PrismaService } from '../prisma/prisma.service';
+import { AuditService } from './audit.service';
+
+type MockPrisma = {
+  auditLog: {
+    create: jest.Mock;
+    findMany: jest.Mock;
+  };
+};
+
+function createMockPrisma(): MockPrisma {
+  return {
+    auditLog: {
+      create: jest.fn(),
+      findMany: jest.fn(),
+    },
+  };
+}
+
+describe('AuditService', () => {
+  let service: AuditService;
+  let prisma: MockPrisma;
+
+  beforeEach(() => {
+    prisma = createMockPrisma();
+    service = new AuditService(prisma as unknown as PrismaService);
+  });
+
+  describe('log', () => {
+    it('creates the audit record with the provided fields', async () => {
+      prisma.auditLog.create.mockResolvedValue({});
+
+      await service.log({
+        entityType: 'Order',
+        entityId: 'order-1',
+        action: 'DISCOUNT_APPLIED',
+        userId: 'user-1',
+        metadata: { discountCents: 100 },
+      });
+
+      expect(prisma.auditLog.create).toHaveBeenCalledTimes(1);
+      expect(prisma.auditLog.create).toHaveBeenCalledWith({
+        data: {
+          entityType: 'Order',
+          entityId: 'order-1',
+          action: 'DISCOUNT_APPLIED',
+          userId: 'user-1',
+          metadata: { discountCents: 100 },
+        },
+      });
+    });
+
+    it('creates the audit record when metadata is omitted', async () => {
+      prisma.auditLog.create.mockResolvedValue({});
+
+      await service.log({
+        entityType: 'InventoryItem',
+        entityId: 'item-1',
+        action: 'STOCK_ADJUSTED',
+        userId: 'user-2',
+      });
+
+      expect(prisma.auditLog.create).toHaveBeenCalledWith({
+        data: {
+          entityType: 'InventoryItem',
+          entityId: 'item-1',
+          action: 'STOCK_ADJUSTED',
+          userId: 'user-2',
+          metadata: undefined,
+        },
+      });
+    });
+  });
+
+  describe('findByEntity', () => {
+    it('queries by entityType/entityId ordered by createdAt desc', async () => {
+      const newest = {
+        id: 'log-2',
+        entityType: 'Order',
+        entityId: 'order-1',
+        action: 'DISCOUNT_APPLIED',
+        userId: 'user-1',
+        metadata: null,
+        createdAt: new Date('2026-01-02'),
+      };
+      const oldest = {
+        id: 'log-1',
+        entityType: 'Order',
+        entityId: 'order-1',
+        action: 'DISCOUNT_APPLIED',
+        userId: 'user-1',
+        metadata: null,
+        createdAt: new Date('2026-01-01'),
+      };
+      // Simulate the DB already returning rows ordered by the requested
+      // `orderBy` clause (newest first).
+      prisma.auditLog.findMany.mockResolvedValue([newest, oldest]);
+
+      const result = await service.findByEntity('Order', 'order-1');
+
+      expect(prisma.auditLog.findMany).toHaveBeenCalledWith({
+        where: { entityType: 'Order', entityId: 'order-1' },
+        orderBy: { createdAt: 'desc' },
+      });
+      expect(result).toEqual([newest, oldest]);
+      expect(result[0].createdAt.getTime()).toBeGreaterThan(
+        result[1].createdAt.getTime(),
+      );
+    });
+  });
+});

--- a/src/audit/audit.service.ts
+++ b/src/audit/audit.service.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+
+@Injectable()
+export class AuditService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async log(params: {
+    entityType: string;
+    entityId: string;
+    action: string;
+    userId: string;
+    metadata?: Record<string, unknown>;
+  }): Promise<void> {
+    await this.prisma.auditLog.create({
+      data: {
+        ...params,
+        metadata: params.metadata as Prisma.InputJsonValue | undefined,
+      },
+    });
+  }
+
+  async findByEntity(entityType: string, entityId: string) {
+    return this.prisma.auditLog.findMany({
+      where: { entityType, entityId },
+      orderBy: { createdAt: 'desc' },
+    });
+  }
+}

--- a/src/orders/orders.controller.ts
+++ b/src/orders/orders.controller.ts
@@ -15,6 +15,7 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 import { Role } from '@prisma/client';
+import { AuditService } from '../audit/audit.service';
 import {
   AuthUser,
   CurrentUser,
@@ -32,7 +33,10 @@ import { OrdersService } from './orders.service';
 @ApiBearerAuth()
 @Controller('orders')
 export class OrdersController {
-  constructor(private readonly ordersService: OrdersService) {}
+  constructor(
+    private readonly ordersService: OrdersService,
+    private readonly auditService: AuditService,
+  ) {}
 
   @Post()
   @Roles(Role.WAITER, Role.CASHIER, Role.MANAGER, Role.ADMIN)
@@ -172,5 +176,19 @@ export class OrdersController {
     @CurrentUser('id') userId: string,
   ) {
     return this.ordersService.applyDiscount(id, dto, userId);
+  }
+
+  @ApiBearerAuth()
+  @ApiTags('orders')
+  @Roles(Role.MANAGER, Role.ADMIN)
+  @Get(':id/audit-log')
+  @ApiOperation({ summary: 'Get the audit history for an order' })
+  @ApiResponse({
+    status: 200,
+    description: 'List of audit entries, newest first',
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  getAuditLog(@Param('id') id: string) {
+    return this.auditService.findByEntity('Order', id);
   }
 }

--- a/src/orders/orders.module.ts
+++ b/src/orders/orders.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
+import { AuditModule } from '../audit/audit.module';
 import { OrdersController } from './orders.controller';
 import { OrdersService } from './orders.service';
 
 @Module({
+  imports: [AuditModule],
   controllers: [OrdersController],
   providers: [OrdersService],
   exports: [OrdersService],

--- a/src/orders/orders.service.spec.ts
+++ b/src/orders/orders.service.spec.ts
@@ -2,6 +2,7 @@ import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { OrderStatus, OrderType } from '@prisma/client';
 import { OrdersService } from './orders.service';
 import { PrismaService } from '../prisma/prisma.service';
+import { AuditService } from '../audit/audit.service';
 
 type MockPrisma = {
   order: {
@@ -39,9 +40,22 @@ function createMockPrisma(): MockPrisma {
   };
 }
 
+type MockAuditService = {
+  log: jest.Mock;
+  findByEntity: jest.Mock;
+};
+
+function createMockAuditService(): MockAuditService {
+  return {
+    log: jest.fn().mockResolvedValue(undefined),
+    findByEntity: jest.fn(),
+  };
+}
+
 describe('OrdersService', () => {
   let service: OrdersService;
   let prisma: MockPrisma;
+  let auditService: MockAuditService;
 
   const orderId = 'order-1';
   const menuItemId = 'menu-item-1';
@@ -61,7 +75,11 @@ describe('OrdersService', () => {
 
   beforeEach(() => {
     prisma = createMockPrisma();
-    service = new OrdersService(prisma as unknown as PrismaService);
+    auditService = createMockAuditService();
+    service = new OrdersService(
+      prisma as unknown as PrismaService,
+      auditService as unknown as AuditService,
+    );
   });
 
   describe('addItem', () => {

--- a/src/orders/orders.service.ts
+++ b/src/orders/orders.service.ts
@@ -12,6 +12,7 @@ import {
   PaginationQueryDto,
 } from '../common/dto/pagination-query.dto';
 import { AuthUser } from '../auth/decorators/current-user.decorator';
+import { AuditService } from '../audit/audit.service';
 import { CreateOrderDto } from './dto/create-order.dto';
 import { AddOrderItemDto } from './dto/add-order-item.dto';
 import { ApplyDiscountDto } from './dto/apply-discount.dto';
@@ -29,7 +30,10 @@ const orderInclude = { items: true } satisfies Prisma.OrderInclude;
 export class OrdersService {
   private readonly TAX_RATE = 0;
 
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly auditService: AuditService,
+  ) {}
 
   async create(dto: CreateOrderDto, customerId?: string) {
     const itemIds = dto.items.map((i) => i.menuItemId);
@@ -348,6 +352,22 @@ export class OrdersService {
         discountAppliedBy: appliedByUserId,
         discountAppliedAt: new Date(),
         discountReason: dto.reason ?? null,
+      },
+    });
+
+    await this.auditService.log({
+      entityType: 'Order',
+      entityId: orderId,
+      action: 'DISCOUNT_APPLIED',
+      userId: appliedByUserId,
+      metadata: {
+        discountType: dto.discountType,
+        discountCents: resolvedDiscountCents,
+        discountPercent:
+          dto.discountType === DiscountType.PERCENTAGE
+            ? dto.discountPercent
+            : undefined,
+        reason: dto.reason,
       },
     });
 

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -828,4 +828,89 @@ describe('RestoSync API (e2e)', () => {
         .expect(200);
     });
   });
+
+  describe('order discount audit trail', () => {
+    let adminToken: string;
+    let managerToken: string;
+    let cashierToken: string;
+    let categoryId: string;
+    let burgerId: string;
+    let orderId: string;
+
+    beforeAll(async () => {
+      const adminLogin = await request(app.getHttpServer())
+        .post('/api/auth/login')
+        .send({ email: 'admin@restosync.local', password: 'Admin123!' })
+        .expect(200);
+      adminToken = adminLogin.body.accessToken;
+
+      const managerLogin = await request(app.getHttpServer())
+        .post('/api/auth/login')
+        .send({ email: 'manager@restosync.local', password: 'Manager123!' })
+        .expect(200);
+      managerToken = managerLogin.body.accessToken;
+
+      const cashierLogin = await request(app.getHttpServer())
+        .post('/api/auth/login')
+        .send({ email: 'cashier@restosync.local', password: 'Cashier123!' })
+        .expect(200);
+      cashierToken = cashierLogin.body.accessToken;
+
+      const category = await request(app.getHttpServer())
+        .post('/api/menu/categories')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ name: `Audit_${Date.now()}` })
+        .expect(201);
+      categoryId = category.body.id;
+
+      const burger = await request(app.getHttpServer())
+        .post('/api/menu/items')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({
+          name: 'Audit Burger',
+          priceCents: 1000,
+          categoryId,
+        })
+        .expect(201);
+      burgerId = burger.body.id;
+
+      const order = await request(app.getHttpServer())
+        .post('/api/orders')
+        .set('Authorization', `Bearer ${cashierToken}`)
+        .send({
+          type: 'DINE_IN',
+          table: 'A1',
+          items: [{ menuItemId: burgerId, quantity: 1 }],
+        })
+        .expect(201);
+      orderId = order.body.id;
+
+      await request(app.getHttpServer())
+        .patch(`/api/orders/${orderId}/discount`)
+        .set('Authorization', `Bearer ${cashierToken}`)
+        .send({ discountType: 'FIXED', discountCents: 100, reason: 'comp' })
+        .expect(200);
+    });
+
+    it('GET /api/orders/:id/audit-log as MANAGER returns 200 with entries', async () => {
+      const res = await request(app.getHttpServer())
+        .get(`/api/orders/${orderId}/audit-log`)
+        .set('Authorization', `Bearer ${managerToken}`)
+        .expect(200);
+
+      expect(Array.isArray(res.body)).toBe(true);
+      expect(res.body.length).toBeGreaterThan(0);
+      const entry = res.body[0];
+      expect(entry.entityType).toBe('Order');
+      expect(entry.entityId).toBe(orderId);
+      expect(entry.action).toBe('DISCOUNT_APPLIED');
+    });
+
+    it('GET /api/orders/:id/audit-log as CASHIER is forbidden', async () => {
+      await request(app.getHttpServer())
+        .get(`/api/orders/${orderId}/audit-log`)
+        .set('Authorization', `Bearer ${cashierToken}`)
+        .expect(403);
+    });
+  });
 });


### PR DESCRIPTION
Closes #59 

## Changes
- Add generic AuditLog model (entityType, entityId, action, userId, metadata, createdAt)
- Add AuditModule/AuditService with log() and findByEntity()
- Wire OrdersService.applyDiscount() to write audit entries (DISCOUNT_APPLIED)
- Add GET /orders/:id/audit-log (MANAGER/ADMIN only)
- Existing discountAppliedBy/At/Reason fields on Order kept as fast lookup;
  AuditLog adds full history on top

## Tests
- Unit: audit.service.spec.ts — log() and findByEntity() behavior
- e2e: audit trail flow — MANAGER can read, CASHIER gets 403

No Prisma middleware/extensions or new dependencies used, per design decision
to keep audit writes explicit within each service (consistent with existing
project patterns).