### PR TITLE
feat(#51): auto-decrement stock on sale Add SALE-type stock adjustmen…

### DIFF
--- a/src/inventory/inventory.module.ts
+++ b/src/inventory/inventory.module.ts
@@ -5,5 +5,6 @@ import { InventoryService } from './inventory.service';
 @Module({
   controllers: [InventoryController],
   providers: [InventoryService],
+  exports: [InventoryService],
 })
 export class InventoryModule {}

--- a/src/inventory/inventory.service.spec.ts
+++ b/src/inventory/inventory.service.spec.ts
@@ -187,6 +187,34 @@ describe('InventoryService', () => {
       });
     });
 
+    it('clamps quantityOnHand at 0 for a SALE adjustment exceeding stock', async () => {
+      prisma.inventoryItem.findUnique.mockResolvedValue({
+        id: itemId,
+        quantityOnHand: 3,
+      });
+
+      await service.adjust(
+        itemId,
+        { type: AdjustmentType.SALE, quantityDelta: -5 },
+        actorId,
+      );
+
+      expect(txInventoryItemUpdate).toHaveBeenCalledWith({
+        where: { id: itemId },
+        data: { quantityOnHand: 0 },
+        include: { adjustments: true, menuItem: true },
+      });
+      expect(txStockAdjustmentCreate).toHaveBeenCalledWith({
+        data: {
+          inventoryItemId: itemId,
+          type: AdjustmentType.SALE,
+          quantityDelta: -5,
+          reason: null,
+          performedById: actorId,
+        },
+      });
+    });
+
     it('creates a StockAdjustment record with type, delta, reason and actor', async () => {
       prisma.inventoryItem.findUnique.mockResolvedValue({
         id: itemId,

--- a/src/payments/payments.module.ts
+++ b/src/payments/payments.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { InventoryModule } from '../inventory/inventory.module';
 import { OrdersModule } from '../orders/orders.module';
 import { PAYMENT_GATEWAY } from './gateway/payment-gateway.interface';
 import { StripeGateway } from './gateway/stripe.gateway';
@@ -6,7 +7,7 @@ import { PaymentsController } from './payments.controller';
 import { PaymentsService } from './payments.service';
 
 @Module({
-  imports: [OrdersModule],
+  imports: [OrdersModule, InventoryModule],
   controllers: [PaymentsController],
   providers: [
     PaymentsService,

--- a/src/payments/payments.service.spec.ts
+++ b/src/payments/payments.service.spec.ts
@@ -1,5 +1,6 @@
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { OrderStatus, PaymentMethod, PaymentStatus } from '@prisma/client';
+import { InventoryService } from '../inventory/inventory.service';
 import { OrdersService } from '../orders/orders.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { PaymentGateway } from './gateway/payment-gateway.interface';
@@ -13,6 +14,9 @@ type MockPrisma = {
     findFirst: jest.Mock;
   };
   payment: {
+    findFirst: jest.Mock;
+  };
+  inventoryItem: {
     findFirst: jest.Mock;
   };
   $transaction: jest.Mock;
@@ -29,6 +33,9 @@ function createMockPrisma(): MockPrisma {
     payment: {
       findFirst: jest.fn(),
     },
+    inventoryItem: {
+      findFirst: jest.fn(),
+    },
     $transaction: jest.fn(),
   };
 }
@@ -36,6 +43,7 @@ function createMockPrisma(): MockPrisma {
 describe('PaymentsService', () => {
   let service: PaymentsService;
   let prisma: MockPrisma;
+  let inventoryService: { adjust: jest.Mock };
   let txOrderUpdate: jest.Mock;
   let txPaymentCreate: jest.Mock;
 
@@ -45,9 +53,18 @@ describe('PaymentsService', () => {
 
   const baseOrder = {
     id: orderId,
+    number: 'ORD-001',
     status: OrderStatus.PENDING,
     totalCents: 1200,
     currency: 'usd',
+    items: [
+      {
+        id: 'item-1',
+        orderId,
+        menuItemId: 'menu-item-1',
+        quantity: 2,
+      },
+    ],
   };
 
   const activeSession = {
@@ -67,9 +84,12 @@ describe('PaymentsService', () => {
       }),
     );
 
+    inventoryService = { adjust: jest.fn().mockResolvedValue({}) };
+
     service = new PaymentsService(
       prisma as unknown as PrismaService,
       {} as unknown as OrdersService,
+      inventoryService as unknown as InventoryService,
       {} as unknown as PaymentGateway,
     );
   });
@@ -225,6 +245,71 @@ describe('PaymentsService', () => {
           }),
         }),
       );
+    });
+
+    describe('inventory decrement hook (#51)', () => {
+      it('decrements linked inventory by the correct quantity', async () => {
+        prisma.order.findUnique.mockResolvedValue(baseOrder);
+        prisma.cashRegisterSession.findFirst.mockResolvedValue(activeSession);
+        prisma.payment.findFirst.mockResolvedValue(null);
+        prisma.inventoryItem.findFirst.mockResolvedValue({
+          id: 'inv-item-1',
+          menuItemId: 'menu-item-1',
+        });
+
+        await service.checkout(
+          { orderId, method: PaymentMethod.CASH, amountPaidCents: 1200 },
+          actorId,
+        );
+
+        expect(prisma.inventoryItem.findFirst).toHaveBeenCalledWith({
+          where: { menuItemId: 'menu-item-1' },
+        });
+        expect(inventoryService.adjust).toHaveBeenCalledWith(
+          'inv-item-1',
+          {
+            type: 'SALE',
+            quantityDelta: -2,
+            reason: `Sale from order ${baseOrder.number}`,
+          },
+          actorId,
+        );
+      });
+
+      it('does not fail when an OrderItem has no linked InventoryItem', async () => {
+        prisma.order.findUnique.mockResolvedValue(baseOrder);
+        prisma.cashRegisterSession.findFirst.mockResolvedValue(activeSession);
+        prisma.payment.findFirst.mockResolvedValue(null);
+        prisma.inventoryItem.findFirst.mockResolvedValue(null);
+
+        await expect(
+          service.checkout(
+            { orderId, method: PaymentMethod.CASH, amountPaidCents: 1200 },
+            actorId,
+          ),
+        ).resolves.toBeDefined();
+
+        expect(inventoryService.adjust).not.toHaveBeenCalled();
+      });
+
+      it('does not fail even if the inventory decrement throws internally', async () => {
+        prisma.order.findUnique.mockResolvedValue(baseOrder);
+        prisma.cashRegisterSession.findFirst.mockResolvedValue(activeSession);
+        prisma.payment.findFirst.mockResolvedValue(null);
+        prisma.inventoryItem.findFirst.mockResolvedValue({
+          id: 'inv-item-1',
+          menuItemId: 'menu-item-1',
+        });
+        inventoryService.adjust.mockRejectedValue(new Error('boom'));
+
+        const result = await service.checkout(
+          { orderId, method: PaymentMethod.CASH, amountPaidCents: 1200 },
+          actorId,
+        );
+
+        expect(result).toEqual({ id: 'payment-1' });
+        expect(inventoryService.adjust).toHaveBeenCalled();
+      });
     });
   });
 });

