### PR TITLE
chore(#61): add issue/PR templates and per-module coverage gates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,58 @@
+name: Bug Report
+description: Report a bug or unexpected behavior
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of the bug
+      placeholder: "When I do X, Y happens instead of Z..."
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Step-by-step instructions to reproduce the bug
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. Observe the error
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What you expected to happen
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What actually happened
+    validations:
+      required: true
+  - type: dropdown
+    id: environment
+    attributes:
+      label: Environment
+      options:
+        - dev
+        - staging
+        - prod
+    validations:
+      required: true
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - critical (system down)
+        - high (feature broken)
+        - medium (workaround exists)
+        - low (cosmetic)
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/tech_task.yml
+++ b/.github/ISSUE_TEMPLATE/tech_task.yml
@@ -1,0 +1,29 @@
+name: Tech Task
+description: Technical improvement, refactor, or process change
+labels: ["tech-task"]
+body:
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: What problem does this solve and why does it matter?
+    validations:
+      required: true
+  - type: textarea
+    id: tasks
+    attributes:
+      label: Tasks
+      description: Concrete, actionable steps to complete this task
+      placeholder: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: How do we know this is done?
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+## Changes
+
+## Tests
+
+## Closes #
+
+- [ ] Tests pass locally (`npm test && npm run test:e2e`)
+- [ ] Migration committed if schema changed (`git status prisma/migrations/` checked — no uncommitted migration files)
+- [ ] No secrets or `.env` values in the diff

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,5 +46,5 @@ jobs:
       - run: npx prisma db seed
       - run: npm run lint
       - run: npm run build
-      - run: npm test
+      - run: npm run test:cov
       - run: npm run test:e2e

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "restosync-api",
   "version": "0.1.0",
-  "description": "NestJS REST API for restaurant management — menu, orders, payments",
+  "description": "NestJS REST API for restaurant management \u2014 menu, orders, payments",
   "author": "Carlos Sandoval Montoya",
   "private": true,
   "license": "UNLICENSED",
@@ -72,14 +72,49 @@
     "typescript": "^5.6.2"
   },
   "jest": {
-    "moduleFileExtensions": ["js", "json", "ts"],
+    "moduleFileExtensions": [
+      "js",
+      "json",
+      "ts"
+    ],
     "rootDir": "src",
     "testRegex": ".*\\.spec\\.ts$",
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"
     },
-    "collectCoverageFrom": ["**/*.(t|j)s"],
+    "collectCoverageFrom": [
+      "**/*.(t|j)s"
+    ],
     "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "coverageThreshold": {
+      "global": {
+        "lines": 0
+      },
+      "src/orders/": {
+        "lines": 31
+      },
+      "src/payments/": {
+        "lines": 24
+      },
+      "src/billing/": {
+        "lines": 73
+      },
+      "src/audit/": {
+        "lines": 66
+      },
+      "src/auth/": {
+        "lines": 0
+      },
+      "src/inventory/": {
+        "lines": 28
+      },
+      "src/reports/": {
+        "lines": 42
+      },
+      "src/cash-register/": {
+        "lines": 46
+      }
+    }
   }
 }


### PR DESCRIPTION
Closes #61 

## Changes
- Add .github/ISSUE_TEMPLATE/ (bug_report.yml, tech_task.yml, config.yml
  with blank issues disabled)
- Add .github/PULL_REQUEST_TEMPLATE.md with checklist (tests pass,
  migration committed, no secrets in diff)
- Add per-module coverage thresholds to jest config in package.json,
  set at current real baselines (not aspirational targets) so CI
  doesn't break on merge:
  orders 31%, payments 24%, billing 73%, audit 66%, auth 0%,
  inventory 28%, reports 42%, cash-register 46%
- CI now runs `npm run test:cov` instead of `npm test`, enforcing
  these thresholds on every push/PR to main

## Notes
- auth module currently has 0% test coverage — flagged as a candidate
  for a future dedicated testing issue, not addressed here
- Thresholds are baselines to prevent regression; raise them as tests
  are added to each module