### PR TITLE
feat(#7): configurable tax rate with production fail-fast validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,10 @@ STRIPE_CURRENCY=usd
 # Requires its own webhook endpoint in the Stripe dashboard pointing at
 # /api/billing/webhook, separate from the payments webhook above.
 STRIPE_BILLING_WEBHOOK_SECRET=whsec_billing_xxx
+
+# TAX_RATE — tax rate as a decimal (e.g. 0.18 = 18%)
+# Peru (IGV):            0.18
+# Spain (IVA general):   0.21
+# REQUIRED in production — the app will not start without this set.
+# Optional in development/test (defaults to 0).
+TAX_RATE=

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -18,4 +18,10 @@ export default () => ({
     // Stripe webhook endpoint with its own signing secret.
     billingWebhookSecret: process.env.STRIPE_BILLING_WEBHOOK_SECRET || '',
   },
+  tax: {
+    // Decimal tax rate (e.g. 0.18 = 18%). Validated in env.validation.ts:
+    // required + range-checked (0-1) in production, optional (defaults to
+    // 0) in development/test.
+    rate: parseFloat(process.env.TAX_RATE || '0'),
+  },
 });

--- a/src/config/env.validation.spec.ts
+++ b/src/config/env.validation.spec.ts
@@ -1,0 +1,94 @@
+// class-transformer's @Transform (used internally by validateEnv for
+// TAX_RATE) relies on the reflect-metadata polyfill, which the real app
+// gets for free via @nestjs/core's own import side-effect at bootstrap.
+// This spec exercises validateEnv() in isolation, so it must be loaded
+// explicitly here.
+import 'reflect-metadata';
+import { validateEnv } from './env.validation';
+
+// Minimal set of required env vars so we can isolate TAX_RATE behavior
+// without unrelated required-field errors polluting the test.
+function baseEnv(overrides: Record<string, string> = {}) {
+  return {
+    DATABASE_URL: 'postgresql://user:pass@localhost:5432/db',
+    JWT_SECRET: 'secret',
+    JWT_REFRESH_SECRET: 'refresh-secret',
+    ...overrides,
+  };
+}
+
+describe('validateEnv — TAX_RATE', () => {
+  it('does not throw when TAX_RATE is missing and NODE_ENV is development', () => {
+    expect(() =>
+      validateEnv(baseEnv({ NODE_ENV: 'development' })),
+    ).not.toThrow();
+  });
+
+  it('does not throw when TAX_RATE is missing and NODE_ENV is unset (defaults to dev-like)', () => {
+    expect(() => validateEnv(baseEnv())).not.toThrow();
+  });
+
+  it('does not throw when TAX_RATE is missing and NODE_ENV is test', () => {
+    expect(() => validateEnv(baseEnv({ NODE_ENV: 'test' }))).not.toThrow();
+  });
+
+  it('throws when TAX_RATE is missing and NODE_ENV is production', () => {
+    expect(() => validateEnv(baseEnv({ NODE_ENV: 'production' }))).toThrow(
+      /TAX_RATE is required when NODE_ENV=production/,
+    );
+  });
+
+  it('does not throw when TAX_RATE is set and NODE_ENV is production', () => {
+    expect(() =>
+      validateEnv(baseEnv({ NODE_ENV: 'production', TAX_RATE: '0.18' })),
+    ).not.toThrow();
+  });
+
+  it('accepts the Peru IGV rate (0.18) in production', () => {
+    expect(() =>
+      validateEnv(baseEnv({ NODE_ENV: 'production', TAX_RATE: '0.18' })),
+    ).not.toThrow();
+  });
+
+  it('accepts the Spain IVA general rate (0.21) in production', () => {
+    expect(() =>
+      validateEnv(baseEnv({ NODE_ENV: 'production', TAX_RATE: '0.21' })),
+    ).not.toThrow();
+  });
+
+  it('accepts boundary value 0', () => {
+    expect(() =>
+      validateEnv(baseEnv({ NODE_ENV: 'production', TAX_RATE: '0' })),
+    ).not.toThrow();
+  });
+
+  it('accepts boundary value 1', () => {
+    expect(() =>
+      validateEnv(baseEnv({ NODE_ENV: 'production', TAX_RATE: '1' })),
+    ).not.toThrow();
+  });
+
+  it('throws when TAX_RATE is above 1 (out of range), even outside production', () => {
+    expect(() =>
+      validateEnv(baseEnv({ NODE_ENV: 'development', TAX_RATE: '1.5' })),
+    ).toThrow(/TAX_RATE must be between 0 and 1/);
+  });
+
+  it('throws when TAX_RATE is negative (out of range), even outside production', () => {
+    expect(() =>
+      validateEnv(baseEnv({ NODE_ENV: 'development', TAX_RATE: '-0.1' })),
+    ).toThrow(/TAX_RATE must be between 0 and 1/);
+  });
+
+  it('throws when TAX_RATE is not a valid number', () => {
+    expect(() =>
+      validateEnv(baseEnv({ NODE_ENV: 'development', TAX_RATE: 'abc' })),
+    ).toThrow(/TAX_RATE must be a valid number/);
+  });
+
+  it('throws when TAX_RATE is out of range in production too', () => {
+    expect(() =>
+      validateEnv(baseEnv({ NODE_ENV: 'production', TAX_RATE: '2' })),
+    ).toThrow(/TAX_RATE must be between 0 and 1/);
+  });
+});