--- a/src/payments/payments.service.ts
+++ b/src/payments/payments.service.ts
@@ -11,6 +11,7 @@ import {
   PaymentStatus,
   Prisma,
 } from '@prisma/client';
+import { InventoryService } from '../inventory/inventory.service';
 import { canTransition } from '../orders/order-status';
 import { OrdersService } from '../orders/orders.service';
 import { PrismaService } from '../prisma/prisma.service';
@@ -21,6 +22,8 @@ import {
   PaymentGateway,
 } from './gateway/payment-gateway.interface';
 
+type OrderWithItems = Prisma.OrderGetPayload<{ include: { items: true } }>;
+
 @Injectable()
 export class PaymentsService {
   private readonly logger = new Logger(PaymentsService.name);
@@ -28,6 +31,7 @@ export class PaymentsService {
   constructor(
     private readonly prisma: PrismaService,
     private readonly orders: OrdersService,
+    private readonly inventoryService: InventoryService,
     @Inject(PAYMENT_GATEWAY) private readonly gateway: PaymentGateway,
   ) {}
 
@@ -78,6 +82,7 @@ export class PaymentsService {
   async checkout(dto: CheckoutDto, actorId: string) {
     const order = await this.prisma.order.findUnique({
       where: { id: dto.orderId },
+      include: { items: true },
     });
     if (!order) {
       throw new NotFoundException('Order not found');
@@ -115,7 +120,7 @@ export class PaymentsService {
 
     this.logger.debug(`Checkout for order ${order.id} by user ${actorId}`);
 
-    return this.prisma.$transaction(async (tx) => {
+    const payment = await this.prisma.$transaction(async (tx) => {
       if (!canTransition(order.status, OrderStatus.CONFIRMED)) {
         throw new BadRequestException(
           `Cannot transition order from ${order.status} to ${OrderStatus.CONFIRMED}`,
@@ -142,6 +147,49 @@ export class PaymentsService {
         include: { order: true },
       });
     });
+
+    // Best-effort, non-blocking: the sale is already confirmed and paid,
+    // so an inventory hiccup must never fail or roll back the checkout.
+    await this.decrementInventoryForOrder(order, actorId);
+
+    return payment;
+  }
+
+  // Optional hook (#51): decrements stock for any OrderItem linked to an
+  // InventoryItem via menuItemId. Items without a linked InventoryItem are
+  // silently skipped — that's the normal case, not an error. Any failure
+  // here is logged and swallowed so it never surfaces to the caller; this
+  // is an intentional exception to the "no try/catch for Prisma errors"
+  // rule, isolating a non-critical side effect from the critical payment
+  // flow.
+  private async decrementInventoryForOrder(
+    order: OrderWithItems,
+    actorId: string,
+  ) {
+    for (const item of order.items) {
+      try {
+        const inventoryItem = await this.prisma.inventoryItem.findFirst({
+          where: { menuItemId: item.menuItemId },
+        });
+        if (!inventoryItem) {
+          continue;
+        }
+
+        await this.inventoryService.adjust(
+          inventoryItem.id,
+          {
+            type: 'SALE',
+            quantityDelta: -item.quantity,
+            reason: `Sale from order ${order.number}`,
+          },
+          actorId,
+        );
+      } catch (err) {
+        this.logger.warn(
+          `Failed to decrement inventory for menuItemId ${item.menuItemId} on order ${order.number}: ${err}`,
+        );
+      }
+    }
   }
 
   async handleWebhook(payload: Buffer, signature: string) {

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -831,6 +831,143 @@ describe('RestoSync API (e2e)', () => {
     });
   });
 
+  describe('auto-decrement stock on sale (#51)', () => {
+    const INITIAL_STOCK = 10;
+    const ORDER_QTY = 3;
+    const ITEM_PRICE_CENTS = 900;
+
+    let adminToken: string;
+    let managerToken: string;
+    let cashierToken: string;
+    let menuItemId: string;
+    let inventoryItemId: string;
+    let orderId: string;
+
+    beforeAll(async () => {
+      const adminLogin = await request(app.getHttpServer())
+        .post('/api/auth/login')
+        .send({ email: 'admin@restosync.local', password: 'Admin123!' })
+        .expect(200);
+      adminToken = adminLogin.body.accessToken;
+
+      const managerLogin = await request(app.getHttpServer())
+        .post('/api/auth/login')
+        .send({ email: 'manager@restosync.local', password: 'Manager123!' })
+        .expect(200);
+      managerToken = managerLogin.body.accessToken;
+
+      const cashierLogin = await request(app.getHttpServer())
+        .post('/api/auth/login')
+        .send({ email: 'cashier@restosync.local', password: 'Cashier123!' })
+        .expect(200);
+      cashierToken = cashierLogin.body.accessToken;
+
+      const category = await request(app.getHttpServer())
+        .post('/api/menu/categories')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ name: `AutoDecrement_${Date.now()}` })
+        .expect(201);
+
+      const menuItem = await request(app.getHttpServer())
+        .post('/api/menu/items')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({
+          name: `Tracked Item ${Date.now()}`,
+          priceCents: ITEM_PRICE_CENTS,
+          categoryId: category.body.id,
+        })
+        .expect(201);
+      menuItemId = menuItem.body.id;
+
+      const inventoryItem = await request(app.getHttpServer())
+        .post('/api/inventory')
+        .set('Authorization', `Bearer ${managerToken}`)
+        .send({
+          name: `Tracked Stock ${Date.now()}`,
+          unit: 'unit',
+          quantityOnHand: INITIAL_STOCK,
+          lowStockThreshold: 1,
+          menuItemId,
+        })
+        .expect(201);
+      inventoryItemId = inventoryItem.body.id;
+
+      // Clean up any register session left open by a previous test run.
+      await request(app.getHttpServer())
+        .post('/api/cash-register/close')
+        .set('Authorization', `Bearer ${cashierToken}`)
+        .send({ countedCents: 0 });
+
+      await request(app.getHttpServer())
+        .post('/api/cash-register/open')
+        .set('Authorization', `Bearer ${cashierToken}`)
+        .send({ openingFloatCents: 0 })
+        .expect(201);
+    });
+
+    it('creates and confirms an order for a menu item with linked inventory', async () => {
+      const order = await request(app.getHttpServer())
+        .post('/api/orders')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({
+          type: 'DINE_IN',
+          table: 'INV1',
+          items: [{ menuItemId, quantity: ORDER_QTY }],
+        })
+        .expect(201);
+      orderId = order.body.id;
+
+      const confirmed = await request(app.getHttpServer())
+        .post(`/api/orders/${orderId}/confirm`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .expect(201);
+      expect(confirmed.body.status).toBe('PENDING');
+    });
+
+    it('POST /api/payments/checkout decrements the linked inventory item', async () => {
+      await request(app.getHttpServer())
+        .post('/api/payments/checkout')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({
+          orderId,
+          method: 'CASH',
+          amountPaidCents: ITEM_PRICE_CENTS * ORDER_QTY,
+        })
+        .expect(201);
+
+      const item = await request(app.getHttpServer())
+        .get(`/api/inventory/${inventoryItemId}`)
+        .set('Authorization', `Bearer ${managerToken}`)
+        .expect(200);
+
+      expect(item.body.quantityOnHand).toBe(INITIAL_STOCK - ORDER_QTY);
+
+      const saleAdjustment = item.body.adjustments.find(
+        (a: { type: string }) => a.type === 'SALE',
+      );
+      expect(saleAdjustment).toBeDefined();
+      expect(saleAdjustment.quantityDelta).toBe(-ORDER_QTY);
+      expect(saleAdjustment.reason).toMatch(/^Sale from order /);
+    });
+
+    afterAll(async () => {
+      await request(app.getHttpServer())
+        .post('/api/cash-register/close')
+        .set('Authorization', `Bearer ${cashierToken}`)
+        .send({ countedCents: ITEM_PRICE_CENTS * ORDER_QTY });
+
+      // Cleanup: delete the InventoryItem created for this suite so it
+      // never leaks into later tests/runs sharing this DB — in
+      // particular the "returns an empty array when no items qualify"
+      // low-stock assertion elsewhere in this file.
+      if (inventoryItemId) {
+        await request(app.getHttpServer())
+          .delete(`/api/inventory/${inventoryItemId}`)
+          .set('Authorization', `Bearer ${managerToken}`);
+      }
+    });
+  });
+
   describe('order discount audit trail', () => {
     let adminToken: string;
     let managerToken: string;


### PR DESCRIPTION
Closes #51 

## Changes
- Add SALE type to AdjustmentType enum (already present in schema,
  confirmed no migration needed)
- Export InventoryService from InventoryModule
- Import InventoryModule into PaymentsModule
- PaymentsService.checkout() now calls decrementInventoryForOrder()
  after successful payment, decrementing linked inventory per order item

## Design notes
- Hook fires after payment SUCCEEDED (real "sale confirmed" moment),
  not on order creation or order confirm
- Best-effort / non-blocking: inventory failures are caught and logged,
  never block or roll back a successful payment
- No linked InventoryItem = silent skip, not an error
- Reuses InventoryService.adjust() — no duplicated clamp-at-0 logic

## Tests
- Unit: correct decrement quantity, silent skip, checkout survives
  inventory adjust throwing
- e2e: full flow (order → checkout → verify decremented stock + SALE
  adjustment record), with proper cleanup in afterAll