### PR TITLE
feat: add Table entity with occupied/available lifecycle Replace Orde…

### DIFF
--- a/prisma/migrations/20260713023034_add_table_entity/migration.sql
+++ b/prisma/migrations/20260713023034_add_table_entity/migration.sql
@@ -1,0 +1,27 @@
+-- CreateEnum
+CREATE TYPE "TableStatus" AS ENUM ('AVAILABLE', 'OCCUPIED');
+
+-- CreateTable
+CREATE TABLE "tables" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "capacity" INTEGER,
+    "status" "TableStatus" NOT NULL DEFAULT 'AVAILABLE',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "tables_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "tables_name_key" ON "tables"("name");
+
+-- AlterTable
+ALTER TABLE "orders" DROP COLUMN "table",
+ADD COLUMN     "tableId" TEXT;
+
+-- CreateIndex
+CREATE INDEX "orders_tableId_idx" ON "orders"("tableId");
+
+-- AddForeignKey
+ALTER TABLE "orders" ADD CONSTRAINT "orders_tableId_fkey" FOREIGN KEY ("tableId") REFERENCES "tables"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,33 +19,33 @@ enum Role {
 }
 
 model User {
-  id           String    @id @default(uuid())
-  email        String    @unique
-  passwordHash String
-  firstName    String?
-  lastName     String?
-  role         Role      @default(CUSTOMER)
-  active       Boolean   @default(true)
+  id               String                @id @default(uuid())
+  email            String                @unique
+  passwordHash     String
+  firstName        String?
+  lastName         String?
+  role             Role                  @default(CUSTOMER)
+  active           Boolean               @default(true)
   orders           Order[]
   openedSessions   CashRegisterSession[] @relation("OpenedSessions")
   closedSessions   CashRegisterSession[] @relation("ClosedSessions")
   stockAdjustments StockAdjustment[]
   sessions         Session[]
-  createdAt    DateTime  @default(now())
-  updatedAt    DateTime  @updatedAt
+  createdAt        DateTime              @default(now())
+  updatedAt        DateTime              @updatedAt
 
   @@map("users")
 }
 
 // Persisted refresh-token sessions (one row per issued refresh token).
 model Session {
-  id           String   @id @default(uuid())
-  userId       String
-  user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
-  refreshHash  String
-  expiresAt    DateTime
-  revokedAt    DateTime?
-  createdAt    DateTime @default(now())
+  id          String    @id @default(uuid())
+  userId      String
+  user        User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  refreshHash String
+  expiresAt   DateTime
+  revokedAt   DateTime?
+  createdAt   DateTime  @default(now())
 
   @@index([userId])
   @@map("sessions")
@@ -66,19 +66,19 @@ model Category {
 }
 
 model MenuItem {
-  id          String      @id @default(uuid())
-  name        String
-  description String?
-  priceCents  Int
-  currency    String      @default("usd")
-  imageUrl    String?
-  available   Boolean     @default(true)
-  categoryId  String
-  category    Category    @relation(fields: [categoryId], references: [id], onDelete: Restrict)
-  orderItems  OrderItem[]
-  inventoryItem  InventoryItem?
-  createdAt   DateTime    @default(now())
-  updatedAt   DateTime    @updatedAt
+  id            String         @id @default(uuid())
+  name          String
+  description   String?
+  priceCents    Int
+  currency      String         @default("usd")
+  imageUrl      String?
+  available     Boolean        @default(true)
+  categoryId    String
+  category      Category       @relation(fields: [categoryId], references: [id], onDelete: Restrict)
+  orderItems    OrderItem[]
+  inventoryItem InventoryItem?
+  createdAt     DateTime       @default(now())
+  updatedAt     DateTime       @updatedAt
 
   @@index([categoryId])
   @@map("menu_items")
@@ -106,47 +106,66 @@ enum OrderStatus {
   CANCELLED
 }
 
+enum TableStatus {
+  AVAILABLE
+  OCCUPIED
+}
+
+model Table {
+  id        String      @id @default(uuid())
+  name      String      @unique
+  capacity  Int?
+  status    TableStatus @default(AVAILABLE)
+  orders    Order[]
+  createdAt DateTime    @default(now())
+  updatedAt DateTime    @updatedAt
+
+  @@map("tables")
+}
+
 model Order {
-  id           String      @id @default(uuid())
-  number       String      @unique
-  customerId   String?
-  customer     User?       @relation(fields: [customerId], references: [id], onDelete: SetNull)
-  type         OrderType   @default(DINE_IN)
-  status       OrderStatus @default(DRAFT)
-  table        String?
-  subtotalCents Int        @default(0)
-  taxCents     Int         @default(0)
-  totalCents   Int         @default(0)
-  discountCents Int        @default(0)
-  discountType  DiscountType @default(FIXED)
+  id                String       @id @default(uuid())
+  number            String       @unique
+  customerId        String?
+  customer          User?        @relation(fields: [customerId], references: [id], onDelete: SetNull)
+  type              OrderType    @default(DINE_IN)
+  status            OrderStatus  @default(DRAFT)
+  tableId           String?
+  tableRef          Table?       @relation(fields: [tableId], references: [id])
+  subtotalCents     Int          @default(0)
+  taxCents          Int          @default(0)
+  totalCents        Int          @default(0)
+  discountCents     Int          @default(0)
+  discountType      DiscountType @default(FIXED)
   discountPercent   Int?
   discountAppliedBy String?
   discountAppliedAt DateTime?
   discountReason    String?
-  currency     String      @default("usd")
-  notes        String?
-  items        OrderItem[]
-  payments     Payment[]
-  createdAt    DateTime    @default(now())
-  updatedAt    DateTime    @updatedAt
+  currency          String       @default("usd")
+  notes             String?
+  items             OrderItem[]
+  payments          Payment[]
+  createdAt         DateTime     @default(now())
+  updatedAt         DateTime     @updatedAt
 
   @@index([customerId])
   @@index([status])
+  @@index([tableId])
   @@map("orders")
 }
 
 model OrderItem {
-  id            String   @id @default(uuid())
-  orderId       String
-  order         Order    @relation(fields: [orderId], references: [id], onDelete: Cascade)
-  menuItemId    String
-  menuItem      MenuItem @relation(fields: [menuItemId], references: [id], onDelete: Restrict)
+  id             String   @id @default(uuid())
+  orderId        String
+  order          Order    @relation(fields: [orderId], references: [id], onDelete: Cascade)
+  menuItemId     String
+  menuItem       MenuItem @relation(fields: [menuItemId], references: [id], onDelete: Restrict)
   // Snapshot of menu item at order time — prices must not change retroactively.
-  nameSnapshot  String
-  priceCents    Int
-  quantity      Int
-  modifiers     Json?
-  notes         String?
+  nameSnapshot   String
+  priceCents     Int
+  quantity       Int
+  modifiers      Json?
+  notes          String?
   lineTotalCents Int
 
   @@index([orderId])
@@ -171,23 +190,23 @@ enum PaymentStatus {
 }
 
 model Payment {
-  id            String        @id @default(uuid())
-  orderId       String
-  order         Order         @relation(fields: [orderId], references: [id], onDelete: Cascade)
-  method        PaymentMethod @default(CASH)
-  provider      String        @default("stripe")
-  providerRef   String?       @unique // Stripe PaymentIntent id (null for CASH/CARD/TRANSFER)
-  amountCents   Int
-  paidCents      Int           @default(0) // amount physically received
-  changeCents    Int           @default(0) // change given back to customer
-  currency      String        @default("usd")
-  status        PaymentStatus @default(REQUIRES_PAYMENT)
-  lastEventId   String? // last processed webhook event id (idempotency)
-  sessionId      String?
-  session        CashRegisterSession? @relation(fields: [sessionId], references: [id])
-  rawEvent        Json?
-  createdAt       DateTime      @default(now())
-  updatedAt       DateTime      @updatedAt
+  id          String               @id @default(uuid())
+  orderId     String
+  order       Order                @relation(fields: [orderId], references: [id], onDelete: Cascade)
+  method      PaymentMethod        @default(CASH)
+  provider    String               @default("stripe")
+  providerRef String?              @unique // Stripe PaymentIntent id (null for CASH/CARD/TRANSFER)
+  amountCents Int
+  paidCents   Int                  @default(0) // amount physically received
+  changeCents Int                  @default(0) // change given back to customer
+  currency    String               @default("usd")
+  status      PaymentStatus        @default(REQUIRES_PAYMENT)
+  lastEventId String? // last processed webhook event id (idempotency)
+  sessionId   String?
+  session     CashRegisterSession? @relation(fields: [sessionId], references: [id])
+  rawEvent    Json?
+  createdAt   DateTime             @default(now())
+  updatedAt   DateTime             @updatedAt
 
   @@index([orderId])
   @@map("payments")
@@ -204,9 +223,9 @@ model CashRegisterSession {
   closedBy          User?     @relation("ClosedSessions", fields: [closedById], references: [id])
   closedAt          DateTime?
   openingFloatCents Int       @default(0)
-  expectedCents     Int?      // computed from sales at close
-  countedCents      Int?      // physically counted by cashier
-  differenceCents   Int?      // countedCents - expectedCents
+  expectedCents     Int? // computed from sales at close
+  countedCents      Int? // physically counted by cashier
+  differenceCents   Int? // countedCents - expectedCents
   notes             String?
   payments          Payment[]
   createdAt         DateTime  @default(now())

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -134,6 +134,18 @@ async function main() {
     });
   }
 
+  // ─── Demo tables ───────────────────────────────────────────────
+
+  const demoTable = await prisma.table.upsert({
+    where: { id: '55555555-5555-4555-8555-555555555501' },
+    update: { name: 'Mesa 1', capacity: 4 },
+    create: {
+      id: '55555555-5555-4555-8555-555555555501',
+      name: 'Mesa 1',
+      capacity: 4,
+    },
+  });
+
   // ─── Demo orders ───────────────────────────────────────────────
 
   const menuLookup = new Map(menuItems.map((m) => [m.name, m]));
@@ -143,7 +155,7 @@ async function main() {
       number: 'DEMO-001',
       type: OrderType.DINE_IN,
       status: OrderStatus.DRAFT,
-      table: 'Mesa 1',
+      tableId: demoTable.id as string | null,
       items: [
         { name: 'Ceviche Clásico', quantity: 2 },
         { name: 'Chicha Morada', quantity: 1 },
@@ -153,7 +165,7 @@ async function main() {
       number: 'DEMO-002',
       type: OrderType.TAKEAWAY,
       status: OrderStatus.DRAFT,
-      table: null as string | null,
+      tableId: null as string | null,
       items: [
         { name: 'Lomo Saltado', quantity: 1 },
         { name: 'Inca Kola', quantity: 2 },
@@ -170,12 +182,12 @@ async function main() {
 
     const order = await prisma.order.upsert({
       where: { number: demo.number },
-      update: { type: demo.type, status: demo.status, table: demo.table },
+      update: { type: demo.type, status: demo.status, tableId: demo.tableId },
       create: {
         number: demo.number,
         type: demo.type,
         status: demo.status,
-        table: demo.table,
+        tableId: demo.tableId,
         customerId: admin.id,
       },
     });

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -15,6 +15,7 @@ import { OrdersModule } from './orders/orders.module';
 import { PaymentsModule } from './payments/payments.module';
 import { PrismaModule } from './prisma/prisma.module';
 import { ReportsModule } from './reports/reports.module';
+import { TablesModule } from './tables/tables.module';
 import { UsersModule } from './users/users.module';
 
 @Module({
@@ -34,6 +35,7 @@ import { UsersModule } from './users/users.module';
     ReportsModule,
     InventoryModule,
     BillingModule,
+    TablesModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/orders/dto/create-order.dto.ts
+++ b/src/orders/dto/create-order.dto.ts
@@ -45,11 +45,11 @@ export class CreateOrderDto {
   @IsEnum(OrderType)
   type!: OrderType;
 
-  @ApiPropertyOptional()
+  @ApiPropertyOptional({ format: 'uuid' })
   @ValidateIf((o) => o.type === OrderType.DINE_IN)
-  @IsString()
-  @IsNotEmpty({ message: 'table is required for dine-in orders' })
-  table?: string;
+  @IsUUID(undefined, { message: 'tableId must be a valid UUID' })
+  @IsNotEmpty({ message: 'tableId is required for dine-in orders' })
+  tableId?: string;
 
   @ApiProperty({ type: [OrderLineDto] })
   @IsArray()

--- a/src/orders/orders.service.spec.ts
+++ b/src/orders/orders.service.spec.ts
@@ -1,6 +1,6 @@
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { OrderStatus, OrderType } from '@prisma/client';
+import { OrderStatus, OrderType, TableStatus } from '@prisma/client';
 import { OrdersService } from './orders.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { AuditService } from '../audit/audit.service';
@@ -8,6 +8,7 @@ import { AuditService } from '../audit/audit.service';
 type MockPrisma = {
   order: {
     findUnique: jest.Mock;
+    findFirst: jest.Mock;
     update: jest.Mock;
   };
   orderItem: {
@@ -19,13 +20,20 @@ type MockPrisma = {
   };
   menuItem: {
     findUnique: jest.Mock;
+    findMany: jest.Mock;
   };
+  table: {
+    findUnique: jest.Mock;
+    update: jest.Mock;
+  };
+  $transaction: jest.Mock;
 };
 
 function createMockPrisma(): MockPrisma {
   return {
     order: {
       findUnique: jest.fn(),
+      findFirst: jest.fn(),
       update: jest.fn(),
     },
     orderItem: {
@@ -37,7 +45,13 @@ function createMockPrisma(): MockPrisma {
     },
     menuItem: {
       findUnique: jest.fn(),
+      findMany: jest.fn(),
     },
+    table: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
+    $transaction: jest.fn(),
   };
 }
 
@@ -103,6 +117,93 @@ describe('OrdersService', () => {
       auditService as unknown as AuditService,
       config as unknown as ConfigService,
     );
+  });
+
+  describe('create', () => {
+    const tableId = 'table-1';
+    let txOrderCreate: jest.Mock;
+    let txTableUpdate: jest.Mock;
+
+    beforeEach(() => {
+      txOrderCreate = jest.fn().mockResolvedValue({
+        id: orderId,
+        status: OrderStatus.DRAFT,
+      });
+      txTableUpdate = jest.fn().mockResolvedValue({});
+      prisma.$transaction.mockImplementation(async (callback) =>
+        callback({
+          order: { create: txOrderCreate },
+          table: { update: txTableUpdate },
+        }),
+      );
+      prisma.menuItem.findMany.mockResolvedValue([availableMenuItem]);
+      prisma.orderItem.findMany.mockResolvedValue([
+        { priceCents: 1200, quantity: 1 },
+      ]);
+      prisma.order.update.mockResolvedValue({
+        ...baseOrder,
+        subtotalCents: 1200,
+        taxCents: 0,
+        totalCents: 1200,
+      });
+    });
+
+    const dto = {
+      type: OrderType.DINE_IN,
+      tableId: 'table-1',
+      items: [{ menuItemId, quantity: 1 }],
+    };
+
+    it('creates a new order and sets the table OCCUPIED when the table is AVAILABLE', async () => {
+      prisma.table.findUnique.mockResolvedValue({
+        id: tableId,
+        status: TableStatus.AVAILABLE,
+      });
+
+      const result = await service.create(dto as any, 'user-1');
+
+      expect(prisma.table.findUnique).toHaveBeenCalledWith({
+        where: { id: tableId },
+      });
+      expect(txOrderCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ tableId }),
+        }),
+      );
+      expect(txTableUpdate).toHaveBeenCalledWith({
+        where: { id: tableId },
+        data: { status: TableStatus.OCCUPIED },
+      });
+      expect(result.totalCents).toBe(1200);
+    });
+
+    it('returns the existing active order instead of creating a duplicate when the table is OCCUPIED', async () => {
+      prisma.table.findUnique.mockResolvedValue({
+        id: tableId,
+        status: TableStatus.OCCUPIED,
+      });
+      const existingOrder = {
+        id: 'existing-order',
+        status: OrderStatus.PENDING,
+        tableId,
+      };
+      prisma.order.findFirst.mockResolvedValue(existingOrder);
+
+      const result = await service.create(dto as any, 'user-1');
+
+      expect(result).toBe(existingOrder);
+      expect(prisma.$transaction).not.toHaveBeenCalled();
+      expect(txOrderCreate).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException for a nonexistent tableId', async () => {
+      prisma.table.findUnique.mockResolvedValue(null);
+
+      await expect(service.create(dto as any, 'user-1')).rejects.toThrow(
+        NotFoundException,
+      );
+      expect(prisma.$transaction).not.toHaveBeenCalled();
+    });
   });
 
   describe('addItem', () => {

--- a/src/orders/orders.service.ts
+++ b/src/orders/orders.service.ts
@@ -5,7 +5,14 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { DiscountType, OrderStatus, Prisma, Role } from '@prisma/client';
+import {
+  DiscountType,
+  OrderStatus,
+  OrderType,
+  Prisma,
+  Role,
+  TableStatus,
+} from '@prisma/client';
 import { randomBytes } from 'crypto';
 import { PrismaService } from '../prisma/prisma.service';
 import {
@@ -27,6 +34,11 @@ const EDITABLE_STATUSES: OrderStatus[] = [
 
 const orderInclude = { items: true } satisfies Prisma.OrderInclude;
 
+const ACTIVE_ORDER_STATUSES: OrderStatus[] = Object.values(OrderStatus).filter(
+  (status) =>
+    status !== OrderStatus.COMPLETED && status !== OrderStatus.CANCELLED,
+);
+
 @Injectable()
 export class OrdersService {
   constructor(
@@ -36,6 +48,26 @@ export class OrdersService {
   ) {}
 
   async create(dto: CreateOrderDto, customerId?: string) {
+    let table: { id: string; status: TableStatus } | null = null;
+    if (dto.type === OrderType.DINE_IN) {
+      table = await this.prisma.table.findUnique({
+        where: { id: dto.tableId },
+      });
+      if (!table) {
+        throw new NotFoundException('Table not found');
+      }
+      if (table.status === TableStatus.OCCUPIED) {
+        const activeOrder = await this.prisma.order.findFirst({
+          where: { tableId: table.id, status: { in: ACTIVE_ORDER_STATUSES } },
+          include: orderInclude,
+          orderBy: { createdAt: 'desc' },
+        });
+        if (activeOrder) {
+          return activeOrder;
+        }
+      }
+    }
+
     const itemIds = dto.items.map((i) => i.menuItemId);
     const menuItems = await this.prisma.menuItem.findMany({
       where: { id: { in: itemIds } },
@@ -66,21 +98,32 @@ export class OrdersService {
       };
     });
 
-    const order = await this.prisma.order.create({
-      data: {
-        number: this.generateOrderNumber(),
-        customerId: customerId ?? null,
-        type: dto.type,
-        table: dto.table,
-        status: OrderStatus.DRAFT,
-        subtotalCents: 0,
-        taxCents: 0,
-        totalCents: 0,
-        currency,
-        notes: dto.notes,
-        items: { create: orderItems },
-      },
-      include: orderInclude,
+    const order = await this.prisma.$transaction(async (tx) => {
+      const created = await tx.order.create({
+        data: {
+          number: this.generateOrderNumber(),
+          customerId: customerId ?? null,
+          type: dto.type,
+          tableId: table?.id ?? null,
+          status: OrderStatus.DRAFT,
+          subtotalCents: 0,
+          taxCents: 0,
+          totalCents: 0,
+          currency,
+          notes: dto.notes,
+          items: { create: orderItems },
+        },
+        include: orderInclude,
+      });
+
+      if (table) {
+        await tx.table.update({
+          where: { id: table.id },
+          data: { status: TableStatus.OCCUPIED },
+        });
+      }
+
+      return created;
     });
 
     return this.recalculateTotals(order.id);

--- a/src/payments/payments.service.spec.ts
+++ b/src/payments/payments.service.spec.ts
@@ -1,5 +1,10 @@
 import { BadRequestException, NotFoundException } from '@nestjs/common';
-import { OrderStatus, PaymentMethod, PaymentStatus } from '@prisma/client';
+import {
+  OrderStatus,
+  PaymentMethod,
+  PaymentStatus,
+  TableStatus,
+} from '@prisma/client';
 import { InventoryService } from '../inventory/inventory.service';
 import { OrdersService } from '../orders/orders.service';
 import { PrismaService } from '../prisma/prisma.service';
@@ -19,6 +24,9 @@ type MockPrisma = {
   inventoryItem: {
     findFirst: jest.Mock;
   };
+  table: {
+    update: jest.Mock;
+  };
   $transaction: jest.Mock;
 };
 
@@ -36,6 +44,9 @@ function createMockPrisma(): MockPrisma {
     inventoryItem: {
       findFirst: jest.fn(),
     },
+    table: {
+      update: jest.fn(),
+    },
     $transaction: jest.fn(),
   };
 }
@@ -46,6 +57,7 @@ describe('PaymentsService', () => {
   let inventoryService: { adjust: jest.Mock };
   let txOrderUpdate: jest.Mock;
   let txPaymentCreate: jest.Mock;
+  let txTableUpdate: jest.Mock;
 
   const orderId = 'order-1';
   const sessionId = 'session-1';
@@ -76,11 +88,13 @@ describe('PaymentsService', () => {
     prisma = createMockPrisma();
     txOrderUpdate = jest.fn().mockResolvedValue({});
     txPaymentCreate = jest.fn().mockResolvedValue({ id: 'payment-1' });
+    txTableUpdate = jest.fn().mockResolvedValue({});
 
     prisma.$transaction.mockImplementation(async (callback) =>
       callback({
         order: { update: txOrderUpdate },
         payment: { create: txPaymentCreate },
+        table: { update: txTableUpdate },
       }),
     );
 
@@ -127,6 +141,44 @@ describe('PaymentsService', () => {
           }),
         }),
       );
+    });
+
+    it('sets the table back to AVAILABLE after successful payment', async () => {
+      const orderWithTable = { ...baseOrder, tableId: 'table-1' };
+      prisma.order.findUnique.mockResolvedValue(orderWithTable);
+      prisma.cashRegisterSession.findFirst.mockResolvedValue(activeSession);
+      prisma.payment.findFirst.mockResolvedValue(null);
+
+      await service.checkout(
+        {
+          orderId,
+          method: PaymentMethod.CASH,
+          amountPaidCents: 1200,
+        },
+        actorId,
+      );
+
+      expect(txTableUpdate).toHaveBeenCalledWith({
+        where: { id: 'table-1' },
+        data: { status: TableStatus.AVAILABLE },
+      });
+    });
+
+    it('does not attempt to release a table for orders without a tableId', async () => {
+      prisma.order.findUnique.mockResolvedValue(baseOrder);
+      prisma.cashRegisterSession.findFirst.mockResolvedValue(activeSession);
+      prisma.payment.findFirst.mockResolvedValue(null);
+
+      await service.checkout(
+        {
+          orderId,
+          method: PaymentMethod.CASH,
+          amountPaidCents: 1200,
+        },
+        actorId,
+      );
+
+      expect(txTableUpdate).not.toHaveBeenCalled();
     });
 
     it('computes changeCents correctly (amountPaid - total)', async () => {

--- a/src/payments/payments.service.ts
+++ b/src/payments/payments.service.ts
@@ -10,6 +10,7 @@ import {
   PaymentMethod,
   PaymentStatus,
   Prisma,
+  TableStatus,
 } from '@prisma/client';
 import { InventoryService } from '../inventory/inventory.service';
 import { canTransition } from '../orders/order-status';
@@ -130,6 +131,16 @@ export class PaymentsService {
         where: { id: order.id },
         data: { status: OrderStatus.CONFIRMED },
       });
+
+      // Releasing the table is a core correctness concern (part of the
+      // critical payment path), not an optional side effect like the
+      // inventory hook below — it must NOT be swallowed on failure.
+      if (order.tableId) {
+        await tx.table.update({
+          where: { id: order.tableId },
+          data: { status: TableStatus.AVAILABLE },
+        });
+      }
 
       return tx.payment.create({
         data: {

--- a/src/tables/dto/create-table.dto.ts
+++ b/src/tables/dto/create-table.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsInt, IsNotEmpty, IsOptional, IsString, Min } from 'class-validator';
+
+export class CreateTableDto {
+  @ApiProperty({ description: 'Table name/number, must be unique' })
+  @IsString()
+  @IsNotEmpty()
+  name!: string;
+
+  @ApiPropertyOptional({ description: 'Seating capacity' })
+  @IsInt()
+  @Min(1)
+  @IsOptional()
+  capacity?: number;
+}

--- a/src/tables/dto/update-table.dto.ts
+++ b/src/tables/dto/update-table.dto.ts
@@ -1,0 +1,18 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsInt, IsNotEmpty, IsOptional, IsString, Min } from 'class-validator';
+
+// Status is intentionally excluded — it is only changed by the order
+// lifecycle (opening/paying an order), never directly by a user.
+export class UpdateTableDto {
+  @ApiPropertyOptional({ description: 'Table name/number, must be unique' })
+  @IsString()
+  @IsNotEmpty()
+  @IsOptional()
+  name?: string;
+
+  @ApiPropertyOptional({ description: 'Seating capacity' })
+  @IsInt()
+  @Min(1)
+  @IsOptional()
+  capacity?: number;
+}

--- a/src/tables/tables.controller.ts
+++ b/src/tables/tables.controller.ts
@@ -1,0 +1,74 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { Role } from '@prisma/client';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { CreateTableDto } from './dto/create-table.dto';
+import { UpdateTableDto } from './dto/update-table.dto';
+import { TablesService } from './tables.service';
+
+@ApiTags('tables')
+@ApiBearerAuth()
+@Controller('tables')
+export class TablesController {
+  constructor(private readonly tablesService: TablesService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'List all tables with their current status' })
+  @ApiResponse({
+    status: 200,
+    description:
+      'List of tables; OCCUPIED tables include a summary of the active order',
+  })
+  findAll() {
+    return this.tablesService.findAll();
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get a single table' })
+  @ApiResponse({ status: 200, description: 'Table details' })
+  @ApiResponse({ status: 404, description: 'Table not found' })
+  findOne(@Param('id') id: string) {
+    return this.tablesService.findOne(id);
+  }
+
+  @Post()
+  @Roles(Role.MANAGER, Role.ADMIN)
+  @ApiOperation({ summary: 'Create a new table' })
+  @ApiResponse({ status: 201, description: 'Table created' })
+  @ApiResponse({ status: 400, description: 'Validation error' })
+  create(@Body() dto: CreateTableDto) {
+    return this.tablesService.create(dto);
+  }
+
+  @Patch(':id')
+  @Roles(Role.MANAGER, Role.ADMIN)
+  @ApiOperation({ summary: 'Update a table name/capacity' })
+  @ApiResponse({ status: 200, description: 'Table updated' })
+  @ApiResponse({ status: 404, description: 'Table not found' })
+  update(@Param('id') id: string, @Body() dto: UpdateTableDto) {
+    return this.tablesService.update(id, dto);
+  }
+
+  @Delete(':id')
+  @Roles(Role.MANAGER, Role.ADMIN)
+  @ApiOperation({ summary: 'Delete a table (only if AVAILABLE)' })
+  @ApiResponse({ status: 200, description: 'Table deleted' })
+  @ApiResponse({ status: 400, description: 'Table is currently occupied' })
+  @ApiResponse({ status: 404, description: 'Table not found' })
+  remove(@Param('id') id: string) {
+    return this.tablesService.remove(id);
+  }
+}

--- a/src/tables/tables.module.ts
+++ b/src/tables/tables.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { TablesController } from './tables.controller';
+import { TablesService } from './tables.service';
+
+@Module({
+  controllers: [TablesController],
+  providers: [TablesService],
+  exports: [TablesService],
+})
+export class TablesModule {}

--- a/src/tables/tables.service.ts
+++ b/src/tables/tables.service.ts
@@ -1,0 +1,83 @@
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { OrderStatus, TableStatus } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateTableDto } from './dto/create-table.dto';
+import { UpdateTableDto } from './dto/update-table.dto';
+
+const ACTIVE_ORDER_STATUSES: OrderStatus[] = Object.values(OrderStatus).filter(
+  (status) =>
+    status !== OrderStatus.COMPLETED && status !== OrderStatus.CANCELLED,
+);
+
+@Injectable()
+export class TablesService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async findAll() {
+    const tables = await this.prisma.table.findMany({
+      orderBy: { name: 'asc' },
+    });
+    return Promise.all(tables.map((table) => this.withActiveOrder(table)));
+  }
+
+  async findOne(id: string) {
+    const table = await this.ensureExists(id);
+    return this.withActiveOrder(table);
+  }
+
+  create(dto: CreateTableDto) {
+    return this.prisma.table.create({
+      data: {
+        name: dto.name,
+        capacity: dto.capacity ?? null,
+      },
+    });
+  }
+
+  async update(id: string, dto: UpdateTableDto) {
+    await this.ensureExists(id);
+    return this.prisma.table.update({
+      where: { id },
+      data: {
+        name: dto.name,
+        capacity: dto.capacity,
+      },
+    });
+  }
+
+  async remove(id: string) {
+    const table = await this.ensureExists(id);
+    if (table.status === TableStatus.OCCUPIED) {
+      throw new BadRequestException('Cannot delete an occupied table');
+    }
+    return this.prisma.table.delete({ where: { id } });
+  }
+
+  private async ensureExists(id: string) {
+    const table = await this.prisma.table.findUnique({ where: { id } });
+    if (!table) {
+      throw new NotFoundException('Table not found');
+    }
+    return table;
+  }
+
+  private async withActiveOrder<T extends { id: string; status: TableStatus }>(
+    table: T,
+  ) {
+    if (table.status !== TableStatus.OCCUPIED) {
+      return { ...table, activeOrder: null };
+    }
+
+    const activeOrder = await this.prisma.order.findFirst({
+      where: { tableId: table.id, status: { in: ACTIVE_ORDER_STATUSES } },
+      orderBy: { createdAt: 'desc' },
+      select: { id: true, number: true, totalCents: true },
+    });
+
+    return { ...table, activeOrder: activeOrder ?? null };
+  }
+}

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -79,6 +79,7 @@ describe('RestoSync API (e2e)', () => {
     let friesId: string;
     let orderId: string;
     let orderItemId: string;
+    let tableId: string;
 
     beforeAll(async () => {
       const login = await request(app.getHttpServer())
@@ -115,6 +116,13 @@ describe('RestoSync API (e2e)', () => {
         })
         .expect(201);
       friesId = fries.body.id;
+
+      const table = await request(app.getHttpServer())
+        .post('/api/tables')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ name: `T1_${Date.now()}` })
+        .expect(201);
+      tableId = table.body.id;
     });
 
     it('POST /api/orders creates an order in DRAFT status', async () => {
@@ -123,7 +131,7 @@ describe('RestoSync API (e2e)', () => {
         .set('Authorization', `Bearer ${adminToken}`)
         .send({
           type: 'DINE_IN',
-          table: 'T1',
+          tableId,
           items: [{ menuItemId: burgerId, quantity: 1 }],
         })
         .expect(201);
@@ -223,6 +231,7 @@ describe('RestoSync API (e2e)', () => {
     let burgerId: string;
     let orderId: string;
     let sessionId: string;
+    let tableId: string;
 
     beforeAll(async () => {
       const cashierLogin = await request(app.getHttpServer())
@@ -260,6 +269,13 @@ describe('RestoSync API (e2e)', () => {
         })
         .expect(201);
       burgerId = burger.body.id;
+
+      const table = await request(app.getHttpServer())
+        .post('/api/tables')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ name: `C1_${Date.now()}` })
+        .expect(201);
+      tableId = table.body.id;
     });
 
     it('POST /api/cash-register/open opens a session with the float', async () => {
@@ -288,7 +304,7 @@ describe('RestoSync API (e2e)', () => {
         .set('Authorization', `Bearer ${adminToken}`)
         .send({
           type: 'DINE_IN',
-          table: 'C1',
+          tableId,
           items: [{ menuItemId: burgerId, quantity: 1 }],
         })
         .expect(201);
@@ -332,6 +348,12 @@ describe('RestoSync API (e2e)', () => {
       expect(res.body.changeCents).toBe(300);
       expect(res.body.order.status).toBe('CONFIRMED');
       expect(res.body.id).toBeDefined();
+
+      const table = await request(app.getHttpServer())
+        .get(`/api/tables/${tableId}`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .expect(200);
+      expect(table.body.status).toBe('AVAILABLE');
     });
 
     // NOTE: checkout() validates `order.status === PENDING` before checking
@@ -510,6 +532,20 @@ describe('RestoSync API (e2e)', () => {
         .expect(201);
       const productBId = productB.body.id;
 
+      const tableA = await request(app.getHttpServer())
+        .post('/api/tables')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ name: `R1_${Date.now()}` })
+        .expect(201);
+      const tableAId = tableA.body.id;
+
+      const tableB = await request(app.getHttpServer())
+        .post('/api/tables')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ name: `R2_${Date.now()}` })
+        .expect(201);
+      const tableBId = tableB.body.id;
+
       // Clean up any register session left open by a previous test run.
       await request(app.getHttpServer())
         .post('/api/cash-register/close')
@@ -528,7 +564,7 @@ describe('RestoSync API (e2e)', () => {
         .set('Authorization', `Bearer ${adminToken}`)
         .send({
           type: 'DINE_IN',
-          table: 'R1',
+          tableId: tableAId,
           items: [{ menuItemId: productAId, quantity: PRODUCT_A_QTY }],
         })
         .expect(201);
@@ -557,7 +593,7 @@ describe('RestoSync API (e2e)', () => {
         .set('Authorization', `Bearer ${adminToken}`)
         .send({
           type: 'DINE_IN',
-          table: 'R2',
+          tableId: tableBId,
           items: [{ menuItemId: productBId, quantity: PRODUCT_B_QTY }],
         })
         .expect(201);
@@ -945,6 +981,7 @@ describe('RestoSync API (e2e)', () => {
     let menuItemId: string;
     let inventoryItemId: string;
     let orderId: string;
+    let tableId: string;
 
     beforeAll(async () => {
       const adminLogin = await request(app.getHttpServer())
@@ -995,6 +1032,13 @@ describe('RestoSync API (e2e)', () => {
         .expect(201);
       inventoryItemId = inventoryItem.body.id;
 
+      const table = await request(app.getHttpServer())
+        .post('/api/tables')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ name: `INV1_${Date.now()}` })
+        .expect(201);
+      tableId = table.body.id;
+
       // Clean up any register session left open by a previous test run.
       await request(app.getHttpServer())
         .post('/api/cash-register/close')
@@ -1014,7 +1058,7 @@ describe('RestoSync API (e2e)', () => {
         .set('Authorization', `Bearer ${adminToken}`)
         .send({
           type: 'DINE_IN',
-          table: 'INV1',
+          tableId,
           items: [{ menuItemId, quantity: ORDER_QTY }],
         })
         .expect(201);
@@ -1116,12 +1160,19 @@ describe('RestoSync API (e2e)', () => {
         .expect(201);
       burgerId = burger.body.id;
 
+      const table = await request(app.getHttpServer())
+        .post('/api/tables')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ name: `A1_${Date.now()}` })
+        .expect(201);
+      const tableId = table.body.id;
+
       const order = await request(app.getHttpServer())
         .post('/api/orders')
         .set('Authorization', `Bearer ${cashierToken}`)
         .send({
           type: 'DINE_IN',
-          table: 'A1',
+          tableId,
           items: [{ menuItemId: burgerId, quantity: 1 }],
         })
         .expect(201);

--- a/test/tables.e2e-spec.ts
+++ b/test/tables.e2e-spec.ts
@@ -1,0 +1,363 @@
+import { ValidationPipe, INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import request from 'supertest';
+import { AppModule } from '../src/app.module';
+
+// Covers the Table entity feature end-to-end: the table lifecycle tied to
+// orders (AVAILABLE -> OCCUPIED -> AVAILABLE on checkout) and the
+// TablesController CRUD endpoints.
+describe('Tables (e2e)', () => {
+  let app: INestApplication;
+  let adminToken: string;
+  let cashierToken: string;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication({ rawBody: true });
+    app.setGlobalPrefix('api', { exclude: ['health'] });
+    app.useGlobalPipes(
+      new ValidationPipe({ whitelist: true, transform: true }),
+    );
+    await app.init();
+
+    const adminLogin = await request(app.getHttpServer())
+      .post('/api/auth/login')
+      .send({ email: 'admin@restosync.local', password: 'Admin123!' })
+      .expect(200);
+    adminToken = adminLogin.body.accessToken;
+
+    const cashierLogin = await request(app.getHttpServer())
+      .post('/api/auth/login')
+      .send({ email: 'cashier@restosync.local', password: 'Cashier123!' })
+      .expect(200);
+    cashierToken = cashierLogin.body.accessToken;
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe('full flow: open table -> order -> retry -> checkout -> release', () => {
+    const ORDER_TOTAL_CENTS = 1000;
+    let categoryId: string;
+    let burgerId: string;
+    let friesId: string;
+    let tableId: string;
+    let orderId: string;
+    let orderItemId: string;
+
+    beforeAll(async () => {
+      const category = await request(app.getHttpServer())
+        .post('/api/menu/categories')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ name: `TableFlow_${Date.now()}` })
+        .expect(201);
+      categoryId = category.body.id;
+
+      const burger = await request(app.getHttpServer())
+        .post('/api/menu/items')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({
+          name: 'Table Flow Burger',
+          priceCents: ORDER_TOTAL_CENTS,
+          categoryId,
+        })
+        .expect(201);
+      burgerId = burger.body.id;
+
+      const fries = await request(app.getHttpServer())
+        .post('/api/menu/items')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({
+          name: 'Table Flow Fries',
+          priceCents: 500,
+          categoryId,
+        })
+        .expect(201);
+      friesId = fries.body.id;
+
+      // Clean up any register session left open by a previous test run.
+      await request(app.getHttpServer())
+        .post('/api/cash-register/close')
+        .set('Authorization', `Bearer ${cashierToken}`)
+        .send({ countedCents: 0 });
+
+      await request(app.getHttpServer())
+        .post('/api/cash-register/open')
+        .set('Authorization', `Bearer ${cashierToken}`)
+        .send({ openingFloatCents: 0 })
+        .expect(201);
+    });
+
+    it('creates a table in AVAILABLE status', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/api/tables')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ name: `Flow_${Date.now()}`, capacity: 4 })
+        .expect(201);
+
+      expect(res.body.status).toBe('AVAILABLE');
+      tableId = res.body.id;
+    });
+
+    it('creates a DINE_IN order for the table, which becomes OCCUPIED', async () => {
+      const order = await request(app.getHttpServer())
+        .post('/api/orders')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({
+          type: 'DINE_IN',
+          tableId,
+          items: [{ menuItemId: burgerId, quantity: 1 }],
+        })
+        .expect(201);
+      orderId = order.body.id;
+      expect(order.body.totalCents).toBe(ORDER_TOTAL_CENTS);
+
+      const table = await request(app.getHttpServer())
+        .get(`/api/tables/${tableId}`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .expect(200);
+      expect(table.body.status).toBe('OCCUPIED');
+      expect(table.body.activeOrder.id).toBe(orderId);
+    });
+
+    it('returns the SAME order instead of creating a duplicate when opening the occupied table again', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/api/orders')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({
+          type: 'DINE_IN',
+          tableId,
+          items: [{ menuItemId: burgerId, quantity: 1 }],
+        })
+        .expect(201);
+
+      expect(res.body.id).toBe(orderId);
+    });
+
+    it('adds items to the same order via POST /orders/:id/items', async () => {
+      const res = await request(app.getHttpServer())
+        .post(`/api/orders/${orderId}/items`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ menuItemId: friesId, quantity: 1 })
+        .expect(201);
+
+      expect(res.body.totalCents).toBe(ORDER_TOTAL_CENTS + 500);
+      const friesItem = res.body.items.find(
+        (item: { menuItemId: string }) => item.menuItemId === friesId,
+      );
+      orderItemId = friesItem.id;
+      expect(orderItemId).toBeDefined();
+    });
+
+    it('confirms the order (DRAFT -> PENDING)', async () => {
+      const res = await request(app.getHttpServer())
+        .post(`/api/orders/${orderId}/confirm`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .expect(201);
+
+      expect(res.body.status).toBe('PENDING');
+    });
+
+    it('checks out the order and releases the table back to AVAILABLE', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/api/payments/checkout')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({
+          orderId,
+          method: 'CASH',
+          amountPaidCents: ORDER_TOTAL_CENTS + 500,
+        })
+        .expect(201);
+      expect(res.body.order.status).toBe('CONFIRMED');
+
+      const table = await request(app.getHttpServer())
+        .get(`/api/tables/${tableId}`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .expect(200);
+      expect(table.body.status).toBe('AVAILABLE');
+      expect(table.body.activeOrder).toBeNull();
+    });
+
+    afterAll(async () => {
+      await request(app.getHttpServer())
+        .post('/api/cash-register/close')
+        .set('Authorization', `Bearer ${cashierToken}`)
+        .send({ countedCents: ORDER_TOTAL_CENTS + 500 });
+    });
+  });
+
+  describe('POST /api/orders validation', () => {
+    it('rejects a DINE_IN order without tableId', async () => {
+      const category = await request(app.getHttpServer())
+        .post('/api/menu/categories')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ name: `NoTable_${Date.now()}` })
+        .expect(201);
+
+      const item = await request(app.getHttpServer())
+        .post('/api/menu/items')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({
+          name: 'No Table Item',
+          priceCents: 500,
+          categoryId: category.body.id,
+        })
+        .expect(201);
+
+      await request(app.getHttpServer())
+        .post('/api/orders')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({
+          type: 'DINE_IN',
+          items: [{ menuItemId: item.body.id, quantity: 1 }],
+        })
+        .expect(400);
+    });
+
+    it('throws NotFoundException for a nonexistent tableId', async () => {
+      const category = await request(app.getHttpServer())
+        .post('/api/menu/categories')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ name: `BadTable_${Date.now()}` })
+        .expect(201);
+
+      const item = await request(app.getHttpServer())
+        .post('/api/menu/items')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({
+          name: 'Bad Table Item',
+          priceCents: 500,
+          categoryId: category.body.id,
+        })
+        .expect(201);
+
+      await request(app.getHttpServer())
+        .post('/api/orders')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({
+          type: 'DINE_IN',
+          tableId: '00000000-0000-4000-8000-000000000000',
+          items: [{ menuItemId: item.body.id, quantity: 1 }],
+        })
+        .expect(404);
+    });
+  });
+
+  describe('TablesController CRUD', () => {
+    let tableId: string;
+
+    it('POST /api/tables creates a table', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/api/tables')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ name: `CRUD_${Date.now()}`, capacity: 2 })
+        .expect(201);
+
+      expect(res.body.status).toBe('AVAILABLE');
+      expect(res.body.capacity).toBe(2);
+      tableId = res.body.id;
+    });
+
+    it('rejects table creation from a non-manager role', async () => {
+      await request(app.getHttpServer())
+        .post('/api/tables')
+        .set('Authorization', `Bearer ${cashierToken}`)
+        .send({ name: `Rejected_${Date.now()}` })
+        .expect(403);
+    });
+
+    it('GET /api/tables lists all tables', async () => {
+      const res = await request(app.getHttpServer())
+        .get('/api/tables')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .expect(200);
+
+      expect(Array.isArray(res.body)).toBe(true);
+      expect(res.body.some((t: { id: string }) => t.id === tableId)).toBe(true);
+    });
+
+    it('GET /api/tables/:id returns a single table', async () => {
+      const res = await request(app.getHttpServer())
+        .get(`/api/tables/${tableId}`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .expect(200);
+
+      expect(res.body.id).toBe(tableId);
+    });
+
+    it('GET /api/tables/:id returns 404 for a nonexistent table', async () => {
+      await request(app.getHttpServer())
+        .get('/api/tables/00000000-0000-4000-8000-000000000000')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .expect(404);
+    });
+
+    it('PATCH /api/tables/:id updates name/capacity', async () => {
+      const res = await request(app.getHttpServer())
+        .patch(`/api/tables/${tableId}`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ capacity: 6 })
+        .expect(200);
+
+      expect(res.body.capacity).toBe(6);
+    });
+
+    it('DELETE /api/tables/:id deletes an AVAILABLE table', async () => {
+      await request(app.getHttpServer())
+        .delete(`/api/tables/${tableId}`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .expect(200);
+
+      await request(app.getHttpServer())
+        .get(`/api/tables/${tableId}`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .expect(404);
+    });
+
+    it('DELETE /api/tables/:id rejects deleting an OCCUPIED table', async () => {
+      const table = await request(app.getHttpServer())
+        .post('/api/tables')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ name: `Occupied_${Date.now()}` })
+        .expect(201);
+      const occupiedTableId = table.body.id;
+
+      const category = await request(app.getHttpServer())
+        .post('/api/menu/categories')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ name: `OccupiedDelete_${Date.now()}` })
+        .expect(201);
+
+      const item = await request(app.getHttpServer())
+        .post('/api/menu/items')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({
+          name: 'Occupied Delete Item',
+          priceCents: 500,
+          categoryId: category.body.id,
+        })
+        .expect(201);
+
+      await request(app.getHttpServer())
+        .post('/api/orders')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({
+          type: 'DINE_IN',
+          tableId: occupiedTableId,
+          items: [{ menuItemId: item.body.id, quantity: 1 }],
+        })
+        .expect(201);
+
+      const res = await request(app.getHttpServer())
+        .delete(`/api/tables/${occupiedTableId}`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .expect(400);
+
+      expect(res.body.message).toMatch(/occupied/i);
+    });
+  });
+});

--- a/test/tax.e2e-spec.ts
+++ b/test/tax.e2e-spec.ts
@@ -64,12 +64,18 @@ describe('Configurable tax strategy (e2e)', () => {
       })
       .expect(201);
 
+    const table = await request(app.getHttpServer())
+      .post('/api/tables')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ name: `TX1_${Date.now()}` })
+      .expect(201);
+
     const order = await request(app.getHttpServer())
       .post('/api/orders')
       .set('Authorization', `Bearer ${adminToken}`)
       .send({
         type: 'DINE_IN',
-        table: 'TX1',
+        tableId: table.body.id,
         items: [{ menuItemId: item.body.id, quantity: 2 }],
       })
       .expect(201);


### PR DESCRIPTION
Closes: (link to whatever issue/discussion tracked this with Carlos,
or leave as a standalone feature PR if not tracked as a numbered issue)

## Changes
- New Table entity (AVAILABLE/OCCUPIED), replacing Order's free-text
  table field with a real tableId FK
- Order creation on an occupied table returns the existing active
  order instead of duplicating (matches real paper-ticket workflow)
- Table auto-releases to AVAILABLE on successful checkout, as part
  of the critical payment transaction
- New src/tables/ module: full CRUD, delete blocked while occupied

## Design notes
- RESERVED status deliberately excluded — reservations with deposit
  is a separate follow-up feature
- Table release is NOT part of the #51 inventory-decrement's
  best-effort try/catch — it's a correctness concern in the critical
  payment path

## Tests
113/113 unit, 72/72 e2e (new: full table lifecycle, TablesController
CRUD including delete-blocked-when-occupied; updated all pre-existing
`table: 'X'` fixtures to real Table rows)