--- a/src/config/env.validation.ts
+++ b/src/config/env.validation.ts
@@ -1,11 +1,15 @@
 import {
   IsNotEmpty,
+  IsNumber,
   IsNumberString,
   IsOptional,
   IsString,
+  Max,
+  Min,
+  ValidateIf,
   validateSync,
 } from 'class-validator';
-import { plainToInstance } from 'class-transformer';
+import { plainToInstance, Transform } from 'class-transformer';
 
 class EnvironmentVariables {
   @IsOptional()
@@ -39,6 +43,27 @@ class EnvironmentVariables {
   @IsOptional()
   @IsString()
   STRIPE_BILLING_WEBHOOK_SECRET?: string;
+
+  // Decimal tax rate (e.g. "0.18" = 18%). REQUIRED when NODE_ENV=production;
+  // optional (defaults to 0) in development/test. Whenever provided, must
+  // be a valid number between 0 and 1 inclusive, regardless of environment.
+  // NOTE: intentionally does NOT combine @IsOptional() with @ValidateIf() —
+  // that combination was a confirmed bug (see #29): @IsOptional() causes
+  // validation to be skipped entirely whenever the value is undefined,
+  // which would make @ValidateIf's condition irrelevant.
+  @ValidateIf(
+    (o) =>
+      o.NODE_ENV === 'production' ||
+      (o.TAX_RATE !== undefined && o.TAX_RATE !== ''),
+  )
+  @Transform(({ value }) =>
+    value === undefined || value === '' ? value : parseFloat(value),
+  )
+  @IsNotEmpty({ message: 'TAX_RATE is required when NODE_ENV=production' })
+  @IsNumber({}, { message: 'TAX_RATE must be a valid number' })
+  @Min(0, { message: 'TAX_RATE must be between 0 and 1' })
+  @Max(1, { message: 'TAX_RATE must be between 0 and 1' })
+  TAX_RATE?: string;
 }
 
 export function validateEnv(config: Record<string, unknown>) {

--- a/src/orders/orders.service.spec.ts
+++ b/src/orders/orders.service.spec.ts
@@ -1,4 +1,5 @@
 import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { OrderStatus, OrderType } from '@prisma/client';
 import { OrdersService } from './orders.service';
 import { PrismaService } from '../prisma/prisma.service';
@@ -52,10 +53,30 @@ function createMockAuditService(): MockAuditService {
   };
 }
 
+type MockConfigService = {
+  get: jest.Mock;
+};
+
+// Defaults tax.rate to 0 so pre-existing tests (written before #7 added
+// configurable tax) keep asserting the same totals. Individual tests can
+// override via `config.get.mockImplementation(...)` to exercise non-zero
+// tax rates.
+function createMockConfigService(): MockConfigService {
+  return {
+    get: jest.fn((key: string) => {
+      if (key === 'tax.rate') {
+        return 0;
+      }
+      return undefined;
+    }),
+  };
+}
+
 describe('OrdersService', () => {
   let service: OrdersService;
   let prisma: MockPrisma;
   let auditService: MockAuditService;
+  let config: MockConfigService;
 
   const orderId = 'order-1';
   const menuItemId = 'menu-item-1';
@@ -76,9 +97,11 @@ describe('OrdersService', () => {
   beforeEach(() => {
     prisma = createMockPrisma();
     auditService = createMockAuditService();
+    config = createMockConfigService();
     service = new OrdersService(
       prisma as unknown as PrismaService,
       auditService as unknown as AuditService,
+      config as unknown as ConfigService,
     );
   });
 
@@ -344,6 +367,61 @@ describe('OrdersService', () => {
       expect(result.subtotalCents).toBe(0);
       expect(result.taxCents).toBe(0);
       expect(result.totalCents).toBe(0);
+    });
+
+    it('computes a non-zero taxCents when config("tax.rate") returns a non-zero rate', async () => {
+      config.get.mockImplementation((key: string) =>
+        key === 'tax.rate' ? 0.18 : undefined,
+      );
+      prisma.orderItem.findMany.mockResolvedValue([
+        { priceCents: 1000, quantity: 1 },
+      ]);
+      prisma.order.update.mockImplementation(({ data }) =>
+        Promise.resolve({ ...baseOrder, ...data }),
+      );
+
+      const result = await (service as any).recalculateTotals(orderId);
+
+      expect(config.get).toHaveBeenCalledWith('tax.rate');
+      // 1000 * 0.18 = 180
+      expect(result.taxCents).toBe(180);
+      expect(result.subtotalCents).toBe(1000);
+      expect(result.totalCents).toBe(1180);
+    });
+
+    it('still produces taxCents = 0 when config("tax.rate") returns 0 (default/dev behavior)', async () => {
+      config.get.mockImplementation((key: string) =>
+        key === 'tax.rate' ? 0 : undefined,
+      );
+      prisma.orderItem.findMany.mockResolvedValue([
+        { priceCents: 1000, quantity: 1 },
+      ]);
+      prisma.order.update.mockImplementation(({ data }) =>
+        Promise.resolve({ ...baseOrder, ...data }),
+      );
+
+      const result = await (service as any).recalculateTotals(orderId);
+
+      expect(result.taxCents).toBe(0);
+      expect(result.totalCents).toBe(1000);
+    });
+
+    it('subtotalCents + taxCents === totalCents when discountCents is 0', async () => {
+      config.get.mockImplementation((key: string) =>
+        key === 'tax.rate' ? 0.21 : undefined,
+      );
+      prisma.order.findUnique.mockResolvedValue({ discountCents: 0 });
+      prisma.orderItem.findMany.mockResolvedValue([
+        { priceCents: 1200, quantity: 2 },
+        { priceCents: 500, quantity: 1 },
+      ]);
+      prisma.order.update.mockImplementation(({ data }) =>
+        Promise.resolve({ ...baseOrder, ...data }),
+      );
+
+      const result = await (service as any).recalculateTotals(orderId);
+
+      expect(result.subtotalCents + result.taxCents).toBe(result.totalCents);
     });
   });
 });

--- a/src/orders/orders.service.ts
+++ b/src/orders/orders.service.ts
@@ -4,6 +4,7 @@ import {
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { DiscountType, OrderStatus, Prisma, Role } from '@prisma/client';
 import { randomBytes } from 'crypto';
 import { PrismaService } from '../prisma/prisma.service';
@@ -28,11 +29,10 @@ const orderInclude = { items: true } satisfies Prisma.OrderInclude;
 
 @Injectable()
 export class OrdersService {
-  private readonly TAX_RATE = 0;
-
   constructor(
     private readonly prisma: PrismaService,
     private readonly auditService: AuditService,
+    private readonly config: ConfigService,
   ) {}
 
   async create(dto: CreateOrderDto, customerId?: string) {
@@ -293,7 +293,8 @@ export class OrdersService {
       (sum, item) => sum + item.priceCents * item.quantity,
       0,
     );
-    const taxCents = Math.round(subtotalCents * this.TAX_RATE);
+    const taxRate = this.config.get<number>('tax.rate') ?? 0;
+    const taxCents = Math.round(subtotalCents * taxRate);
     const totalCents = Math.max(
       0,
       subtotalCents + taxCents - (order?.discountCents ?? 0),

--- a/test/tax.e2e-spec.ts
+++ b/test/tax.e2e-spec.ts
@@ -1,0 +1,88 @@
+import { ValidationPipe, INestApplication } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Test } from '@nestjs/testing';
+import request from 'supertest';
+import { AppModule } from '../src/app.module';
+
+// Verifies OrdersService's recalculateTotals() picks up a configured,
+// non-zero tax rate end-to-end (#7). Uses its own isolated Nest
+// application instance with ConfigService.get('tax.rate') stubbed to a
+// non-zero rate, rather than mutating process.env.TAX_RATE globally —
+// this avoids leaking a non-zero tax rate into the main app.e2e-spec.ts
+// suite's assumptions (which rely on the default TAX_RATE=0 behavior).
+describe('Configurable tax strategy (e2e)', () => {
+  let app: INestApplication;
+  const TAX_RATE = 0.18; // Peru IGV
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication({ rawBody: true });
+    app.setGlobalPrefix('api', { exclude: ['health'] });
+    app.useGlobalPipes(
+      new ValidationPipe({ whitelist: true, transform: true }),
+    );
+
+    const configService = app.get(ConfigService);
+    const originalGet = configService.get.bind(configService);
+    jest.spyOn(configService, 'get').mockImplementation((key: string) => {
+      if (key === 'tax.rate') {
+        return TAX_RATE;
+      }
+      return originalGet(key);
+    });
+
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('creates an order that reflects the configured non-zero tax rate', async () => {
+    const adminLogin = await request(app.getHttpServer())
+      .post('/api/auth/login')
+      .send({ email: 'admin@restosync.local', password: 'Admin123!' })
+      .expect(200);
+    const adminToken = adminLogin.body.accessToken;
+
+    const category = await request(app.getHttpServer())
+      .post('/api/menu/categories')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ name: `Tax_${Date.now()}` })
+      .expect(201);
+
+    const item = await request(app.getHttpServer())
+      .post('/api/menu/items')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({
+        name: 'Taxable Burger',
+        priceCents: 1000,
+        categoryId: category.body.id,
+      })
+      .expect(201);
+
+    const order = await request(app.getHttpServer())
+      .post('/api/orders')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({
+        type: 'DINE_IN',
+        table: 'TX1',
+        items: [{ menuItemId: item.body.id, quantity: 2 }],
+      })
+      .expect(201);
+
+    // subtotal = 1000 * 2 = 2000; tax = round(2000 * 0.18) = 360
+    expect(order.body.subtotalCents).toBe(2000);
+    expect(order.body.taxCents).toBe(360);
+    expect(order.body.taxCents).toBeGreaterThan(0);
+    // No discount applied: subtotal + tax === total.
+    expect(order.body.discountCents).toBe(0);
+    expect(order.body.totalCents).toBe(
+      order.body.subtotalCents + order.body.taxCents,
+    );
+    expect(order.body.totalCents).toBe(2360);
+  });
+});


### PR DESCRIPTION
Closes #7 

## Changes
- Replace hardcoded TAX_RATE=0 constant with ConfigService-driven tax.rate
- TAX_RATE env var: decimal 0-1, required in production (app fails to
  boot without it), optional in dev/test (defaults to 0)
- Range validated 0-1 in all environments
- .env.example documents Peru (0.18) and Spain (0.21) reference values
- totalCents formula unchanged (subtotal + tax - discount, clamped at 0)

## Tests
- Unit: recalculateTotals() with non-zero and zero tax rates
- Unit: 13 env validation tests (dev optional, prod required, range
  boundaries, Peru/Spain values)
- e2e: isolated app instance confirms non-zero tax flows through to
  totalCents correctly, without affecting existing zero-tax e2e assumptions
- Manually verified: NODE_ENV=production boot fails without TAX_RATE,
  succeeds with TAX_RATE=0.18

Out of scope (per issue): tax-inclusive/exclusive pricing, per-category
tax rates — tracked as follow-up.