### PR TITLE
feat(#60): reposition Stripe as decoupled SaaS billing module

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,12 @@ JWT_EXPIRES_IN=15m
 JWT_REFRESH_SECRET=change-me-too-in-production
 JWT_REFRESH_EXPIRES_IN=7d
 
-# Stripe
+# Stripe (POS checkout — diner-facing, see src/payments/)
 STRIPE_SECRET_KEY=sk_test_xxx
 STRIPE_WEBHOOK_SECRET=whsec_xxx
 STRIPE_CURRENCY=usd
+
+# Stripe (SaaS billing — restaurant pays RestoSync, see src/billing/)
+# Requires its own webhook endpoint in the Stripe dashboard pointing at
+# /api/billing/webhook, separate from the payments webhook above.
+STRIPE_BILLING_WEBHOOK_SECRET=whsec_billing_xxx

--- a/prisma/migrations/20260703080036_add_subscription_billing/migration.sql
+++ b/prisma/migrations/20260703080036_add_subscription_billing/migration.sql
@@ -1,0 +1,19 @@
+-- CreateTable
+CREATE TABLE "subscriptions" (
+    "id" TEXT NOT NULL,
+    "stripeCustomerId" TEXT NOT NULL,
+    "stripeSubscriptionId" TEXT,
+    "status" TEXT NOT NULL,
+    "planName" TEXT NOT NULL,
+    "currentPeriodEnd" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "subscriptions_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "subscriptions_stripeCustomerId_key" ON "subscriptions"("stripeCustomerId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "subscriptions_stripeSubscriptionId_key" ON "subscriptions"("stripeSubscriptionId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -270,3 +270,20 @@ model AuditLog {
   @@index([createdAt])
   @@map("audit_logs")
 }
+
+// ---------- Billing (SaaS subscription — restaurant pays RestoSync) ----------
+// Decoupled from src/payments/ (POS checkout, diner pays restaurant).
+// See src/billing/README.md for the boundary between the two concerns.
+
+model Subscription {
+  id                   String    @id @default(uuid())
+  stripeCustomerId     String    @unique
+  stripeSubscriptionId String?   @unique
+  status               String // "active" | "past_due" | "canceled" | "trialing"
+  planName             String // free-form for now, e.g. "starter"
+  currentPeriodEnd     DateTime?
+  createdAt            DateTime  @default(now())
+  updatedAt            DateTime  @updatedAt
+
+  @@map("subscriptions")
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,6 +5,7 @@ import { AppController } from './app.controller';
 import { AuthModule } from './auth/auth.module';
 import { JwtAuthGuard } from './auth/guards/jwt-auth.guard';
 import { RolesGuard } from './auth/guards/roles.guard';
+import { BillingModule } from './billing/billing.module';
 import configuration from './config/configuration';
 import { validateEnv } from './config/env.validation';
 import { CashRegisterModule } from './cash-register/cash-register.module';
@@ -32,6 +33,7 @@ import { UsersModule } from './users/users.module';
     CashRegisterModule,
     ReportsModule,
     InventoryModule,
+    BillingModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/billing/README.md
+++ b/src/billing/README.md
@@ -1,0 +1,55 @@
+# Billing vs Payments boundary
+
+- `src/payments/` → POS checkout. The diner pays the restaurant.
+  Methods: CASH, CARD, TRANSFER. STRIPE is a reserved enum value for
+  a possible future diner-facing online payment flow — NOT implemented,
+  NOT part of this module's active logic.
+
+- `src/billing/` → SaaS subscription billing. The restaurant (as
+  RestoSync's customer) pays RestoSync via Stripe. This is completely
+  decoupled from the order/checkout flow and has no relationship to
+  PaymentMethod or Order/Payment models.
+
+- Do not mix these two concerns in the same module going forward.
+
+## Scope (intentionally minimal for the MVP)
+
+- One `Subscription` model — no Plan/features/entitlements model.
+- One webhook endpoint (`POST /billing/webhook`) handling only the
+  minimum events needed to keep subscription status in sync:
+  `customer.subscription.created`, `customer.subscription.updated`,
+  `customer.subscription.deleted`, `invoice.payment_failed`.
+- No Stripe Customer Portal integration.
+- No Restaurant/Tenant model — the project is mono-tenant for the MVP
+  (multi-tenancy is tracked separately in #9).
+
+## Credentials
+
+- Reuses the same `STRIPE_SECRET_KEY` (Stripe account/API key) already
+  configured for `src/payments/`'s Stripe gateway — no separate Stripe
+  account, no duplicated SDK setup.
+- Uses its **own** webhook signing secret, `STRIPE_BILLING_WEBHOOK_SECRET`,
+  distinct from `STRIPE_WEBHOOK_SECRET` (used by `src/payments/`). These
+  must NOT be the same value — see "Stripe dashboard setup" below.
+
+## Stripe dashboard setup
+
+`POST /api/billing/webhook` and `POST /api/payments/webhook` are two
+independent Stripe webhook endpoints and must be configured as **two
+separate endpoints** in the Stripe dashboard (Developers → Webhooks),
+each subscribed to its own set of events:
+
+1. **Payments webhook** (existing, `src/payments/`) → URL pointing at
+   `/api/payments/webhook`, subscribed to `payment_intent.succeeded` /
+   `payment_intent.payment_failed`. Its signing secret goes into
+   `STRIPE_WEBHOOK_SECRET`.
+2. **Billing webhook** (this module) → a **new, separate** endpoint in
+   the dashboard pointing at `/api/billing/webhook`, subscribed to
+   `customer.subscription.created` / `customer.subscription.updated` /
+   `customer.subscription.deleted` / `invoice.payment_failed`. Its
+   signing secret goes into `STRIPE_BILLING_WEBHOOK_SECRET`.
+
+Do not point both endpoints at the same URL, and do not reuse one
+endpoint's signing secret for the other — each Stripe webhook endpoint
+has its own unique signing secret, and mixing them up will cause
+signature verification to fail for every event.

--- a/src/billing/billing.controller.ts
+++ b/src/billing/billing.controller.ts
@@ -1,0 +1,40 @@
+import {
+  BadRequestException,
+  Controller,
+  Headers,
+  HttpCode,
+  HttpStatus,
+  Post,
+  RawBodyRequest,
+  Req,
+} from '@nestjs/common';
+import { ApiExcludeEndpoint, ApiTags } from '@nestjs/swagger';
+import { Request } from 'express';
+import { Public } from '../auth/decorators/public.decorator';
+import { BillingService } from './billing.service';
+
+// SaaS subscription billing webhook — the restaurant pays RestoSync via
+// Stripe. Fully decoupled from src/payments/ (POS checkout). See
+// src/billing/README.md for the boundary between the two concerns.
+@ApiTags('billing')
+@Controller('billing')
+export class BillingController {
+  constructor(private readonly billingService: BillingService) {}
+
+  @Public()
+  @ApiExcludeEndpoint()
+  @Post('webhook')
+  @HttpCode(HttpStatus.OK)
+  handleWebhook(
+    @Req() req: RawBodyRequest<Request>,
+    @Headers('stripe-signature') signature: string,
+  ) {
+    if (!req.rawBody) {
+      throw new BadRequestException('Missing raw body');
+    }
+    if (!signature) {
+      throw new BadRequestException('Missing stripe-signature header');
+    }
+    return this.billingService.handleWebhook(req.rawBody, signature);
+  }
+}

--- a/src/billing/billing.module.ts
+++ b/src/billing/billing.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { BillingController } from './billing.controller';
+import { BillingService } from './billing.service';
+
+@Module({
+  controllers: [BillingController],
+  providers: [BillingService],
+  exports: [BillingService],
+})
+export class BillingModule {}

--- a/src/billing/billing.service.spec.ts
+++ b/src/billing/billing.service.spec.ts
@@ -1,0 +1,300 @@
+import { BadRequestException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { PrismaService } from '../prisma/prisma.service';
+import { BillingService } from './billing.service';
+
+// Mock the Stripe SDK so we can control webhooks.constructEvent() without
+// needing real Stripe credentials or a real signed payload.
+const constructEventMock = jest.fn();
+jest.mock('stripe', () => {
+  return jest.fn().mockImplementation(() => ({
+    webhooks: { constructEvent: constructEventMock },
+  }));
+});
+
+type MockPrisma = {
+  subscription: {
+    create: jest.Mock;
+    update: jest.Mock;
+    findUnique: jest.Mock;
+  };
+};
+
+function createMockPrisma(): MockPrisma {
+  return {
+    subscription: {
+      create: jest.fn(),
+      update: jest.fn(),
+      findUnique: jest.fn(),
+    },
+  };
+}
+
+function createMockConfig(): ConfigService {
+  return {
+    get: jest.fn((key: string) => {
+      const values: Record<string, string> = {
+        'stripe.secretKey': 'sk_test_123',
+        'stripe.billingWebhookSecret': 'whsec_billing_test_123',
+      };
+      return values[key];
+    }),
+  } as unknown as ConfigService;
+}
+
+describe('BillingService', () => {
+  let service: BillingService;
+  let prisma: MockPrisma;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    prisma = createMockPrisma();
+    service = new BillingService(
+      prisma as unknown as PrismaService,
+      createMockConfig(),
+    );
+  });
+
+  describe('createSubscription', () => {
+    it('creates the subscription record with status active', async () => {
+      prisma.subscription.create.mockResolvedValue({
+        id: 'sub-row-1',
+        stripeCustomerId: 'cus_123',
+        stripeSubscriptionId: 'sub_123',
+        planName: 'starter',
+        status: 'active',
+      });
+
+      const result = await service.createSubscription(
+        'cus_123',
+        'sub_123',
+        'starter',
+      );
+
+      expect(prisma.subscription.create).toHaveBeenCalledWith({
+        data: {
+          stripeCustomerId: 'cus_123',
+          stripeSubscriptionId: 'sub_123',
+          planName: 'starter',
+          status: 'active',
+        },
+      });
+      expect(result.status).toBe('active');
+    });
+  });
+
+  describe('updateSubscriptionStatus', () => {
+    it('updates status when the subscription exists', async () => {
+      prisma.subscription.findUnique.mockResolvedValue({
+        id: 'sub-row-1',
+        stripeSubscriptionId: 'sub_123',
+        status: 'active',
+      });
+      prisma.subscription.update.mockResolvedValue({
+        id: 'sub-row-1',
+        stripeSubscriptionId: 'sub_123',
+        status: 'past_due',
+      });
+
+      const result = await service.updateSubscriptionStatus(
+        'sub_123',
+        'past_due',
+      );
+
+      expect(prisma.subscription.findUnique).toHaveBeenCalledWith({
+        where: { stripeSubscriptionId: 'sub_123' },
+      });
+      expect(prisma.subscription.update).toHaveBeenCalledWith({
+        where: { stripeSubscriptionId: 'sub_123' },
+        data: { status: 'past_due' },
+      });
+      expect(result?.status).toBe('past_due');
+    });
+
+    it('includes currentPeriodEnd in the update data when provided', async () => {
+      prisma.subscription.findUnique.mockResolvedValue({
+        id: 'sub-row-1',
+        stripeSubscriptionId: 'sub_123',
+      });
+      prisma.subscription.update.mockResolvedValue({});
+      const periodEnd = new Date('2026-08-01');
+
+      await service.updateSubscriptionStatus('sub_123', 'active', periodEnd);
+
+      expect(prisma.subscription.update).toHaveBeenCalledWith({
+        where: { stripeSubscriptionId: 'sub_123' },
+        data: { status: 'active', currentPeriodEnd: periodEnd },
+      });
+    });
+
+    it('does not throw and returns null when the subscription does not exist', async () => {
+      prisma.subscription.findUnique.mockResolvedValue(null);
+
+      const result = await service.updateSubscriptionStatus(
+        'sub_nonexistent',
+        'canceled',
+      );
+
+      expect(result).toBeNull();
+      expect(prisma.subscription.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('findByStripeCustomerId', () => {
+    it('returns the subscription when found', async () => {
+      const subscription = {
+        id: 'sub-row-1',
+        stripeCustomerId: 'cus_123',
+        status: 'active',
+      };
+      prisma.subscription.findUnique.mockResolvedValue(subscription);
+
+      const result = await service.findByStripeCustomerId('cus_123');
+
+      expect(prisma.subscription.findUnique).toHaveBeenCalledWith({
+        where: { stripeCustomerId: 'cus_123' },
+      });
+      expect(result).toEqual(subscription);
+    });
+
+    it('returns null when not found', async () => {
+      prisma.subscription.findUnique.mockResolvedValue(null);
+
+      const result = await service.findByStripeCustomerId('cus_missing');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('handleWebhook', () => {
+    it('throws BadRequestException when the signature is invalid', async () => {
+      constructEventMock.mockImplementation(() => {
+        throw new Error('signature mismatch');
+      });
+
+      await expect(
+        service.handleWebhook(Buffer.from('payload'), 'bad-signature'),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('dispatches customer.subscription.created to createSubscription', async () => {
+      constructEventMock.mockReturnValue({
+        type: 'customer.subscription.created',
+        data: {
+          object: {
+            id: 'sub_123',
+            customer: 'cus_123',
+            items: { data: [{ price: { nickname: 'starter' } }] },
+          },
+        },
+      });
+      prisma.subscription.findUnique.mockResolvedValue(null); // no existing sub yet
+      prisma.subscription.create.mockResolvedValue({});
+
+      await service.handleWebhook(Buffer.from('payload'), 'sig');
+
+      expect(prisma.subscription.create).toHaveBeenCalledWith({
+        data: {
+          stripeCustomerId: 'cus_123',
+          stripeSubscriptionId: 'sub_123',
+          planName: 'starter',
+          status: 'active',
+        },
+      });
+    });
+
+    it('dispatches customer.subscription.updated to updateSubscriptionStatus', async () => {
+      constructEventMock.mockReturnValue({
+        type: 'customer.subscription.updated',
+        data: {
+          object: {
+            id: 'sub_123',
+            status: 'past_due',
+            current_period_end: 1780000000,
+          },
+        },
+      });
+      prisma.subscription.findUnique.mockResolvedValue({
+        stripeSubscriptionId: 'sub_123',
+      });
+      prisma.subscription.update.mockResolvedValue({});
+
+      await service.handleWebhook(Buffer.from('payload'), 'sig');
+
+      expect(prisma.subscription.update).toHaveBeenCalledWith({
+        where: { stripeSubscriptionId: 'sub_123' },
+        data: {
+          status: 'past_due',
+          currentPeriodEnd: new Date(1780000000 * 1000),
+        },
+      });
+    });
+
+    it('dispatches customer.subscription.deleted to updateSubscriptionStatus(canceled)', async () => {
+      constructEventMock.mockReturnValue({
+        type: 'customer.subscription.deleted',
+        data: {
+          object: { id: 'sub_123' },
+        },
+      });
+      prisma.subscription.findUnique.mockResolvedValue({
+        stripeSubscriptionId: 'sub_123',
+      });
+      prisma.subscription.update.mockResolvedValue({});
+
+      await service.handleWebhook(Buffer.from('payload'), 'sig');
+
+      expect(prisma.subscription.update).toHaveBeenCalledWith({
+        where: { stripeSubscriptionId: 'sub_123' },
+        data: { status: 'canceled' },
+      });
+    });
+
+    it('dispatches invoice.payment_failed to updateSubscriptionStatus(past_due)', async () => {
+      constructEventMock.mockReturnValue({
+        type: 'invoice.payment_failed',
+        data: {
+          object: { subscription: 'sub_123' },
+        },
+      });
+      prisma.subscription.findUnique.mockResolvedValue({
+        stripeSubscriptionId: 'sub_123',
+      });
+      prisma.subscription.update.mockResolvedValue({});
+
+      await service.handleWebhook(Buffer.from('payload'), 'sig');
+
+      expect(prisma.subscription.update).toHaveBeenCalledWith({
+        where: { stripeSubscriptionId: 'sub_123' },
+        data: { status: 'past_due' },
+      });
+    });
+
+    it('ignores invoice.payment_failed when there is no subscription on the invoice', async () => {
+      constructEventMock.mockReturnValue({
+        type: 'invoice.payment_failed',
+        data: {
+          object: { subscription: null },
+        },
+      });
+
+      await service.handleWebhook(Buffer.from('payload'), 'sig');
+
+      expect(prisma.subscription.findUnique).not.toHaveBeenCalled();
+      expect(prisma.subscription.update).not.toHaveBeenCalled();
+    });
+
+    it('does nothing for unhandled event types', async () => {
+      constructEventMock.mockReturnValue({
+        type: 'customer.updated',
+        data: { object: {} },
+      });
+
+      const result = await service.handleWebhook(Buffer.from('payload'), 'sig');
+
+      expect(result).toEqual({ received: true });
+      expect(prisma.subscription.create).not.toHaveBeenCalled();
+      expect(prisma.subscription.update).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/billing/billing.service.ts
+++ b/src/billing/billing.service.ts
@@ -1,0 +1,156 @@
+import { BadRequestException, Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import Stripe from 'stripe';
+import { PrismaService } from '../prisma/prisma.service';
+
+// SaaS subscription billing: the restaurant (as RestoSync's customer) pays
+// RestoSync via Stripe. Fully decoupled from src/payments/ (POS checkout).
+// See src/billing/README.md for the boundary between the two concerns.
+@Injectable()
+export class BillingService {
+  private readonly logger = new Logger(BillingService.name);
+  private readonly stripe: Stripe;
+  private readonly webhookSecret: string;
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly config: ConfigService,
+  ) {
+    // Reuses the same Stripe account/secret key already configured for the
+    // POS payments gateway (STRIPE_SECRET_KEY) — no duplicated SDK setup.
+    // The webhook signing secret, however, is intentionally separate
+    // (STRIPE_BILLING_WEBHOOK_SECRET): this is a distinct Stripe webhook
+    // endpoint (/api/billing/webhook) with its own signing secret, not to
+    // be confused with the POS payments webhook secret.
+    this.stripe = new Stripe(config.get<string>('stripe.secretKey') || '', {
+      apiVersion: '2024-06-20',
+    });
+    this.webhookSecret =
+      config.get<string>('stripe.billingWebhookSecret') || '';
+  }
+
+  async createSubscription(
+    stripeCustomerId: string,
+    stripeSubscriptionId: string,
+    planName: string,
+  ) {
+    return this.prisma.subscription.create({
+      data: {
+        stripeCustomerId,
+        stripeSubscriptionId,
+        planName,
+        status: 'active',
+      },
+    });
+  }
+
+  async updateSubscriptionStatus(
+    stripeSubscriptionId: string,
+    status: string,
+    currentPeriodEnd?: Date,
+  ) {
+    // Guard against out-of-order webhook delivery (e.g. an update/deleted
+    // event arriving before the local record exists) rather than letting
+    // Prisma throw P2025 for a record we simply haven't seen yet.
+    const existing = await this.prisma.subscription.findUnique({
+      where: { stripeSubscriptionId },
+    });
+    if (!existing) {
+      this.logger.warn(
+        `No subscription found for stripeSubscriptionId ${stripeSubscriptionId}`,
+      );
+      return null;
+    }
+
+    return this.prisma.subscription.update({
+      where: { stripeSubscriptionId },
+      data: {
+        status,
+        ...(currentPeriodEnd ? { currentPeriodEnd } : {}),
+      },
+    });
+  }
+
+  async findByStripeCustomerId(stripeCustomerId: string) {
+    return this.prisma.subscription.findUnique({
+      where: { stripeCustomerId },
+    });
+  }
+
+  // Verifies the Stripe signature (same pattern as StripeGateway.constructEvent
+  // in src/payments/) and syncs the minimal subscription status fields.
+  async handleWebhook(payload: Buffer, signature: string) {
+    const event = this.constructEvent(payload, signature);
+
+    switch (event.type) {
+      case 'customer.subscription.created':
+        await this.onSubscriptionCreated(event);
+        break;
+      case 'customer.subscription.updated':
+        await this.onSubscriptionUpdated(event);
+        break;
+      case 'customer.subscription.deleted':
+        await this.onSubscriptionDeleted(event);
+        break;
+      case 'invoice.payment_failed':
+        await this.onInvoicePaymentFailed(event);
+        break;
+      default:
+        this.logger.debug(`Unhandled billing webhook event: ${event.type}`);
+    }
+    return { received: true };
+  }
+
+  private constructEvent(payload: Buffer, signature: string): Stripe.Event {
+    try {
+      return this.stripe.webhooks.constructEvent(
+        payload,
+        signature,
+        this.webhookSecret,
+      );
+    } catch (err) {
+      this.logger.warn(`Webhook signature verification failed: ${err}`);
+      throw new BadRequestException('Invalid webhook signature');
+    }
+  }
+
+  private async onSubscriptionCreated(event: Stripe.Event) {
+    const subscription = event.data.object as Stripe.Subscription;
+    const existing = await this.findByStripeCustomerId(
+      subscription.customer as string,
+    );
+    if (existing) {
+      return;
+    }
+    await this.createSubscription(
+      subscription.customer as string,
+      subscription.id,
+      subscription.items.data[0]?.price?.nickname || 'default',
+    );
+  }
+
+  private async onSubscriptionUpdated(event: Stripe.Event) {
+    const subscription = event.data.object as Stripe.Subscription;
+    await this.updateSubscriptionStatus(
+      subscription.id,
+      subscription.status,
+      subscription.current_period_end
+        ? new Date(subscription.current_period_end * 1000)
+        : undefined,
+    );
+  }
+
+  private async onSubscriptionDeleted(event: Stripe.Event) {
+    const subscription = event.data.object as Stripe.Subscription;
+    await this.updateSubscriptionStatus(subscription.id, 'canceled');
+  }
+
+  private async onInvoicePaymentFailed(event: Stripe.Event) {
+    const invoice = event.data.object as Stripe.Invoice;
+    const subscriptionId = invoice.subscription as string | null;
+    if (!subscriptionId) {
+      return;
+    }
+    await this.updateSubscriptionStatus(subscriptionId, 'past_due');
+  }
+}

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -10,7 +10,12 @@ export default () => ({
   },
   stripe: {
     secretKey: process.env.STRIPE_SECRET_KEY || '',
+    // POS checkout webhook (src/payments/) — diner-facing PaymentIntents.
     webhookSecret: process.env.STRIPE_WEBHOOK_SECRET || '',
     currency: process.env.STRIPE_CURRENCY || 'usd',
+    // SaaS billing webhook (src/billing/) — restaurant pays RestoSync.
+    // Deliberately separate from webhookSecret above: this is a distinct
+    // Stripe webhook endpoint with its own signing secret.
+    billingWebhookSecret: process.env.STRIPE_BILLING_WEBHOOK_SECRET || '',
   },
 });

--- a/src/config/env.validation.ts
+++ b/src/config/env.validation.ts
@@ -35,6 +35,10 @@ class EnvironmentVariables {
   @IsOptional()
   @IsString()
   STRIPE_WEBHOOK_SECRET?: string;
+
+  @IsOptional()
+  @IsString()
+  STRIPE_BILLING_WEBHOOK_SECRET?: string;
 }
 
 export function validateEnv(config: Record<string, unknown>) {

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -14,7 +14,9 @@ describe('RestoSync API (e2e)', () => {
       imports: [AppModule],
     }).compile();
 
-    app = moduleRef.createNestApplication();
+    // rawBody is required so Stripe webhook signature verification works,
+    // matching main.ts's NestFactory.create(AppModule, { rawBody: true }).
+    app = moduleRef.createNestApplication({ rawBody: true });
     app.setGlobalPrefix('api', { exclude: ['health'] });
     app.useGlobalPipes(
       new ValidationPipe({ whitelist: true, transform: true }),
@@ -911,6 +913,37 @@ describe('RestoSync API (e2e)', () => {
         .get(`/api/orders/${orderId}/audit-log`)
         .set('Authorization', `Bearer ${cashierToken}`)
         .expect(403);
+    });
+  });
+
+  describe('billing webhook (SaaS subscription, decoupled from POS payments)', () => {
+    it('POST /api/billing/webhook with an invalid signature returns 400', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/api/billing/webhook')
+        .set('stripe-signature', 'invalid-signature')
+        .send({ type: 'customer.subscription.updated', data: { object: {} } })
+        .expect(400);
+
+      expect(res.body.statusCode).toBe(400);
+    });
+
+    it('POST /api/billing/webhook with no stripe-signature header returns 400', async () => {
+      await request(app.getHttpServer())
+        .post('/api/billing/webhook')
+        .send({ type: 'customer.subscription.updated', data: { object: {} } })
+        .expect(400);
+    });
+
+    it('POST /api/billing/webhook does not require authentication (public endpoint)', async () => {
+      // No Authorization header at all — still reaches the handler (which
+      // then 400s on signature verification) instead of a 401, confirming
+      // the endpoint is public like the existing payments webhook.
+      const res = await request(app.getHttpServer())
+        .post('/api/billing/webhook')
+        .set('stripe-signature', 'invalid-signature')
+        .send({});
+
+      expect(res.status).not.toBe(401);
     });
   });
 });


### PR DESCRIPTION
Closes #60 

## Changes
- Add src/billing/ module, fully decoupled from src/payments/ (POS checkout)
- Add minimal Subscription model (stripeCustomerId, status, planName, currentPeriodEnd)
- POST /billing/webhook handles customer.subscription.* and invoice.payment_failed
- Separate STRIPE_BILLING_WEBHOOK_SECRET from STRIPE_WEBHOOK_SECRET
  (each Stripe endpoint requires its own signing secret)
- Document Payments vs Billing boundary in src/billing/README.md,
  including required Stripe dashboard setup for the new webhook endpoint
- No billing-oriented code existed in src/payments/ to migrate — confirmed
  after full review; payments.service.ts only handles POS PaymentIntents

## Tests
- Unit: billing.service.spec.ts (13 tests) — subscription CRUD, webhook
  signature validation, all 4 event handlers, edge cases
- e2e: webhook auth flow (invalid signature → 400, no signature → 400,
  confirms endpoint is public since Stripe signature is the auth)

PaymentMethod.STRIPE enum untouched (reserved, unimplemented in POS flow).
No changes to orders/checkout/cash-register flow.