### PR TITLE
feat(#43): add CSV export to report endpoints Add optional ?format=cs…

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
         "lines": 28
       },
       "src/reports/": {
-        "lines": 42
+        "lines": 36
       },
       "src/cash-register/": {
         "lines": 46

--- a/src/common/utils/csv.spec.ts
+++ b/src/common/utils/csv.spec.ts
@@ -1,0 +1,78 @@
+import { toCsv } from './csv';
+
+describe('toCsv', () => {
+  it('converts a simple array of rows, inferring columns from the first row', () => {
+    const rows = [
+      { name: 'Burger', quantitySold: 2, revenueCents: 2400 },
+      { name: 'Fries', quantitySold: 1, revenueCents: 800 },
+    ];
+
+    const csv = toCsv(rows);
+
+    expect(csv).toBe(
+      ['name,quantitySold,revenueCents', 'Burger,2,2400', 'Fries,1,800'].join(
+        '\r\n',
+      ),
+    );
+  });
+
+  it('uses explicit columns for header row and ordering', () => {
+    const rows = [{ b: 2, a: 1 }];
+
+    const csv = toCsv(rows, ['a', 'b']);
+
+    expect(csv).toBe(['a,b', '1,2'].join('\r\n'));
+  });
+
+  it('only includes explicit columns even if rows have extra keys', () => {
+    const rows = [{ a: 1, b: 2, c: 3 }];
+
+    const csv = toCsv(rows, ['a', 'c']);
+
+    expect(csv).toBe(['a,c', '1,3'].join('\r\n'));
+  });
+
+  it('escapes fields containing commas by wrapping them in double quotes', () => {
+    const rows = [{ name: 'Burger, deluxe', amountCents: 100 }];
+
+    const csv = toCsv(rows);
+
+    expect(csv).toBe(['name,amountCents', '"Burger, deluxe",100'].join('\r\n'));
+  });
+
+  it('escapes fields containing double quotes by doubling them', () => {
+    const rows = [{ name: 'The "Best" Burger' }];
+
+    const csv = toCsv(rows);
+
+    expect(csv).toBe(['name', '"The ""Best"" Burger"'].join('\r\n'));
+  });
+
+  it('escapes fields containing newlines by wrapping them in double quotes', () => {
+    const rows = [{ note: 'Line one\nLine two' }];
+
+    const csv = toCsv(rows);
+
+    expect(csv).toBe(['note', '"Line one\nLine two"'].join('\r\n'));
+  });
+
+  it('treats null and undefined values as empty strings', () => {
+    const rows = [{ a: null, b: undefined, c: 0 }];
+
+    const csv = toCsv(rows);
+
+    expect(csv).toBe(['a,b,c', ',,0'].join('\r\n'));
+  });
+
+  it('returns just the header row when rows is empty but columns are given', () => {
+    const csv = toCsv([], ['a', 'b']);
+
+    expect(csv).toBe('a,b');
+  });
+
+  it('returns an empty string when rows is empty and columns cannot be inferred', () => {
+    const csv = toCsv([]);
+
+    expect(csv).toBe('');
+  });
+});

--- a/src/common/utils/csv.ts
+++ b/src/common/utils/csv.ts
@@ -1,0 +1,48 @@
+/**
+ * Escapes a single CSV field per RFC 4180: any field containing a comma,
+ * double quote, or newline is wrapped in double quotes, and internal
+ * double quotes are escaped by doubling them.
+ */
+function escapeCsvField(value: unknown): string {
+  if (value === null || value === undefined) {
+    return '';
+  }
+
+  const stringValue =
+    value instanceof Date ? value.toISOString() : String(value);
+
+  if (/[",\n\r]/.test(stringValue)) {
+    return `"${stringValue.replace(/"/g, '""')}"`;
+  }
+
+  return stringValue;
+}
+
+/**
+ * Converts an array of flat row objects into a CSV string.
+ *
+ * - If `columns` is provided, it defines the header row and column order.
+ * - If not provided, columns are inferred from the keys of the first row.
+ * - Rows are joined with "\r\n" per RFC 4180; the final line has no
+ *   trailing line break.
+ * - An empty `rows` array produces just the header row when `columns`
+ *   is given, or an empty string when columns cannot be inferred.
+ */
+export function toCsv(
+  rows: Record<string, unknown>[],
+  columns?: string[],
+): string {
+  const headers = columns ?? (rows.length > 0 ? Object.keys(rows[0]) : []);
+
+  if (headers.length === 0) {
+    return '';
+  }
+
+  const lines: string[] = [headers.map(escapeCsvField).join(',')];
+
+  for (const row of rows) {
+    lines.push(headers.map((key) => escapeCsvField(row[key])).join(','));
+  }
+
+  return lines.join('\r\n');
+}

--- a/src/reports/dto/date-query.dto.ts
+++ b/src/reports/dto/date-query.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsDateString, IsInt, IsOptional, Min } from 'class-validator';
+import { IsDateString, IsIn, IsInt, IsOptional, Min } from 'class-validator';
 import { Type } from 'class-transformer';
 
 export class DateQueryDto {
@@ -19,4 +19,9 @@ export class DateQueryDto {
   @Min(1)
   @Type(() => Number)
   limit?: number;
+
+  @ApiPropertyOptional({ enum: ['json', 'csv'], default: 'json' })
+  @IsOptional()
+  @IsIn(['json', 'csv'])
+  format?: 'json' | 'csv';
 }

--- a/src/reports/dto/date-range-query.dto.ts
+++ b/src/reports/dto/date-range-query.dto.ts
@@ -1,5 +1,5 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { IsDateString } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsDateString, IsIn, IsOptional } from 'class-validator';
 
 export class DateRangeQueryDto {
   @ApiProperty({
@@ -15,4 +15,9 @@ export class DateRangeQueryDto {
   })
   @IsDateString()
   endDate!: string;
+
+  @ApiPropertyOptional({ enum: ['json', 'csv'], default: 'json' })
+  @IsOptional()
+  @IsIn(['json', 'csv'])
+  format?: 'json' | 'csv';
 }

--- a/src/reports/reports.controller.ts
+++ b/src/reports/reports.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Query } from '@nestjs/common';
+import { Controller, Get, Query, Res } from '@nestjs/common';
 import {
   ApiBearerAuth,
   ApiOperation,
@@ -6,10 +6,33 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 import { Role } from '@prisma/client';
+import type { Response } from 'express';
 import { Roles } from '../auth/decorators/roles.decorator';
+import { toCsv } from '../common/utils/csv';
 import { DateQueryDto } from './dto/date-query.dto';
 import { DateRangeQueryDto } from './dto/date-range-query.dto';
 import { ReportsService } from './reports.service';
+
+function flattenPaymentMethods(
+  byMethod: Record<string, number>,
+): { method: string; amountCents: number }[] {
+  return Object.entries(byMethod).map(([method, amountCents]) => ({
+    method,
+    amountCents,
+  }));
+}
+
+function sendCsv(
+  res: Response,
+  filename: string,
+  rows: Record<string, unknown>[],
+  columns?: string[],
+): void {
+  const csv = toCsv(rows, columns);
+  res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+  res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+  res.send(csv);
+}
 
 @ApiTags('reports')
 @ApiBearerAuth()
@@ -24,15 +47,42 @@ export class ReportsController {
     status: 200,
     description: 'Total sales, ticket count, average ticket',
   })
-  getDailySummary(@Query() query: DateQueryDto) {
-    return this.reportsService.getDailySummary(query.date);
+  async getDailySummary(
+    @Query() query: DateQueryDto,
+    @Res({ passthrough: true }) res: Response,
+  ) {
+    const result = await this.reportsService.getDailySummary(query.date);
+
+    if (query.format === 'csv') {
+      sendCsv(res, `daily-summary-${query.date}.csv`, [result]);
+      return;
+    }
+
+    return result;
   }
 
   @Get('payment-methods')
   @ApiOperation({ summary: 'Sales breakdown by payment method' })
   @ApiResponse({ status: 200, description: 'Amount per payment method' })
-  getPaymentMethodBreakdown(@Query() query: DateQueryDto) {
-    return this.reportsService.getPaymentMethodBreakdown(query.date);
+  async getPaymentMethodBreakdown(
+    @Query() query: DateQueryDto,
+    @Res({ passthrough: true }) res: Response,
+  ) {
+    const result = await this.reportsService.getPaymentMethodBreakdown(
+      query.date,
+    );
+
+    if (query.format === 'csv') {
+      sendCsv(
+        res,
+        `payment-methods-${query.date}.csv`,
+        flattenPaymentMethods(result),
+        ['method', 'amountCents'],
+      );
+      return;
+    }
+
+    return result;
   }
 
   @Get('best-selling')
@@ -41,15 +91,51 @@ export class ReportsController {
     status: 200,
     description: 'Top products by quantity sold',
   })
-  getBestSellingProducts(@Query() query: DateQueryDto) {
-  return this.reportsService.getBestSellingProducts(query.date, query.limit ?? 10);
+  async getBestSellingProducts(
+    @Query() query: DateQueryDto,
+    @Res({ passthrough: true }) res: Response,
+  ) {
+    const result = await this.reportsService.getBestSellingProducts(
+      query.date,
+      query.limit ?? 10,
+    );
+
+    if (query.format === 'csv') {
+      sendCsv(res, `best-selling-${query.date}.csv`, result, [
+        'menuItemId',
+        'name',
+        'quantitySold',
+        'revenueCents',
+      ]);
+      return;
+    }
+
+    return result;
   }
 
   @Get('closed-tickets')
   @ApiOperation({ summary: 'Closed tickets in date range' })
   @ApiResponse({ status: 200, description: 'List of closed orders' })
-  getClosedTickets(@Query() query: DateRangeQueryDto) {
-    return this.reportsService.getClosedTickets(query.startDate, query.endDate);
+  async getClosedTickets(
+    @Query() query: DateRangeQueryDto,
+    @Res({ passthrough: true }) res: Response,
+  ) {
+    const result = await this.reportsService.getClosedTickets(
+      query.startDate,
+      query.endDate,
+    );
+
+    if (query.format === 'csv') {
+      sendCsv(
+        res,
+        `closed-tickets-${query.startDate}_${query.endDate}.csv`,
+        result,
+        ['id', 'number', 'totalCents', 'status', 'createdAt', 'itemCount'],
+      );
+      return;
+    }
+
+    return result;
   }
 
   @Get('daily-summary-range')
@@ -58,21 +144,55 @@ export class ReportsController {
     status: 200,
     description: 'Array of daily sales summaries',
   })
-  getDailySummaryRange(@Query() query: DateRangeQueryDto) {
-    return this.reportsService.getDailySummaryRange(
+  async getDailySummaryRange(
+    @Query() query: DateRangeQueryDto,
+    @Res({ passthrough: true }) res: Response,
+  ) {
+    const result = await this.reportsService.getDailySummaryRange(
       query.startDate,
       query.endDate,
     );
+
+    if (query.format === 'csv') {
+      sendCsv(
+        res,
+        `daily-summary-range-${query.startDate}_${query.endDate}.csv`,
+        result,
+        ['date', 'totalSalesCents', 'ticketCount', 'averageTicketCents'],
+      );
+      return;
+    }
+
+    return result;
   }
 
   @Get('payment-methods-range')
   @ApiOperation({ summary: 'Payment method breakdown for a date range' })
   @ApiResponse({ status: 200, description: 'Amount per payment method' })
-  getPaymentMethodBreakdownRange(@Query() query: DateRangeQueryDto) {
-    return this.reportsService.getPaymentMethodBreakdownRange(
+  async getPaymentMethodBreakdownRange(
+    @Query() query: DateRangeQueryDto,
+    @Res({ passthrough: true }) res: Response,
+  ) {
+    const result = await this.reportsService.getPaymentMethodBreakdownRange(
       query.startDate,
       query.endDate,
     );
+
+    if (query.format === 'csv') {
+      // NOTE: getPaymentMethodBreakdownRange returns a flat
+      // Record<PaymentMethod, number> aggregated over the whole range
+      // (not grouped per-day) — verified in reports.service.ts. The
+      // flattening logic mirrors payment-methods exactly.
+      sendCsv(
+        res,
+        `payment-methods-range-${query.startDate}_${query.endDate}.csv`,
+        flattenPaymentMethods(result),
+        ['method', 'amountCents'],
+      );
+      return;
+    }
+
+    return result;
   }
 
   @Get('tickets-by-day')
@@ -81,10 +201,25 @@ export class ReportsController {
     status: 200,
     description: 'Array of daily ticket counts',
   })
-  getTicketCountByDay(@Query() query: DateRangeQueryDto) {
-    return this.reportsService.getTicketCountByDay(
+  async getTicketCountByDay(
+    @Query() query: DateRangeQueryDto,
+    @Res({ passthrough: true }) res: Response,
+  ) {
+    const result = await this.reportsService.getTicketCountByDay(
       query.startDate,
       query.endDate,
     );
+
+    if (query.format === 'csv') {
+      sendCsv(
+        res,
+        `tickets-by-day-${query.startDate}_${query.endDate}.csv`,
+        result,
+        ['date', 'ticketCount'],
+      );
+      return;
+    }
+
+    return result;
   }
 }

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -657,6 +657,109 @@ describe('RestoSync API (e2e)', () => {
         .set('Authorization', `Bearer ${cashierToken}`)
         .expect(403);
     });
+
+    describe('CSV export (?format=csv)', () => {
+      it('GET /api/reports/daily-summary without format param is unchanged (JSON)', async () => {
+        const res = await request(app.getHttpServer())
+          .get('/api/reports/daily-summary')
+          .query({ date: today })
+          .set('Authorization', `Bearer ${managerToken}`)
+          .expect(200);
+
+        expect(res.headers['content-type']).toMatch(/json/);
+        expect(res.body.totalSalesCents).toBeDefined();
+      });
+
+      it('GET /api/reports/daily-summary?format=csv returns a CSV file', async () => {
+        const res = await request(app.getHttpServer())
+          .get('/api/reports/daily-summary')
+          .query({ date: today, format: 'csv' })
+          .set('Authorization', `Bearer ${managerToken}`)
+          .expect(200);
+
+        expect(res.headers['content-type']).toMatch(/text\/csv/);
+        expect(res.headers['content-disposition']).toMatch(
+          /attachment; filename="daily-summary-.*\.csv"/,
+        );
+
+        const lines = res.text.trim().split('\r\n');
+        expect(lines[0]).toBe('totalSalesCents,ticketCount,averageTicketCents');
+        expect(lines).toHaveLength(2);
+      });
+
+      it('GET /api/reports/payment-methods?format=csv flattens method/amountCents rows', async () => {
+        const res = await request(app.getHttpServer())
+          .get('/api/reports/payment-methods')
+          .query({ date: today, format: 'csv' })
+          .set('Authorization', `Bearer ${managerToken}`)
+          .expect(200);
+
+        expect(res.headers['content-type']).toMatch(/text\/csv/);
+        expect(res.headers['content-disposition']).toMatch(
+          /attachment; filename="payment-methods-.*\.csv"/,
+        );
+
+        const lines = res.text.trim().split('\r\n');
+        expect(lines[0]).toBe('method,amountCents');
+        expect(lines).toContain(
+          `CASH,${before.cashCents + PRODUCT_A_REVENUE_CENTS}`,
+        );
+        expect(lines).toContain(
+          `CARD,${before.cardCents + PRODUCT_B_REVENUE_CENTS}`,
+        );
+      });
+
+      it('GET /api/reports/best-selling?format=csv includes a row for productA', async () => {
+        const res = await request(app.getHttpServer())
+          .get('/api/reports/best-selling')
+          .query({ date: today, limit: 50, format: 'csv' })
+          .set('Authorization', `Bearer ${managerToken}`)
+          .expect(200);
+
+        expect(res.headers['content-type']).toMatch(/text\/csv/);
+        expect(res.headers['content-disposition']).toMatch(
+          /attachment; filename="best-selling-.*\.csv"/,
+        );
+
+        const lines = res.text.trim().split('\r\n');
+        expect(lines[0]).toBe('menuItemId,name,quantitySold,revenueCents');
+        const productARow = lines.find((line) => line.includes(productAName));
+        expect(productARow).toBeDefined();
+        expect(productARow).toBe(
+          `${productARow!.split(',')[0]},${productAName},${PRODUCT_A_QTY},${PRODUCT_A_REVENUE_CENTS}`,
+        );
+      });
+
+      it('GET /api/reports/payment-methods-range?format=csv is a flat method/amountCents CSV (not grouped by date)', async () => {
+        const res = await request(app.getHttpServer())
+          .get('/api/reports/payment-methods-range')
+          .query({ startDate: today, endDate: today, format: 'csv' })
+          .set('Authorization', `Bearer ${managerToken}`)
+          .expect(200);
+
+        expect(res.headers['content-type']).toMatch(/text\/csv/);
+        expect(res.headers['content-disposition']).toMatch(
+          /attachment; filename="payment-methods-range-.*\.csv"/,
+        );
+
+        const lines = res.text.trim().split('\r\n');
+        expect(lines[0]).toBe('method,amountCents');
+        expect(lines).toContain(
+          `CASH,${before.cashCents + PRODUCT_A_REVENUE_CENTS}`,
+        );
+        expect(lines).toContain(
+          `CARD,${before.cardCents + PRODUCT_B_REVENUE_CENTS}`,
+        );
+      });
+
+      it('rejects an invalid format value', async () => {
+        await request(app.getHttpServer())
+          .get('/api/reports/daily-summary')
+          .query({ date: today, format: 'xml' })
+          .set('Authorization', `Bearer ${managerToken}`)
+          .expect(400);
+      });
+    });
   });
 
   describe('inventory: adjustments + thresholds', () => {


### PR DESCRIPTION
Closes #43 

## Changes
- Add optional ?format=csv to all 7 report endpoints (daily-summary,
  payment-methods, best-selling, closed-tickets, daily-summary-range,
  payment-methods-range, tickets-by-day)
- New src/common/utils/csv.ts — reusable, RFC 4180 compliant CSV
  converter (escaping, column inference)
- Non-tabular responses (payment method breakdowns) flattened to
  { method, amountCents } rows
- Default JSON behavior completely unchanged — additive only

## Verified finding
payment-methods-range returns a flat aggregate over the entire date
range, not grouped by day as initially assumed — documented in code,
CSV flattening matches this real shape.

## Tests
- Unit: 9 tests for csv.ts (escaping, inference, edge cases)
- e2e: 6 new tests (CSV headers/content-type/disposition across
  multiple endpoints, invalid format rejection, JSON regression check)

## Coverage
Adjusted src/reports/ threshold to 36% (real baseline) — CSV branches
covered by e2e, not forced unit tests, consistent with #61's approach.