### PR TITLE
feat: add table reservations with 3 flexible types (WITH_PREORDER, DEPOSIT_ONLY, INFORMAL)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
-    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "test:e2e": "jest --config ./test/jest-e2e.json --runInBand",
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev",
     "prisma:deploy": "prisma migrate deploy",

--- a/prisma/migrations/20260713031725_add_reservations/migration.sql
+++ b/prisma/migrations/20260713031725_add_reservations/migration.sql
@@ -1,0 +1,51 @@
+-- AlterEnum
+ALTER TYPE "TableStatus" ADD VALUE 'RESERVED';
+
+-- CreateEnum
+CREATE TYPE "ReservationType" AS ENUM ('WITH_PREORDER', 'DEPOSIT_ONLY', 'INFORMAL');
+
+-- CreateEnum
+CREATE TYPE "ReservationStatus" AS ENUM ('PENDING', 'CONFIRMED', 'SEATED', 'NO_SHOW', 'CANCELLED');
+
+-- CreateTable
+CREATE TABLE "reservations" (
+    "id" TEXT NOT NULL,
+    "customerName" TEXT NOT NULL,
+    "customerPhone" TEXT NOT NULL,
+    "customerEmail" TEXT,
+    "partySize" INTEGER NOT NULL,
+    "reservedFor" TIMESTAMP(3) NOT NULL,
+    "toleranceMinutes" INTEGER NOT NULL DEFAULT 10,
+    "allergies" TEXT,
+    "specialOccasion" TEXT,
+    "reservationType" "ReservationType" NOT NULL,
+    "tableId" TEXT,
+    "orderId" TEXT,
+    "depositCents" INTEGER NOT NULL DEFAULT 0,
+    "depositConfirmedBy" TEXT,
+    "depositConfirmedAt" TIMESTAMP(3),
+    "status" "ReservationStatus" NOT NULL DEFAULT 'PENDING',
+    "createdBy" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "reservations_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "reservations_orderId_key" ON "reservations"("orderId");
+
+-- CreateIndex
+CREATE INDEX "reservations_status_idx" ON "reservations"("status");
+
+-- CreateIndex
+CREATE INDEX "reservations_reservedFor_idx" ON "reservations"("reservedFor");
+
+-- CreateIndex
+CREATE INDEX "reservations_tableId_idx" ON "reservations"("tableId");
+
+-- AddForeignKey
+ALTER TABLE "reservations" ADD CONSTRAINT "reservations_tableId_fkey" FOREIGN KEY ("tableId") REFERENCES "tables"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "reservations" ADD CONSTRAINT "reservations_orderId_fkey" FOREIGN KEY ("orderId") REFERENCES "orders"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -108,17 +108,19 @@ enum OrderStatus {
 
 enum TableStatus {
   AVAILABLE
+  RESERVED
   OCCUPIED
 }
 
 model Table {
-  id        String      @id @default(uuid())
-  name      String      @unique
-  capacity  Int?
-  status    TableStatus @default(AVAILABLE)
-  orders    Order[]
-  createdAt DateTime    @default(now())
-  updatedAt DateTime    @updatedAt
+  id           String        @id @default(uuid())
+  name         String        @unique
+  capacity     Int?
+  status       TableStatus   @default(AVAILABLE)
+  orders       Order[]
+  reservations Reservation[]
+  createdAt    DateTime      @default(now())
+  updatedAt    DateTime      @updatedAt
 
   @@map("tables")
 }
@@ -145,6 +147,7 @@ model Order {
   notes             String?
   items             OrderItem[]
   payments          Payment[]
+  reservation       Reservation?
   createdAt         DateTime     @default(now())
   updatedAt         DateTime     @updatedAt
 
@@ -170,6 +173,51 @@ model OrderItem {
 
   @@index([orderId])
   @@map("order_items")
+}
+
+// ---------- Reservations ----------
+
+enum ReservationType {
+  WITH_PREORDER
+  DEPOSIT_ONLY
+  INFORMAL
+}
+
+enum ReservationStatus {
+  PENDING
+  CONFIRMED
+  SEATED
+  NO_SHOW
+  CANCELLED
+}
+
+model Reservation {
+  id                 String            @id @default(uuid())
+  customerName       String
+  customerPhone      String
+  customerEmail      String?
+  partySize          Int
+  reservedFor        DateTime
+  toleranceMinutes   Int               @default(10)
+  allergies          String?
+  specialOccasion    String?
+  reservationType    ReservationType
+  tableId            String?
+  table              Table?            @relation(fields: [tableId], references: [id])
+  orderId            String?           @unique
+  order              Order?            @relation(fields: [orderId], references: [id])
+  depositCents       Int               @default(0)
+  depositConfirmedBy String?
+  depositConfirmedAt DateTime?
+  status             ReservationStatus @default(PENDING)
+  createdBy          String // staff user who registered it
+  createdAt          DateTime          @default(now())
+  updatedAt          DateTime          @updatedAt
+
+  @@index([status])
+  @@index([reservedFor])
+  @@index([tableId])
+  @@map("reservations")
 }
 
 // ---------- Payments ----------

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -15,6 +15,7 @@ import { OrdersModule } from './orders/orders.module';
 import { PaymentsModule } from './payments/payments.module';
 import { PrismaModule } from './prisma/prisma.module';
 import { ReportsModule } from './reports/reports.module';
+import { ReservationsModule } from './reservations/reservations.module';
 import { TablesModule } from './tables/tables.module';
 import { UsersModule } from './users/users.module';
 
@@ -36,6 +37,7 @@ import { UsersModule } from './users/users.module';
     InventoryModule,
     BillingModule,
     TablesModule,
+    ReservationsModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -24,4 +24,11 @@ export default () => ({
     // 0) in development/test.
     rate: parseFloat(process.env.TAX_RATE || '0'),
   },
+  reservations: {
+    // Fixed deposit amount (in cents) for DEPOSIT_ONLY reservations.
+    // Unlike TAX_RATE, an unconfigured deposit has low risk (no legal
+    // consequences), so this is optional with a sensible default rather
+    // than fail-fast-in-production — see env.validation.ts.
+    depositCents: parseInt(process.env.RESERVATION_DEPOSIT_CENTS || '1000', 10),
+  },
 });

--- a/src/config/env.validation.ts
+++ b/src/config/env.validation.ts
@@ -64,6 +64,15 @@ class EnvironmentVariables {
   @Min(0, { message: 'TAX_RATE must be between 0 and 1' })
   @Max(1, { message: 'TAX_RATE must be between 0 and 1' })
   TAX_RATE?: string;
+
+  // Fixed deposit amount (in cents) for DEPOSIT_ONLY reservations. Whenever
+  // provided, must be a non-negative integer. Unlike TAX_RATE, a missing
+  // value has no legal consequences, so it's simply @IsOptional() with a
+  // default applied in configuration.ts — no fail-fast-in-production
+  // behavior needed here.
+  @IsOptional()
+  @IsNumberString()
+  RESERVATION_DEPOSIT_CENTS?: string;
 }
 
 export function validateEnv(config: Record<string, unknown>) {

--- a/src/reservations/dto/create-reservation.dto.ts
+++ b/src/reservations/dto/create-reservation.dto.ts
@@ -1,0 +1,108 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { ReservationType } from '@prisma/client';
+import { Type } from 'class-transformer';
+import {
+  ArrayMinSize,
+  IsArray,
+  IsDateString,
+  IsEmail,
+  IsEnum,
+  IsInt,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  IsUUID,
+  Min,
+  ValidateIf,
+  ValidateNested,
+} from 'class-validator';
+import { OrderLineDto } from '../../orders/dto/create-order.dto';
+
+export class CreateReservationDto {
+  @ApiProperty()
+  @IsString()
+  @IsNotEmpty()
+  customerName!: string;
+
+  @ApiProperty()
+  @IsString()
+  @IsNotEmpty()
+  customerPhone!: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsEmail()
+  customerEmail?: string;
+
+  @ApiProperty({ example: 4, minimum: 1 })
+  @IsInt()
+  @Min(1)
+  partySize!: number;
+
+  @ApiProperty({ description: 'Date/time the customer is expected' })
+  @IsDateString()
+  reservedFor!: string;
+
+  // Fully optional and freely editable by staff — if omitted, the service
+  // applies a type-appropriate default (INFORMAL: 10, DEPOSIT_ONLY: 20,
+  // WITH_PREORDER: 30 minutes), reflecting that reservations with more
+  // money already committed reasonably get more patience before being
+  // marked no-show. If provided, the given value is used exactly as-is,
+  // with no clamping beyond this base validation.
+  @ApiPropertyOptional({
+    description:
+      'Grace period in minutes before staff decides on a no-show. Defaults ' +
+      'vary by reservationType when omitted (INFORMAL: 10, DEPOSIT_ONLY: ' +
+      '20, WITH_PREORDER: 30) but any explicit value is honored exactly.',
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  toleranceMinutes?: number;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  allergies?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  specialOccasion?: string;
+
+  @ApiProperty({ enum: ReservationType })
+  @IsEnum(ReservationType)
+  reservationType!: ReservationType;
+
+  // Required (and must reference an AVAILABLE table) for WITH_PREORDER and
+  // DEPOSIT_ONLY — a specific table is committed once the deposit is
+  // confirmed. NOT accepted for INFORMAL (no table is chosen until the
+  // customer actually arrives) — enforced in the service, since rejecting
+  // an unexpected value for a *different* type isn't expressible with a
+  // single bare @ValidateIf on this field without conflicting with the
+  // "required for these two types" condition below.
+  @ApiPropertyOptional({ format: 'uuid' })
+  @ValidateIf(
+    (o) =>
+      o.reservationType === ReservationType.WITH_PREORDER ||
+      o.reservationType === ReservationType.DEPOSIT_ONLY,
+  )
+  @IsUUID(undefined, { message: 'tableId must be a valid UUID' })
+  @IsNotEmpty({
+    message:
+      'tableId is required for WITH_PREORDER and DEPOSIT_ONLY reservations',
+  })
+  tableId?: string;
+
+  // Required for WITH_PREORDER (the phone pre-order). NOT accepted for
+  // DEPOSIT_ONLY or INFORMAL — enforced in the service (see note above).
+  @ApiPropertyOptional({ type: [OrderLineDto] })
+  @ValidateIf((o) => o.reservationType === ReservationType.WITH_PREORDER)
+  @IsArray()
+  @ArrayMinSize(1, {
+    message: 'items is required for WITH_PREORDER reservations',
+  })
+  @ValidateNested({ each: true })
+  @Type(() => OrderLineDto)
+  items?: OrderLineDto[];
+}

--- a/src/reservations/dto/list-reservations-query.dto.ts
+++ b/src/reservations/dto/list-reservations-query.dto.ts
@@ -1,0 +1,19 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { ReservationStatus } from '@prisma/client';
+import { IsDateString, IsEnum, IsOptional } from 'class-validator';
+import { PaginationQueryDto } from '../../common/dto/pagination-query.dto';
+
+export class ListReservationsQueryDto extends PaginationQueryDto {
+  @ApiPropertyOptional({ enum: ReservationStatus })
+  @IsOptional()
+  @IsEnum(ReservationStatus)
+  status?: ReservationStatus;
+
+  @ApiPropertyOptional({
+    example: '2025-06-30',
+    description: 'Filter by reservedFor date (YYYY-MM-DD)',
+  })
+  @IsOptional()
+  @IsDateString()
+  date?: string;
+}

--- a/src/reservations/dto/seat-reservation.dto.ts
+++ b/src/reservations/dto/seat-reservation.dto.ts
@@ -1,0 +1,16 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsUUID } from 'class-validator';
+
+// Only meaningful for INFORMAL reservations, where no table was chosen at
+// reservation time — staff picks an available table when the customer
+// actually arrives. Ignored for WITH_PREORDER/DEPOSIT_ONLY, which already
+// have a committed table from reservation creation.
+export class SeatReservationDto {
+  @ApiPropertyOptional({
+    format: 'uuid',
+    description: 'Required only when seating an INFORMAL reservation',
+  })
+  @IsOptional()
+  @IsUUID()
+  tableId?: string;
+}

--- a/src/reservations/reservations.controller.ts
+++ b/src/reservations/reservations.controller.ts
@@ -1,0 +1,108 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Query,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { Role } from '@prisma/client';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { CreateReservationDto } from './dto/create-reservation.dto';
+import { ListReservationsQueryDto } from './dto/list-reservations-query.dto';
+import { SeatReservationDto } from './dto/seat-reservation.dto';
+import { ReservationsService } from './reservations.service';
+
+@ApiTags('reservations')
+@ApiBearerAuth()
+@Roles(Role.CASHIER, Role.MANAGER, Role.ADMIN)
+@Controller('reservations')
+export class ReservationsController {
+  constructor(private readonly reservationsService: ReservationsService) {}
+
+  @Post()
+  @ApiOperation({
+    summary:
+      'Register a reservation (WITH_PREORDER, DEPOSIT_ONLY, or INFORMAL)',
+  })
+  @ApiResponse({ status: 201, description: 'Reservation created' })
+  @ApiResponse({ status: 400, description: 'Validation error' })
+  @ApiResponse({ status: 404, description: 'Table not found' })
+  create(@Body() dto: CreateReservationDto, @CurrentUser('id') userId: string) {
+    return this.reservationsService.create(dto, userId);
+  }
+
+  @Get()
+  @ApiOperation({ summary: 'List reservations, filterable by status/date' })
+  @ApiResponse({ status: 200, description: 'List of reservations' })
+  findAll(@Query() query: ListReservationsQueryDto) {
+    return this.reservationsService.findAll(query);
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get a single reservation' })
+  @ApiResponse({ status: 200, description: 'Reservation details' })
+  @ApiResponse({ status: 404, description: 'Reservation not found' })
+  findOne(@Param('id') id: string) {
+    return this.reservationsService.findOne(id);
+  }
+
+  @Patch(':id/confirm')
+  @ApiOperation({
+    summary:
+      'Confirm a reservation (deposit received); commits the table to RESERVED for paid types',
+  })
+  @ApiResponse({ status: 200, description: 'Reservation confirmed' })
+  @ApiResponse({ status: 400, description: 'Reservation not PENDING' })
+  @ApiResponse({ status: 404, description: 'Reservation not found' })
+  confirm(@Param('id') id: string, @CurrentUser('id') userId: string) {
+    return this.reservationsService.confirm(id, userId);
+  }
+
+  @Post(':id/seat')
+  @ApiOperation({
+    summary:
+      'Seat the customer: creates/links the order and sets the table OCCUPIED',
+  })
+  @ApiResponse({ status: 201, description: 'Order created/linked' })
+  @ApiResponse({
+    status: 400,
+    description: 'Reservation not CONFIRMED or missing required data',
+  })
+  @ApiResponse({ status: 404, description: 'Reservation not found' })
+  seat(
+    @Param('id') id: string,
+    @Body() dto: SeatReservationDto,
+    @CurrentUser('id') userId: string,
+  ) {
+    return this.reservationsService.seat(id, dto, userId);
+  }
+
+  @Patch(':id/no-show')
+  @ApiOperation({
+    summary: 'Mark as a no-show (staff decision, never automatic)',
+  })
+  @ApiResponse({ status: 200, description: 'Reservation marked NO_SHOW' })
+  @ApiResponse({ status: 400, description: 'Reservation already terminal' })
+  @ApiResponse({ status: 404, description: 'Reservation not found' })
+  noShow(@Param('id') id: string) {
+    return this.reservationsService.noShow(id);
+  }
+
+  @Patch(':id/cancel')
+  @ApiOperation({ summary: 'Cancel a reservation' })
+  @ApiResponse({ status: 200, description: 'Reservation cancelled' })
+  @ApiResponse({ status: 400, description: 'Reservation already terminal' })
+  @ApiResponse({ status: 404, description: 'Reservation not found' })
+  cancel(@Param('id') id: string) {
+    return this.reservationsService.cancel(id);
+  }
+}

--- a/src/reservations/reservations.module.ts
+++ b/src/reservations/reservations.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { OrdersModule } from '../orders/orders.module';
+import { ReservationsController } from './reservations.controller';
+import { ReservationsService } from './reservations.service';
+
+@Module({
+  imports: [OrdersModule],
+  controllers: [ReservationsController],
+  providers: [ReservationsService],
+  exports: [ReservationsService],
+})
+export class ReservationsModule {}

--- a/src/reservations/reservations.service.spec.ts
+++ b/src/reservations/reservations.service.spec.ts
@@ -1,0 +1,663 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import {
+  DiscountType,
+  OrderType,
+  ReservationStatus,
+  ReservationType,
+  TableStatus,
+} from '@prisma/client';
+import { OrdersService } from '../orders/orders.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { ReservationsService } from './reservations.service';
+
+type MockPrisma = {
+  table: {
+    findUnique: jest.Mock;
+    update: jest.Mock;
+  };
+  reservation: {
+    create: jest.Mock;
+    findUnique: jest.Mock;
+    findMany: jest.Mock;
+    update: jest.Mock;
+  };
+  order: {
+    update: jest.Mock;
+  };
+  $transaction: jest.Mock;
+};
+
+function createMockPrisma(): MockPrisma {
+  const txTable = { update: jest.fn().mockResolvedValue({}) };
+  const txReservation = { update: jest.fn().mockResolvedValue({}) };
+  const txOrder = { update: jest.fn().mockResolvedValue({}) };
+
+  const prisma: MockPrisma = {
+    table: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
+    reservation: {
+      create: jest.fn(),
+      findUnique: jest.fn(),
+      findMany: jest.fn(),
+      update: jest.fn(),
+    },
+    order: {
+      update: jest.fn(),
+    },
+    $transaction: jest.fn(),
+  };
+
+  // Supports both callback-style `$transaction(async (tx) => ...)` (used by
+  // confirm()/terminate()) and array-style `$transaction([p1, p2, p3])`
+  // (used by seatWithPreorder()), mirroring the real Prisma client's dual
+  // signature.
+  prisma.$transaction.mockImplementation((arg) => {
+    if (typeof arg === 'function') {
+      return arg({
+        table: txTable,
+        reservation: txReservation,
+        order: txOrder,
+      });
+    }
+    return Promise.all(arg);
+  });
+
+  return prisma;
+}
+
+describe('ReservationsService', () => {
+  let service: ReservationsService;
+  let prisma: MockPrisma;
+  let ordersService: {
+    create: jest.Mock;
+    applyDiscount: jest.Mock;
+  };
+  let config: { get: jest.Mock };
+
+  const actorId = 'user-1';
+  const tableId = 'table-1';
+  const reservationId = 'reservation-1';
+  const menuItemId = 'menu-item-1';
+
+  const availableTable = { id: tableId, status: TableStatus.AVAILABLE };
+
+  beforeEach(() => {
+    prisma = createMockPrisma();
+    ordersService = {
+      create: jest.fn(),
+      applyDiscount: jest.fn(),
+    };
+    config = {
+      get: jest.fn((key: string) =>
+        key === 'reservations.depositCents' ? 1000 : undefined,
+      ),
+    };
+    service = new ReservationsService(
+      prisma as unknown as PrismaService,
+      ordersService as unknown as OrdersService,
+      config as unknown as ConfigService,
+    );
+  });
+
+  describe('create', () => {
+    const baseDto = {
+      customerName: 'Jane Doe',
+      customerPhone: '+51999999999',
+      partySize: 4,
+      reservedFor: '2026-08-01T20:00:00.000Z',
+    };
+
+    it('WITH_PREORDER: computes depositCents as floor(order.totalCents / 2) and creates the pre-order via OrdersService', async () => {
+      prisma.table.findUnique.mockResolvedValue(availableTable);
+      ordersService.create.mockResolvedValue({
+        id: 'order-1',
+        totalCents: 4501,
+      });
+      prisma.reservation.create.mockImplementation(({ data }) =>
+        Promise.resolve({ id: reservationId, ...data }),
+      );
+
+      const dto = {
+        ...baseDto,
+        reservationType: ReservationType.WITH_PREORDER,
+        tableId,
+        items: [{ menuItemId, quantity: 2 }],
+      };
+
+      const result = await service.create(dto as any, actorId);
+
+      expect(prisma.table.findUnique).toHaveBeenCalledWith({
+        where: { id: tableId },
+      });
+      expect(ordersService.create).toHaveBeenCalledWith({
+        type: OrderType.TAKEAWAY,
+        items: dto.items,
+      });
+      // floor(4501 / 2) = 2250
+      expect(result.depositCents).toBe(2250);
+      expect(result.orderId).toBe('order-1');
+      expect(result.tableId).toBe(tableId);
+      expect(result.status).toBe(ReservationStatus.PENDING);
+      expect(result.createdBy).toBe(actorId);
+    });
+
+    it('DEPOSIT_ONLY: uses the configured fixed deposit amount', async () => {
+      prisma.table.findUnique.mockResolvedValue(availableTable);
+      prisma.reservation.create.mockImplementation(({ data }) =>
+        Promise.resolve({ id: reservationId, ...data }),
+      );
+
+      const dto = {
+        ...baseDto,
+        reservationType: ReservationType.DEPOSIT_ONLY,
+        tableId,
+      };
+
+      const result = await service.create(dto as any, actorId);
+
+      expect(config.get).toHaveBeenCalledWith('reservations.depositCents');
+      expect(result.depositCents).toBe(1000);
+      expect(result.orderId).toBeNull();
+      expect(ordersService.create).not.toHaveBeenCalled();
+    });
+
+    it('INFORMAL: no table, no order, depositCents is 0', async () => {
+      prisma.reservation.create.mockImplementation(({ data }) =>
+        Promise.resolve({ id: reservationId, ...data }),
+      );
+
+      const dto = {
+        ...baseDto,
+        reservationType: ReservationType.INFORMAL,
+      };
+
+      const result = await service.create(dto as any, actorId);
+
+      expect(prisma.table.findUnique).not.toHaveBeenCalled();
+      expect(ordersService.create).not.toHaveBeenCalled();
+      expect(result.depositCents).toBeUndefined();
+      expect(result.tableId).toBeUndefined();
+      expect(result.orderId).toBeUndefined();
+    });
+
+    it('rejects INFORMAL reservations that include a tableId', async () => {
+      const dto = {
+        ...baseDto,
+        reservationType: ReservationType.INFORMAL,
+        tableId,
+      };
+
+      await expect(service.create(dto as any, actorId)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('rejects INFORMAL reservations that include items', async () => {
+      const dto = {
+        ...baseDto,
+        reservationType: ReservationType.INFORMAL,
+        items: [{ menuItemId, quantity: 1 }],
+      };
+
+      await expect(service.create(dto as any, actorId)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('rejects DEPOSIT_ONLY reservations that include items', async () => {
+      prisma.table.findUnique.mockResolvedValue(availableTable);
+
+      const dto = {
+        ...baseDto,
+        reservationType: ReservationType.DEPOSIT_ONLY,
+        tableId,
+        items: [{ menuItemId, quantity: 1 }],
+      };
+
+      await expect(service.create(dto as any, actorId)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('throws NotFoundException when the table does not exist', async () => {
+      prisma.table.findUnique.mockResolvedValue(null);
+
+      const dto = {
+        ...baseDto,
+        reservationType: ReservationType.DEPOSIT_ONLY,
+        tableId,
+      };
+
+      await expect(service.create(dto as any, actorId)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('throws BadRequestException when the table is not AVAILABLE', async () => {
+      prisma.table.findUnique.mockResolvedValue({
+        id: tableId,
+        status: TableStatus.OCCUPIED,
+      });
+
+      const dto = {
+        ...baseDto,
+        reservationType: ReservationType.WITH_PREORDER,
+        tableId,
+        items: [{ menuItemId, quantity: 1 }],
+      };
+
+      await expect(service.create(dto as any, actorId)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    describe('toleranceMinutes defaults (type-aware, overridable)', () => {
+      beforeEach(() => {
+        prisma.table.findUnique.mockResolvedValue(availableTable);
+        prisma.reservation.create.mockImplementation(({ data }) =>
+          Promise.resolve({ id: reservationId, ...data }),
+        );
+        ordersService.create.mockResolvedValue({
+          id: 'order-1',
+          totalCents: 1000,
+        });
+      });
+
+      it('defaults to 10 minutes for INFORMAL when omitted', async () => {
+        const result = await service.create(
+          { ...baseDto, reservationType: ReservationType.INFORMAL } as any,
+          actorId,
+        );
+        expect(result.toleranceMinutes).toBe(10);
+      });
+
+      it('defaults to 20 minutes for DEPOSIT_ONLY when omitted', async () => {
+        const result = await service.create(
+          {
+            ...baseDto,
+            reservationType: ReservationType.DEPOSIT_ONLY,
+            tableId,
+          } as any,
+          actorId,
+        );
+        expect(result.toleranceMinutes).toBe(20);
+      });
+
+      it('defaults to 30 minutes for WITH_PREORDER when omitted', async () => {
+        const result = await service.create(
+          {
+            ...baseDto,
+            reservationType: ReservationType.WITH_PREORDER,
+            tableId,
+            items: [{ menuItemId, quantity: 1 }],
+          } as any,
+          actorId,
+        );
+        expect(result.toleranceMinutes).toBe(30);
+      });
+
+      it('honors an explicit toleranceMinutes exactly, regardless of type, with no clamping', async () => {
+        const result = await service.create(
+          {
+            ...baseDto,
+            reservationType: ReservationType.INFORMAL,
+            toleranceMinutes: 999,
+          } as any,
+          actorId,
+        );
+        expect(result.toleranceMinutes).toBe(999);
+      });
+
+      it('honors a small explicit override even for WITH_PREORDER (no minimum enforced beyond the DTO)', async () => {
+        const result = await service.create(
+          {
+            ...baseDto,
+            reservationType: ReservationType.WITH_PREORDER,
+            tableId,
+            items: [{ menuItemId, quantity: 1 }],
+            toleranceMinutes: 1,
+          } as any,
+          actorId,
+        );
+        expect(result.toleranceMinutes).toBe(1);
+      });
+    });
+  });
+
+  describe('confirm', () => {
+    it('sets Table.status to RESERVED for WITH_PREORDER/DEPOSIT_ONLY and stamps the deposit confirmation', async () => {
+      prisma.reservation.findUnique.mockResolvedValue({
+        id: reservationId,
+        status: ReservationStatus.PENDING,
+        reservationType: ReservationType.DEPOSIT_ONLY,
+        tableId,
+      });
+      const txTableUpdate = jest.fn().mockResolvedValue({});
+      const txReservationUpdate = jest.fn().mockResolvedValue({
+        id: reservationId,
+        status: ReservationStatus.CONFIRMED,
+        depositConfirmedBy: actorId,
+      });
+      prisma.$transaction.mockImplementationOnce((cb) =>
+        cb({
+          table: { update: txTableUpdate },
+          reservation: { update: txReservationUpdate },
+        }),
+      );
+
+      const result = await service.confirm(reservationId, actorId);
+
+      expect(txTableUpdate).toHaveBeenCalledWith({
+        where: { id: tableId },
+        data: { status: TableStatus.RESERVED },
+      });
+      expect(txReservationUpdate).toHaveBeenCalledWith({
+        where: { id: reservationId },
+        data: expect.objectContaining({
+          status: ReservationStatus.CONFIRMED,
+          depositConfirmedBy: actorId,
+        }),
+      });
+      expect(result.status).toBe(ReservationStatus.CONFIRMED);
+    });
+
+    it('does NOT touch the table for INFORMAL reservations', async () => {
+      prisma.reservation.findUnique.mockResolvedValue({
+        id: reservationId,
+        status: ReservationStatus.PENDING,
+        reservationType: ReservationType.INFORMAL,
+        tableId: null,
+      });
+      prisma.reservation.update.mockResolvedValue({
+        id: reservationId,
+        status: ReservationStatus.CONFIRMED,
+      });
+
+      const result = await service.confirm(reservationId, actorId);
+
+      expect(prisma.$transaction).not.toHaveBeenCalled();
+      expect(prisma.reservation.update).toHaveBeenCalledWith({
+        where: { id: reservationId },
+        data: { status: ReservationStatus.CONFIRMED },
+      });
+      expect(result.status).toBe(ReservationStatus.CONFIRMED);
+    });
+
+    it('throws BadRequestException if the reservation is not PENDING', async () => {
+      prisma.reservation.findUnique.mockResolvedValue({
+        id: reservationId,
+        status: ReservationStatus.CONFIRMED,
+        reservationType: ReservationType.INFORMAL,
+      });
+
+      await expect(service.confirm(reservationId, actorId)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('throws NotFoundException if the reservation does not exist', async () => {
+      prisma.reservation.findUnique.mockResolvedValue(null);
+
+      await expect(service.confirm(reservationId, actorId)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('seat', () => {
+    it('WITH_PREORDER: links the existing order to the table and sets it OCCUPIED', async () => {
+      prisma.reservation.findUnique.mockResolvedValue({
+        id: reservationId,
+        status: ReservationStatus.CONFIRMED,
+        reservationType: ReservationType.WITH_PREORDER,
+        orderId: 'order-1',
+        tableId,
+      });
+      prisma.table.update.mockResolvedValue({});
+      prisma.reservation.update.mockResolvedValue({});
+      prisma.order.update.mockResolvedValue({
+        id: 'order-1',
+        tableId,
+        items: [],
+      });
+
+      const result = await service.seat(reservationId, {}, actorId);
+
+      expect(prisma.table.update).toHaveBeenCalledWith({
+        where: { id: tableId },
+        data: { status: TableStatus.OCCUPIED },
+      });
+      expect(prisma.reservation.update).toHaveBeenCalledWith({
+        where: { id: reservationId },
+        data: { status: ReservationStatus.SEATED },
+      });
+      expect(prisma.order.update).toHaveBeenCalledWith({
+        where: { id: 'order-1' },
+        data: { tableId },
+        include: { items: true },
+      });
+      expect(ordersService.create).not.toHaveBeenCalled();
+      expect(result.id).toBe('order-1');
+    });
+
+    it('DEPOSIT_ONLY: creates a new (empty) order via OrdersService.create and links it, WITHOUT applying the discount yet', async () => {
+      prisma.reservation.findUnique.mockResolvedValue({
+        id: reservationId,
+        status: ReservationStatus.CONFIRMED,
+        reservationType: ReservationType.DEPOSIT_ONLY,
+        tableId,
+        depositCents: 1000,
+      });
+      // Order is created empty — no pre-order for DEPOSIT_ONLY — so its
+      // subtotal is $0 right now. Applying a FIXED discount larger than a
+      // $0 subtotal would be rejected by OrdersService.applyDiscount()'s
+      // shared "discount cannot exceed subtotal" guard (which must NOT be
+      // weakened for this flow), so the deposit is deliberately not
+      // auto-applied here.
+      ordersService.create.mockResolvedValue({ id: 'order-2', items: [] });
+
+      const result = await service.seat(reservationId, {}, actorId);
+
+      expect(ordersService.create).toHaveBeenCalledWith({
+        type: OrderType.DINE_IN,
+        tableId,
+        items: [],
+      });
+      expect(prisma.reservation.update).toHaveBeenCalledWith({
+        where: { id: reservationId },
+        data: { orderId: 'order-2', status: ReservationStatus.SEATED },
+      });
+      expect(ordersService.applyDiscount).not.toHaveBeenCalled();
+      expect(result.id).toBe('order-2');
+    });
+
+    it('DEPOSIT_ONLY: auto-applies the deposit discount once the order already has items (subtotalCents > 0)', async () => {
+      prisma.reservation.findUnique.mockResolvedValue({
+        id: reservationId,
+        status: ReservationStatus.CONFIRMED,
+        reservationType: ReservationType.DEPOSIT_ONLY,
+        tableId,
+        depositCents: 1000,
+      });
+      ordersService.create.mockResolvedValue({
+        id: 'order-2',
+        items: [{ priceCents: 5000, quantity: 1 }],
+      });
+      ordersService.applyDiscount.mockResolvedValue({
+        id: 'order-2',
+        discountCents: 1000,
+      });
+
+      const result = await service.seat(reservationId, {}, actorId);
+
+      expect(ordersService.applyDiscount).toHaveBeenCalledWith(
+        'order-2',
+        {
+          discountType: DiscountType.FIXED,
+          discountCents: 1000,
+          reason: 'Reservation deposit applied',
+        },
+        actorId,
+      );
+      expect(result.discountCents).toBe(1000);
+    });
+
+    it('DEPOSIT_ONLY: skips discount application when depositCents is 0, even if the order has items', async () => {
+      prisma.reservation.findUnique.mockResolvedValue({
+        id: reservationId,
+        status: ReservationStatus.CONFIRMED,
+        reservationType: ReservationType.DEPOSIT_ONLY,
+        tableId,
+        depositCents: 0,
+      });
+      ordersService.create.mockResolvedValue({
+        id: 'order-2',
+        items: [{ priceCents: 5000, quantity: 1 }],
+      });
+
+      await service.seat(reservationId, {}, actorId);
+
+      expect(ordersService.applyDiscount).not.toHaveBeenCalled();
+    });
+
+    it('INFORMAL: requires a staff-chosen tableId in the request body', async () => {
+      prisma.reservation.findUnique.mockResolvedValue({
+        id: reservationId,
+        status: ReservationStatus.CONFIRMED,
+        reservationType: ReservationType.INFORMAL,
+        tableId: null,
+      });
+
+      await expect(service.seat(reservationId, {}, actorId)).rejects.toThrow(
+        BadRequestException,
+      );
+      expect(ordersService.create).not.toHaveBeenCalled();
+    });
+
+    it('INFORMAL: creates the order on the staff-chosen table and links it', async () => {
+      prisma.reservation.findUnique.mockResolvedValue({
+        id: reservationId,
+        status: ReservationStatus.CONFIRMED,
+        reservationType: ReservationType.INFORMAL,
+        tableId: null,
+      });
+      ordersService.create.mockResolvedValue({ id: 'order-3', items: [] });
+
+      const result = await service.seat(
+        reservationId,
+        { tableId: 'table-9' },
+        actorId,
+      );
+
+      expect(ordersService.create).toHaveBeenCalledWith({
+        type: OrderType.DINE_IN,
+        tableId: 'table-9',
+        items: [],
+      });
+      expect(prisma.reservation.update).toHaveBeenCalledWith({
+        where: { id: reservationId },
+        data: {
+          tableId: 'table-9',
+          orderId: 'order-3',
+          status: ReservationStatus.SEATED,
+        },
+      });
+      expect(ordersService.applyDiscount).not.toHaveBeenCalled();
+      expect(result.id).toBe('order-3');
+    });
+
+    it('throws BadRequestException if the reservation is not CONFIRMED', async () => {
+      prisma.reservation.findUnique.mockResolvedValue({
+        id: reservationId,
+        status: ReservationStatus.PENDING,
+        reservationType: ReservationType.INFORMAL,
+      });
+
+      await expect(
+        service.seat(reservationId, { tableId: 'table-9' }, actorId),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('noShow / cancel', () => {
+    it('noShow releases a RESERVED table back to AVAILABLE and does not touch the deposit', async () => {
+      prisma.reservation.findUnique.mockResolvedValue({
+        id: reservationId,
+        status: ReservationStatus.CONFIRMED,
+        tableId,
+        depositCents: 1000,
+      });
+      const txTableFindUnique = jest
+        .fn()
+        .mockResolvedValue({ id: tableId, status: TableStatus.RESERVED });
+      const txTableUpdate = jest.fn().mockResolvedValue({});
+      const txReservationUpdate = jest.fn().mockResolvedValue({
+        id: reservationId,
+        status: ReservationStatus.NO_SHOW,
+      });
+      prisma.$transaction.mockImplementationOnce((cb) =>
+        cb({
+          table: { findUnique: txTableFindUnique, update: txTableUpdate },
+          reservation: { update: txReservationUpdate },
+        }),
+      );
+
+      const result = await service.noShow(reservationId);
+
+      expect(txTableUpdate).toHaveBeenCalledWith({
+        where: { id: tableId },
+        data: { status: TableStatus.AVAILABLE },
+      });
+      expect(txReservationUpdate).toHaveBeenCalledWith({
+        where: { id: reservationId },
+        data: { status: ReservationStatus.NO_SHOW },
+      });
+      expect(result.status).toBe(ReservationStatus.NO_SHOW);
+      // Deposit is left untouched — forfeited, not refunded/reapplied.
+      expect(ordersService.applyDiscount).not.toHaveBeenCalled();
+    });
+
+    it('cancel releases the table only if it is currently RESERVED', async () => {
+      prisma.reservation.findUnique.mockResolvedValue({
+        id: reservationId,
+        status: ReservationStatus.PENDING,
+        tableId,
+        depositCents: 0,
+      });
+      const txTableFindUnique = jest
+        .fn()
+        .mockResolvedValue({ id: tableId, status: TableStatus.AVAILABLE });
+      const txTableUpdate = jest.fn().mockResolvedValue({});
+      const txReservationUpdate = jest.fn().mockResolvedValue({
+        id: reservationId,
+        status: ReservationStatus.CANCELLED,
+      });
+      prisma.$transaction.mockImplementationOnce((cb) =>
+        cb({
+          table: { findUnique: txTableFindUnique, update: txTableUpdate },
+          reservation: { update: txReservationUpdate },
+        }),
+      );
+
+      await service.cancel(reservationId);
+
+      // Table was still AVAILABLE (deposit never confirmed) — nothing to release.
+      expect(txTableUpdate).not.toHaveBeenCalled();
+    });
+
+    it('rejects cancelling a reservation that is already SEATED/terminal', async () => {
+      prisma.reservation.findUnique.mockResolvedValue({
+        id: reservationId,
+        status: ReservationStatus.SEATED,
+        tableId,
+      });
+
+      await expect(service.cancel(reservationId)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+  });
+});

--- a/src/reservations/reservations.service.ts
+++ b/src/reservations/reservations.service.ts
@@ -1,0 +1,364 @@
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import {
+  DiscountType,
+  OrderType,
+  Prisma,
+  ReservationStatus,
+  ReservationType,
+  TableStatus,
+} from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateOrderDto } from '../orders/dto/create-order.dto';
+import { OrdersService } from '../orders/orders.service';
+import { CreateReservationDto } from './dto/create-reservation.dto';
+import { ListReservationsQueryDto } from './dto/list-reservations-query.dto';
+import { SeatReservationDto } from './dto/seat-reservation.dto';
+
+// Only PENDING/CONFIRMED reservations can still be confirmed, seated,
+// cancelled, or marked as a no-show — anything terminal (SEATED, NO_SHOW,
+// CANCELLED) is final.
+const TERMINABLE_STATUSES: ReservationStatus[] = [
+  ReservationStatus.PENDING,
+  ReservationStatus.CONFIRMED,
+];
+
+// Reservations with more money already committed (a pre-order or a
+// deposit) reasonably get more patience before staff decide on a
+// no-show. Purely a DEFAULT — staff can always override with any value
+// at creation time, with no min/max restriction beyond the DTO's base
+// validation.
+const DEFAULT_TOLERANCE_BY_TYPE: Record<ReservationType, number> = {
+  [ReservationType.INFORMAL]: 10,
+  [ReservationType.DEPOSIT_ONLY]: 20,
+  [ReservationType.WITH_PREORDER]: 30,
+};
+
+@Injectable()
+export class ReservationsService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly ordersService: OrdersService,
+    private readonly config: ConfigService,
+  ) {}
+
+  async create(dto: CreateReservationDto, actorId: string) {
+    if (dto.reservationType === ReservationType.INFORMAL) {
+      if (dto.tableId || dto.items) {
+        throw new BadRequestException(
+          'tableId and items are not allowed for INFORMAL reservations',
+        );
+      }
+      return this.prisma.reservation.create({
+        data: this.baseReservationData(dto, actorId),
+      });
+    }
+
+    // WITH_PREORDER and DEPOSIT_ONLY both commit a specific table once the
+    // deposit is confirmed later — but the table stays AVAILABLE right now.
+    const table = await this.prisma.table.findUnique({
+      where: { id: dto.tableId },
+    });
+    if (!table) {
+      throw new NotFoundException('Table not found');
+    }
+    if (table.status !== TableStatus.AVAILABLE) {
+      throw new BadRequestException(
+        `Table is ${table.status} and cannot be reserved`,
+      );
+    }
+
+    let orderId: string | null = null;
+    let depositCents: number;
+
+    if (dto.reservationType === ReservationType.WITH_PREORDER) {
+      // Reuse OrdersService.create() entirely (price-snapshot logic lives
+      // there) — pass type TAKEAWAY so no table gets committed yet; the
+      // Reservation's own `tableId` tracks the desired table separately.
+      const order = await this.ordersService.create({
+        type: OrderType.TAKEAWAY,
+        items: dto.items,
+      } as CreateOrderDto);
+      orderId = order.id;
+      depositCents = Math.floor(order.totalCents / 2);
+    } else {
+      if (dto.items) {
+        throw new BadRequestException(
+          'items are not allowed for DEPOSIT_ONLY reservations',
+        );
+      }
+      depositCents =
+        this.config.get<number>('reservations.depositCents') ?? 1000;
+    }
+
+    return this.prisma.reservation.create({
+      data: {
+        ...this.baseReservationData(dto, actorId),
+        tableId: dto.tableId,
+        orderId,
+        depositCents,
+      },
+    });
+  }
+
+  async findAll(query: ListReservationsQueryDto) {
+    const where: Prisma.ReservationWhereInput = {};
+    if (query.status) {
+      where.status = query.status;
+    }
+    if (query.date) {
+      const start = new Date(`${query.date}T00:00:00.000Z`);
+      const end = new Date(start.getTime() + 24 * 60 * 60 * 1000);
+      where.reservedFor = { gte: start, lt: end };
+    }
+
+    return this.prisma.reservation.findMany({
+      where,
+      skip: query.skip,
+      take: query.limit,
+      orderBy: { reservedFor: 'asc' },
+    });
+  }
+
+  async findOne(id: string) {
+    const reservation = await this.prisma.reservation.findUnique({
+      where: { id },
+    });
+    if (!reservation) {
+      throw new NotFoundException('Reservation not found');
+    }
+    return reservation;
+  }
+
+  async confirm(id: string, actorId: string) {
+    const reservation = await this.findOne(id);
+    if (reservation.status !== ReservationStatus.PENDING) {
+      throw new BadRequestException(
+        `Cannot confirm a reservation with status ${reservation.status}`,
+      );
+    }
+
+    if (reservation.reservationType === ReservationType.INFORMAL) {
+      return this.prisma.reservation.update({
+        where: { id },
+        data: { status: ReservationStatus.CONFIRMED },
+      });
+    }
+
+    // WITH_PREORDER / DEPOSIT_ONLY: the deposit has just been confirmed
+    // received by staff — this is the moment the table is actually
+    // committed (AVAILABLE -> RESERVED).
+    return this.prisma.$transaction(async (tx) => {
+      if (reservation.tableId) {
+        await tx.table.update({
+          where: { id: reservation.tableId },
+          data: { status: TableStatus.RESERVED },
+        });
+      }
+      return tx.reservation.update({
+        where: { id },
+        data: {
+          status: ReservationStatus.CONFIRMED,
+          depositConfirmedBy: actorId,
+          depositConfirmedAt: new Date(),
+        },
+      });
+    });
+  }
+
+  async seat(id: string, dto: SeatReservationDto, actorId: string) {
+    const reservation = await this.findOne(id);
+    if (reservation.status !== ReservationStatus.CONFIRMED) {
+      throw new BadRequestException(
+        `Reservation must be CONFIRMED before seating (current: ${reservation.status})`,
+      );
+    }
+
+    switch (reservation.reservationType) {
+      case ReservationType.WITH_PREORDER:
+        return this.seatWithPreorder(reservation);
+      case ReservationType.DEPOSIT_ONLY:
+        return this.seatDepositOnly(reservation, actorId);
+      case ReservationType.INFORMAL:
+        return this.seatInformal(reservation, dto);
+      default:
+        throw new BadRequestException('Unknown reservation type');
+    }
+  }
+
+  private async seatWithPreorder(reservation: {
+    id: string;
+    orderId: string | null;
+    tableId: string | null;
+  }) {
+    if (!reservation.orderId || !reservation.tableId) {
+      throw new BadRequestException(
+        'Reservation is missing its pre-order or table',
+      );
+    }
+
+    const [, , order] = await this.prisma.$transaction([
+      this.prisma.table.update({
+        where: { id: reservation.tableId },
+        data: { status: TableStatus.OCCUPIED },
+      }),
+      this.prisma.reservation.update({
+        where: { id: reservation.id },
+        data: { status: ReservationStatus.SEATED },
+      }),
+      this.prisma.order.update({
+        where: { id: reservation.orderId },
+        data: { tableId: reservation.tableId },
+        include: { items: true },
+      }),
+    ]);
+
+    return order;
+  }
+
+  private async seatDepositOnly(
+    reservation: {
+      id: string;
+      tableId: string | null;
+      depositCents: number;
+    },
+    actorId: string,
+  ) {
+    if (!reservation.tableId) {
+      throw new BadRequestException('Reservation has no table assigned');
+    }
+
+    // Reuses OrdersService.create()'s existing table-occupied-check logic
+    // (throws if the table went away, sets it OCCUPIED in one transaction).
+    const order = await this.ordersService.create({
+      type: OrderType.DINE_IN,
+      tableId: reservation.tableId,
+      items: [],
+    } as CreateOrderDto);
+
+    await this.prisma.reservation.update({
+      where: { id: reservation.id },
+      data: { orderId: order.id, status: ReservationStatus.SEATED },
+    });
+
+    // The order is created empty (DEPOSIT_ONLY has no pre-order), so its
+    // subtotal is $0 right now. OrdersService.applyDiscount() enforces a
+    // shared, non-negotiable safety rule ("discount cannot exceed
+    // subtotal") used by every consumer of discounts across the app — we
+    // must not weaken it just for this flow. So the deposit is only
+    // auto-applied once the order actually has items (subtotalCents > 0);
+    // otherwise it isn't reflected as a discount yet. Staff can apply it
+    // manually later via the existing PATCH /orders/:id/discount endpoint
+    // (using this reservation's depositCents) once food has been ordered.
+    const subtotalCents = (order.items ?? []).reduce(
+      (sum: number, item: { priceCents: number; quantity: number }) =>
+        sum + item.priceCents * item.quantity,
+      0,
+    );
+
+    if (reservation.depositCents > 0 && subtotalCents > 0) {
+      // Reuses the existing discount mechanism (validation + audit trail)
+      // rather than a bespoke deposit-application code path.
+      return this.ordersService.applyDiscount(
+        order.id,
+        {
+          discountType: DiscountType.FIXED,
+          discountCents: reservation.depositCents,
+          reason: 'Reservation deposit applied',
+        },
+        actorId,
+      );
+    }
+
+    return order;
+  }
+
+  private async seatInformal(
+    reservation: { id: string },
+    dto: SeatReservationDto,
+  ) {
+    if (!dto.tableId) {
+      throw new BadRequestException(
+        'tableId is required to seat an INFORMAL reservation',
+      );
+    }
+
+    const order = await this.ordersService.create({
+      type: OrderType.DINE_IN,
+      tableId: dto.tableId,
+      items: [],
+    } as CreateOrderDto);
+
+    await this.prisma.reservation.update({
+      where: { id: reservation.id },
+      data: {
+        tableId: dto.tableId,
+        orderId: order.id,
+        status: ReservationStatus.SEATED,
+      },
+    });
+
+    return order;
+  }
+
+  async noShow(id: string) {
+    return this.terminate(id, ReservationStatus.NO_SHOW);
+  }
+
+  async cancel(id: string) {
+    return this.terminate(id, ReservationStatus.CANCELLED);
+  }
+
+  // Deposits (if any) are intentionally NOT refunded or reapplied here —
+  // they're simply forfeited, left as a historical record on the row.
+  private async terminate(id: string, nextStatus: ReservationStatus) {
+    const reservation = await this.findOne(id);
+    if (!TERMINABLE_STATUSES.includes(reservation.status)) {
+      throw new BadRequestException(
+        `Cannot mark reservation as ${nextStatus} from status ${reservation.status}`,
+      );
+    }
+
+    return this.prisma.$transaction(async (tx) => {
+      if (reservation.tableId) {
+        const table = await tx.table.findUnique({
+          where: { id: reservation.tableId },
+        });
+        if (table?.status === TableStatus.RESERVED) {
+          await tx.table.update({
+            where: { id: reservation.tableId },
+            data: { status: TableStatus.AVAILABLE },
+          });
+        }
+      }
+      return tx.reservation.update({
+        where: { id },
+        data: { status: nextStatus },
+      });
+    });
+  }
+
+  private baseReservationData(
+    dto: CreateReservationDto,
+    actorId: string,
+  ): Prisma.ReservationUncheckedCreateInput {
+    return {
+      customerName: dto.customerName,
+      customerPhone: dto.customerPhone,
+      customerEmail: dto.customerEmail,
+      partySize: dto.partySize,
+      reservedFor: new Date(dto.reservedFor),
+      toleranceMinutes:
+        dto.toleranceMinutes ?? DEFAULT_TOLERANCE_BY_TYPE[dto.reservationType],
+      allergies: dto.allergies,
+      specialOccasion: dto.specialOccasion,
+      reservationType: dto.reservationType,
+      status: ReservationStatus.PENDING,
+      createdBy: actorId,
+    };
+  }
+}

--- a/test/reservations.e2e-spec.ts
+++ b/test/reservations.e2e-spec.ts
@@ -1,0 +1,484 @@
+import { ValidationPipe, INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import request from 'supertest';
+import { AppModule } from '../src/app.module';
+
+// Covers the Reservations feature end-to-end: DEPOSIT_ONLY (the most
+// complete case — deposit confirmation, table commitment, discount
+// application, checkout release) and INFORMAL (no table/deposit until
+// the customer actually arrives).
+describe('Reservations (e2e)', () => {
+  let app: INestApplication;
+  let adminToken: string;
+  let cashierToken: string;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication({ rawBody: true });
+    app.setGlobalPrefix('api', { exclude: ['health'] });
+    app.useGlobalPipes(
+      new ValidationPipe({ whitelist: true, transform: true }),
+    );
+    await app.init();
+
+    const adminLogin = await request(app.getHttpServer())
+      .post('/api/auth/login')
+      .send({ email: 'admin@restosync.local', password: 'Admin123!' })
+      .expect(200);
+    adminToken = adminLogin.body.accessToken;
+
+    const cashierLogin = await request(app.getHttpServer())
+      .post('/api/auth/login')
+      .send({ email: 'cashier@restosync.local', password: 'Cashier123!' })
+      .expect(200);
+    cashierToken = cashierLogin.body.accessToken;
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe('DEPOSIT_ONLY: create -> confirm -> seat -> checkout -> table released', () => {
+    let tableId: string;
+    let reservationId: string;
+    let orderId: string;
+    let burgerId: string;
+    const DEPOSIT_CENTS = 1000; // default RESERVATION_DEPOSIT_CENTS
+
+    beforeAll(async () => {
+      const table = await request(app.getHttpServer())
+        .post('/api/tables')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ name: `Deposit_${Date.now()}` })
+        .expect(201);
+      tableId = table.body.id;
+
+      const category = await request(app.getHttpServer())
+        .post('/api/menu/categories')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ name: `ReservationDeposit_${Date.now()}` })
+        .expect(201);
+
+      const burger = await request(app.getHttpServer())
+        .post('/api/menu/items')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({
+          name: 'Reservation Deposit Burger',
+          priceCents: 5000,
+          categoryId: category.body.id,
+        })
+        .expect(201);
+      burgerId = burger.body.id;
+
+      // Clean up any register session left open by a previous test run.
+      await request(app.getHttpServer())
+        .post('/api/cash-register/close')
+        .set('Authorization', `Bearer ${cashierToken}`)
+        .send({ countedCents: 0 });
+
+      await request(app.getHttpServer())
+        .post('/api/cash-register/open')
+        .set('Authorization', `Bearer ${cashierToken}`)
+        .send({ openingFloatCents: 0 })
+        .expect(201);
+    });
+
+    it('rejects reservation creation from a WAITER-equivalent/non-cashier role', async () => {
+      // CUSTOMER role definitely lacks CASHIER/MANAGER/ADMIN — used here as
+      // a stand-in for "not staff allowed to take reservations".
+      const email = `resv_customer_${Date.now()}@example.com`;
+      const register = await request(app.getHttpServer())
+        .post('/api/auth/register')
+        .send({ email, password: 'Secret123!', firstName: 'Test' })
+        .expect(201);
+
+      await request(app.getHttpServer())
+        .post('/api/reservations')
+        .set('Authorization', `Bearer ${register.body.accessToken}`)
+        .send({
+          customerName: 'Jane Doe',
+          customerPhone: '+51999999999',
+          partySize: 2,
+          reservedFor: '2026-08-01T20:00:00.000Z',
+          reservationType: 'DEPOSIT_ONLY',
+          tableId,
+        })
+        .expect(403);
+    });
+
+    it('POST /api/reservations creates a PENDING DEPOSIT_ONLY reservation with the configured fixed deposit', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/api/reservations')
+        .set('Authorization', `Bearer ${cashierToken}`)
+        .send({
+          customerName: 'Jane Doe',
+          customerPhone: '+51999999999',
+          partySize: 2,
+          reservedFor: '2026-08-01T20:00:00.000Z',
+          reservationType: 'DEPOSIT_ONLY',
+          tableId,
+        })
+        .expect(201);
+
+      expect(res.body.status).toBe('PENDING');
+      expect(res.body.depositCents).toBe(DEPOSIT_CENTS);
+      expect(res.body.orderId).toBeNull();
+      reservationId = res.body.id;
+
+      // Table is NOT committed yet — stays AVAILABLE until deposit confirmed.
+      const table = await request(app.getHttpServer())
+        .get(`/api/tables/${tableId}`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .expect(200);
+      expect(table.body.status).toBe('AVAILABLE');
+    });
+
+    it('PATCH /api/reservations/:id/confirm marks the deposit confirmed and commits the table to RESERVED', async () => {
+      const res = await request(app.getHttpServer())
+        .patch(`/api/reservations/${reservationId}/confirm`)
+        .set('Authorization', `Bearer ${cashierToken}`)
+        .expect(200);
+
+      expect(res.body.status).toBe('CONFIRMED');
+      expect(res.body.depositConfirmedBy).toBeDefined();
+      expect(res.body.depositConfirmedAt).toBeDefined();
+
+      const table = await request(app.getHttpServer())
+        .get(`/api/tables/${tableId}`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .expect(200);
+      expect(table.body.status).toBe('RESERVED');
+    });
+
+    it('POST /api/reservations/:id/seat creates the (still-empty) order and sets the table OCCUPIED, WITHOUT applying the deposit discount yet', async () => {
+      const res = await request(app.getHttpServer())
+        .post(`/api/reservations/${reservationId}/seat`)
+        .set('Authorization', `Bearer ${cashierToken}`)
+        .send({})
+        .expect(201);
+
+      // The order is created empty (no pre-order for DEPOSIT_ONLY), so the
+      // deposit is deliberately NOT auto-applied as a discount yet — doing
+      // so on a $0 subtotal would trip OrdersService.applyDiscount()'s
+      // "discount cannot exceed subtotal" guard, which must stay intact.
+      expect(res.body.discountCents).toBe(0);
+      orderId = res.body.id;
+
+      const table = await request(app.getHttpServer())
+        .get(`/api/tables/${tableId}`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .expect(200);
+      expect(table.body.status).toBe('OCCUPIED');
+      expect(table.body.activeOrder.id).toBe(orderId);
+
+      const reservation = await request(app.getHttpServer())
+        .get(`/api/reservations/${reservationId}`)
+        .set('Authorization', `Bearer ${cashierToken}`)
+        .expect(200);
+      expect(reservation.body.status).toBe('SEATED');
+      expect(reservation.body.orderId).toBe(orderId);
+    });
+
+    it('adds the pre-agreed items, staff manually applies the deposit discount, then confirms/checks out, releasing the table', async () => {
+      const withItem = await request(app.getHttpServer())
+        .post(`/api/orders/${orderId}/items`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ menuItemId: burgerId, quantity: 1 })
+        .expect(201);
+
+      expect(withItem.body.totalCents).toBe(5000);
+
+      // Now that the order has a non-zero subtotal, staff can apply the
+      // reservation's deposit as a discount via the existing, unmodified
+      // discount endpoint (same guard as any other order in the app).
+      const withDiscount = await request(app.getHttpServer())
+        .patch(`/api/orders/${orderId}/discount`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({
+          discountType: 'FIXED',
+          discountCents: DEPOSIT_CENTS,
+          reason: 'Reservation deposit applied',
+        })
+        .expect(200);
+
+      // subtotal 5000 - discount 1000 (deposit) = 4000
+      expect(withDiscount.body.totalCents).toBe(4000);
+      expect(withDiscount.body.discountCents).toBe(DEPOSIT_CENTS);
+
+      await request(app.getHttpServer())
+        .post(`/api/orders/${orderId}/confirm`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .expect(201);
+
+      const checkout = await request(app.getHttpServer())
+        .post('/api/payments/checkout')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ orderId, method: 'CASH', amountPaidCents: 4000 })
+        .expect(201);
+      expect(checkout.body.order.status).toBe('CONFIRMED');
+      expect(checkout.body.amountCents).toBe(4000);
+
+      const table = await request(app.getHttpServer())
+        .get(`/api/tables/${tableId}`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .expect(200);
+      expect(table.body.status).toBe('AVAILABLE');
+    });
+
+    it('confirms the "discount cannot exceed subtotal" guard is still enforced (regression check for the applyDiscount revert)', async () => {
+      const category = await request(app.getHttpServer())
+        .post('/api/menu/categories')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ name: `GuardCheck_${Date.now()}` })
+        .expect(201);
+
+      const cheapItem = await request(app.getHttpServer())
+        .post('/api/menu/items')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({
+          name: 'Guard Check Item',
+          priceCents: 500,
+          categoryId: category.body.id,
+        })
+        .expect(201);
+
+      const table = await request(app.getHttpServer())
+        .post('/api/tables')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ name: `GuardCheck_${Date.now()}` })
+        .expect(201);
+
+      const order = await request(app.getHttpServer())
+        .post('/api/orders')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({
+          type: 'DINE_IN',
+          tableId: table.body.id,
+          items: [{ menuItemId: cheapItem.body.id, quantity: 1 }],
+        })
+        .expect(201);
+      expect(order.body.totalCents).toBe(500);
+
+      const res = await request(app.getHttpServer())
+        .patch(`/api/orders/${order.body.id}/discount`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({
+          discountType: 'FIXED',
+          discountCents: 10000,
+          reason: 'too much',
+        })
+        .expect(400);
+
+      expect(res.body.message).toMatch(/cannot exceed order subtotal/i);
+    });
+
+    afterAll(async () => {
+      await request(app.getHttpServer())
+        .post('/api/cash-register/close')
+        .set('Authorization', `Bearer ${cashierToken}`)
+        .send({ countedCents: 4000 });
+    });
+  });
+
+  describe('INFORMAL: create -> confirm -> seat with staff-chosen table -> no discount', () => {
+    let reservationId: string;
+    let tableId: string;
+
+    it('POST /api/reservations rejects tableId/items for INFORMAL', async () => {
+      await request(app.getHttpServer())
+        .post('/api/reservations')
+        .set('Authorization', `Bearer ${cashierToken}`)
+        .send({
+          customerName: 'Informal Guest',
+          customerPhone: '+51988888888',
+          partySize: 3,
+          reservedFor: '2026-08-02T19:00:00.000Z',
+          reservationType: 'INFORMAL',
+          tableId: '00000000-0000-4000-8000-000000000000',
+        })
+        .expect(400);
+    });
+
+    it('POST /api/reservations creates a PENDING INFORMAL reservation with no table/order/deposit', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/api/reservations')
+        .set('Authorization', `Bearer ${cashierToken}`)
+        .send({
+          customerName: 'Informal Guest',
+          customerPhone: '+51988888888',
+          partySize: 3,
+          reservedFor: '2026-08-02T19:00:00.000Z',
+          reservationType: 'INFORMAL',
+        })
+        .expect(201);
+
+      expect(res.body.status).toBe('PENDING');
+      expect(res.body.depositCents).toBe(0);
+      expect(res.body.tableId).toBeNull();
+      expect(res.body.orderId).toBeNull();
+      reservationId = res.body.id;
+    });
+
+    it('PATCH /api/reservations/:id/confirm does not touch any table', async () => {
+      const res = await request(app.getHttpServer())
+        .patch(`/api/reservations/${reservationId}/confirm`)
+        .set('Authorization', `Bearer ${cashierToken}`)
+        .expect(200);
+
+      expect(res.body.status).toBe('CONFIRMED');
+    });
+
+    it('POST /api/reservations/:id/seat requires a staff-chosen tableId', async () => {
+      await request(app.getHttpServer())
+        .post(`/api/reservations/${reservationId}/seat`)
+        .set('Authorization', `Bearer ${cashierToken}`)
+        .send({})
+        .expect(400);
+    });
+
+    it('POST /api/reservations/:id/seat with tableId creates the order with no discount applied', async () => {
+      const table = await request(app.getHttpServer())
+        .post('/api/tables')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ name: `Informal_${Date.now()}` })
+        .expect(201);
+      tableId = table.body.id;
+
+      const res = await request(app.getHttpServer())
+        .post(`/api/reservations/${reservationId}/seat`)
+        .set('Authorization', `Bearer ${cashierToken}`)
+        .send({ tableId })
+        .expect(201);
+
+      expect(res.body.discountCents).toBe(0);
+
+      const table2 = await request(app.getHttpServer())
+        .get(`/api/tables/${tableId}`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .expect(200);
+      expect(table2.body.status).toBe('OCCUPIED');
+
+      const reservation = await request(app.getHttpServer())
+        .get(`/api/reservations/${reservationId}`)
+        .set('Authorization', `Bearer ${cashierToken}`)
+        .expect(200);
+      expect(reservation.body.status).toBe('SEATED');
+      expect(reservation.body.tableId).toBe(tableId);
+    });
+  });
+
+  describe('no-show / cancel release the table without reapplying the deposit', () => {
+    it('no-show releases a RESERVED table back to AVAILABLE', async () => {
+      const table = await request(app.getHttpServer())
+        .post('/api/tables')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ name: `NoShow_${Date.now()}` })
+        .expect(201);
+
+      const reservation = await request(app.getHttpServer())
+        .post('/api/reservations')
+        .set('Authorization', `Bearer ${cashierToken}`)
+        .send({
+          customerName: 'No Show Guest',
+          customerPhone: '+51977777777',
+          partySize: 2,
+          reservedFor: '2026-08-03T19:00:00.000Z',
+          reservationType: 'DEPOSIT_ONLY',
+          tableId: table.body.id,
+        })
+        .expect(201);
+
+      await request(app.getHttpServer())
+        .patch(`/api/reservations/${reservation.body.id}/confirm`)
+        .set('Authorization', `Bearer ${cashierToken}`)
+        .expect(200);
+
+      const reservedTable = await request(app.getHttpServer())
+        .get(`/api/tables/${table.body.id}`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .expect(200);
+      expect(reservedTable.body.status).toBe('RESERVED');
+
+      const noShow = await request(app.getHttpServer())
+        .patch(`/api/reservations/${reservation.body.id}/no-show`)
+        .set('Authorization', `Bearer ${cashierToken}`)
+        .expect(200);
+      expect(noShow.body.status).toBe('NO_SHOW');
+
+      const releasedTable = await request(app.getHttpServer())
+        .get(`/api/tables/${table.body.id}`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .expect(200);
+      expect(releasedTable.body.status).toBe('AVAILABLE');
+    });
+
+    it('rejects no-show/cancel on an already-terminal reservation', async () => {
+      const table = await request(app.getHttpServer())
+        .post('/api/tables')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ name: `Terminal_${Date.now()}` })
+        .expect(201);
+
+      const reservation = await request(app.getHttpServer())
+        .post('/api/reservations')
+        .set('Authorization', `Bearer ${cashierToken}`)
+        .send({
+          customerName: 'Terminal Guest',
+          customerPhone: '+51966666666',
+          partySize: 2,
+          reservedFor: '2026-08-04T19:00:00.000Z',
+          reservationType: 'DEPOSIT_ONLY',
+          tableId: table.body.id,
+        })
+        .expect(201);
+
+      await request(app.getHttpServer())
+        .patch(`/api/reservations/${reservation.body.id}/cancel`)
+        .set('Authorization', `Bearer ${cashierToken}`)
+        .expect(200);
+
+      await request(app.getHttpServer())
+        .patch(`/api/reservations/${reservation.body.id}/cancel`)
+        .set('Authorization', `Bearer ${cashierToken}`)
+        .expect(400);
+
+      await request(app.getHttpServer())
+        .patch(`/api/reservations/${reservation.body.id}/no-show`)
+        .set('Authorization', `Bearer ${cashierToken}`)
+        .expect(400);
+    });
+  });
+
+  describe('GET /api/reservations filtering', () => {
+    it('filters by status', async () => {
+      const res = await request(app.getHttpServer())
+        .get('/api/reservations')
+        .query({ status: 'SEATED', limit: 100 })
+        .set('Authorization', `Bearer ${cashierToken}`)
+        .expect(200);
+
+      expect(Array.isArray(res.body)).toBe(true);
+      for (const reservation of res.body) {
+        expect(reservation.status).toBe('SEATED');
+      }
+    });
+
+    it('filters by reservedFor date', async () => {
+      const res = await request(app.getHttpServer())
+        .get('/api/reservations')
+        .query({ date: '2026-08-02', limit: 100 })
+        .set('Authorization', `Bearer ${cashierToken}`)
+        .expect(200);
+
+      expect(Array.isArray(res.body)).toBe(true);
+      expect(
+        res.body.every((r: { reservedFor: string }) =>
+          r.reservedFor.startsWith('2026-08-02'),
+        ),
+      ).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Changes
- New Reservation entity + ReservationType/ReservationStatus enums
- Table.status gains RESERVED (between AVAILABLE and OCCUPIED)
- Three reservation flows, validated against a real restaurant's
  WhatsApp reservation workflow:
  - **WITH_PREORDER**: phone pre-order + 50% deposit, table committed
    on deposit confirmation
  - **DEPOSIT_ONLY**: fixed deposit (RESERVATION_DEPOSIT_CENTS,
    configurable) to hold a table
  - **INFORMAL**: just an estimated arrival time + party size, no
    payment, no table committed until arrival — the most common
    real-world case
- Deposits confirmed manually by staff (no live Stripe integration)
- No-shows always require manual staff action, never automatic
- Type-aware default tolerance before release (INFORMAL: 10min,
  DEPOSIT_ONLY: 20min, WITH_PREORDER: 30min), fully staff-editable

## Design notes
- Reuses OrdersService.create() and applyDiscount() rather than
  duplicating order/discount logic
- Deposit is applied as a discount only once the order has real
  items — deliberately avoids touching applyDiscount()'s shared
  "discount cannot exceed subtotal" guard
- Added --runInBand to test:e2e (general e2e stability fix — several
  spec files share global cash-register session state and were
  racing under parallel workers)

## Tests
140/140 unit, e2e covering full lifecycle for DEPOSIT_ONLY and
INFORMAL, no-show/cancel release, list filtering, and a regression
test confirming the discount-subtotal guard still rejects
over-subtotal discounts on normal orders.