### PR TITLE
fix: interpret Reservation.reservedFor as restaurant-local time

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,3 +28,8 @@ STRIPE_BILLING_WEBHOOK_SECRET=whsec_billing_xxx
 # REQUIRED in production — the app will not start without this set.
 # Optional in development/test (defaults to 0).
 TAX_RATE=
+
+# RESTAURANT_TIMEZONE — IANA timezone used to interpret
+# Reservation.reservedFor (a naive local datetime with no Z/offset
+# suffix) and to display it back. Optional — defaults to America/Lima.
+RESTAURANT_TIMEZONE=America/Lima

--- a/src/common/utils/local-time.spec.ts
+++ b/src/common/utils/local-time.spec.ts
@@ -1,0 +1,40 @@
+import { localToUtc, utcToLocalDisplay } from './local-time';
+
+describe('localToUtc', () => {
+  it('converts a known America/Lima local time to the correct UTC value (fixed UTC-5, no DST)', () => {
+    const result = localToUtc('2026-07-18T14:00:00', 'America/Lima');
+    expect(result.toISOString()).toBe('2026-07-18T19:00:00.000Z');
+  });
+
+  it('works correctly for a DST timezone (America/New_York) in summer (EDT, UTC-4)', () => {
+    // July is EDT (UTC-4) in New York.
+    const result = localToUtc('2026-07-18T14:00:00', 'America/New_York');
+    expect(result.toISOString()).toBe('2026-07-18T18:00:00.000Z');
+  });
+
+  it('works correctly for a DST timezone (America/New_York) in winter (EST, UTC-5)', () => {
+    // January is EST (UTC-5) in New York.
+    const result = localToUtc('2026-01-18T14:00:00', 'America/New_York');
+    expect(result.toISOString()).toBe('2026-01-18T19:00:00.000Z');
+  });
+
+  it('accepts a datetime string without seconds', () => {
+    const result = localToUtc('2026-07-18T14:00', 'America/Lima');
+    expect(result.toISOString()).toBe('2026-07-18T19:00:00.000Z');
+  });
+});
+
+describe('utcToLocalDisplay', () => {
+  it('formats a stored UTC Date back into America/Lima local wall-clock time', () => {
+    const utcDate = new Date('2026-07-18T19:00:00.000Z');
+    expect(utcToLocalDisplay(utcDate, 'America/Lima')).toBe(
+      '2026-07-18T14:00:00',
+    );
+  });
+
+  it('is the inverse of localToUtc for a DST timezone', () => {
+    const local = '2026-07-18T14:00:00';
+    const utc = localToUtc(local, 'America/New_York');
+    expect(utcToLocalDisplay(utc, 'America/New_York')).toBe(local);
+  });
+});

--- a/src/common/utils/local-time.ts
+++ b/src/common/utils/local-time.ts
@@ -1,0 +1,74 @@
+// Scoped fix for Reservation.reservedFor: converts between a "naive"
+// local wall-clock string (no Z/offset suffix — see
+// CreateReservationDto.reservedFor) and the UTC `Date` actually stored in
+// Postgres, using only Node's built-in Intl API (no new npm dependency).
+//
+// Deliberately separate from src/common/utils/timezone.ts (an earlier,
+// unrelated, currently-dormant effort) — do not merge these.
+
+/**
+ * Converts a naive local datetime string (e.g. "2026-07-18T14:00:00", no
+ * timezone suffix) into the corresponding UTC `Date`, interpreting it as
+ * wall-clock time in `timeZone`.
+ *
+ * Technique: first parse the naive string as if it were already UTC (a
+ * "guess"). Then ask Intl what offset `timeZone` actually has at that
+ * instant, and correct the guess by that offset. This converges in one
+ * step for all real-world IANA timezones (including DST transitions),
+ * since offsets change at most once around any given instant and the
+ * guess is already within the same day.
+ */
+export function localToUtc(localDateTimeStr: string, timeZone: string): Date {
+  const guessUtc = new Date(`${localDateTimeStr}Z`);
+  const offsetMinutes = getOffsetMinutesAt(guessUtc, timeZone);
+  return new Date(guessUtc.getTime() - offsetMinutes * 60 * 1000);
+}
+
+/**
+ * Formats a UTC `Date` (as stored in the DB) back into a naive local
+ * datetime string (no timezone suffix), representing wall-clock time in
+ * `timeZone`. Purely a display convenience — never persisted.
+ */
+export function utcToLocalDisplay(date: Date, timeZone: string): string {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  }).formatToParts(date);
+
+  const get = (type: string) =>
+    parts.find((p) => p.type === type)?.value ?? '00';
+
+  // Intl can format hour '24' at midnight for hour12: false in some
+  // environments — normalize to '00'.
+  const hour = get('hour') === '24' ? '00' : get('hour');
+
+  return `${get('year')}-${get('month')}-${get('day')}T${hour}:${get(
+    'minute',
+  )}:${get('second')}`;
+}
+
+// Returns the UTC offset (in minutes, positive = ahead of UTC) that
+// `timeZone` observes at the given instant.
+function getOffsetMinutesAt(instant: Date, timeZone: string): number {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    timeZoneName: 'longOffset',
+  }).formatToParts(instant);
+
+  const offsetStr = parts.find((p) => p.type === 'timeZoneName')?.value;
+  if (!offsetStr) return 0;
+
+  const match = offsetStr.match(/GMT([+-])(\d{1,2})(?::(\d{2}))?/);
+  if (!match) return 0;
+
+  const sign = match[1] === '-' ? -1 : 1;
+  const hours = parseInt(match[2], 10);
+  const minutes = match[3] ? parseInt(match[3], 10) : 0;
+  return sign * (hours * 60 + minutes);
+}

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -31,4 +31,13 @@ export default () => ({
     // than fail-fast-in-production — see env.validation.ts.
     depositCents: parseInt(process.env.RESERVATION_DEPOSIT_CENTS || '1000', 10),
   },
+  restaurant: {
+    // IANA timezone used to interpret Reservation.reservedFor as entered
+    // by staff (naive, local wall-clock string — see
+    // CreateReservationDto.reservedFor) and to display it back. Like
+    // RESERVATION_DEPOSIT_CENTS, an unconfigured value has no legal
+    // consequences, so it's optional with a sensible default rather than
+    // fail-fast-in-production — see env.validation.ts.
+    timezone: process.env.RESTAURANT_TIMEZONE || 'America/Lima',
+  },
 });

--- a/src/config/env.validation.ts
+++ b/src/config/env.validation.ts
@@ -73,6 +73,15 @@ class EnvironmentVariables {
   @IsOptional()
   @IsNumberString()
   RESERVATION_DEPOSIT_CENTS?: string;
+
+  // IANA timezone (e.g. "America/Lima", "Europe/Madrid") used to interpret
+  // Reservation.reservedFor. Whenever provided, must be a string. Like
+  // RESERVATION_DEPOSIT_CENTS, a missing value has no legal consequences,
+  // so it's simply @IsOptional() with a default applied in
+  // configuration.ts — no fail-fast-in-production behavior needed here.
+  @IsOptional()
+  @IsString()
+  RESTAURANT_TIMEZONE?: string;
 }
 
 export function validateEnv(config: Record<string, unknown>) {

--- a/src/reservations/dto/create-reservation.dto.spec.ts
+++ b/src/reservations/dto/create-reservation.dto.spec.ts
@@ -1,0 +1,60 @@
+import { validate } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+import { ReservationType } from '@prisma/client';
+import { CreateReservationDto } from './create-reservation.dto';
+
+function baseDto(overrides: Record<string, unknown> = {}) {
+  return plainToInstance(CreateReservationDto, {
+    customerName: 'Jane Doe',
+    customerPhone: '+51999999999',
+    partySize: 4,
+    reservedFor: '2026-07-18T14:00:00',
+    reservationType: ReservationType.INFORMAL,
+    ...overrides,
+  });
+}
+
+describe('CreateReservationDto — reservedFor', () => {
+  it('accepts a correctly-formatted naive local datetime string (with seconds)', async () => {
+    const dto = baseDto({ reservedFor: '2026-07-18T14:00:00' });
+    const errors = await validate(dto);
+    expect(errors.find((e) => e.property === 'reservedFor')).toBeUndefined();
+  });
+
+  it('accepts a correctly-formatted naive local datetime string (without seconds)', async () => {
+    const dto = baseDto({ reservedFor: '2026-07-18T14:00' });
+    const errors = await validate(dto);
+    expect(errors.find((e) => e.property === 'reservedFor')).toBeUndefined();
+  });
+
+  it('rejects a value with a Z (UTC) suffix', async () => {
+    const dto = baseDto({ reservedFor: '2026-07-18T14:00:00Z' });
+    const errors = await validate(dto);
+    const err = errors.find((e) => e.property === 'reservedFor');
+    expect(err).toBeDefined();
+    expect(Object.values(err!.constraints || {}).join(' ')).toMatch(
+      /do not include Z or an offset/,
+    );
+  });
+
+  it('rejects a value with an explicit positive offset', async () => {
+    const dto = baseDto({ reservedFor: '2026-07-18T14:00:00+05:00' });
+    const errors = await validate(dto);
+    const err = errors.find((e) => e.property === 'reservedFor');
+    expect(err).toBeDefined();
+  });
+
+  it('rejects a value with an explicit negative offset', async () => {
+    const dto = baseDto({ reservedFor: '2026-07-18T14:00:00-05:00' });
+    const errors = await validate(dto);
+    const err = errors.find((e) => e.property === 'reservedFor');
+    expect(err).toBeDefined();
+  });
+
+  it('rejects a bare date with no time component', async () => {
+    const dto = baseDto({ reservedFor: '2026-07-18' });
+    const errors = await validate(dto);
+    const err = errors.find((e) => e.property === 'reservedFor');
+    expect(err).toBeDefined();
+  });
+});

--- a/src/reservations/dto/create-reservation.dto.ts
+++ b/src/reservations/dto/create-reservation.dto.ts
@@ -4,7 +4,6 @@ import { Type } from 'class-transformer';
 import {
   ArrayMinSize,
   IsArray,
-  IsDateString,
   IsEmail,
   IsEnum,
   IsInt,
@@ -12,6 +11,7 @@ import {
   IsOptional,
   IsString,
   IsUUID,
+  Matches,
   Min,
   ValidateIf,
   ValidateNested,
@@ -39,8 +39,26 @@ export class CreateReservationDto {
   @Min(1)
   partySize!: number;
 
-  @ApiProperty({ description: 'Date/time the customer is expected' })
-  @IsDateString()
+  // A naive local datetime string (no 'Z'/offset suffix), interpreted as
+  // wall-clock time in the restaurant's configured timezone (see
+  // config/configuration.ts: restaurant.timezone). Rejecting UTC-suffixed
+  // values is deliberate — accepting both local-naive AND UTC-suffixed
+  // input ambiguously is exactly the bug this validation fixes (staff
+  // filling in local wall-clock values that were silently misinterpreted
+  // as UTC).
+  @ApiProperty({
+    description:
+      "Date/time the customer is expected, as the restaurant's local " +
+      'wall-clock time with NO timezone suffix (e.g. ' +
+      '"2026-07-18T14:00:00") — do not include Z or an offset.',
+    example: '2026-07-18T14:00:00',
+  })
+  @Matches(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2})?$/, {
+    message:
+      'reservedFor must be a local time without timezone suffix (e.g. ' +
+      '"2026-07-18T14:00:00"), representing the restaurant\'s local time ' +
+      '— do not include Z or an offset',
+  })
   reservedFor!: string;
 
   // Fully optional and freely editable by staff — if omitted, the service

--- a/src/reservations/reservations.service.spec.ts
+++ b/src/reservations/reservations.service.spec.ts
@@ -91,9 +91,11 @@ describe('ReservationsService', () => {
       applyDiscount: jest.fn(),
     };
     config = {
-      get: jest.fn((key: string) =>
-        key === 'reservations.depositCents' ? 1000 : undefined,
-      ),
+      get: jest.fn((key: string) => {
+        if (key === 'reservations.depositCents') return 1000;
+        if (key === 'restaurant.timezone') return 'America/Lima';
+        return undefined;
+      }),
     };
     service = new ReservationsService(
       prisma as unknown as PrismaService,
@@ -107,8 +109,27 @@ describe('ReservationsService', () => {
       customerName: 'Jane Doe',
       customerPhone: '+51999999999',
       partySize: 4,
-      reservedFor: '2026-08-01T20:00:00.000Z',
+      reservedFor: '2026-08-01T20:00:00',
     };
+
+    it('converts the naive local reservedFor to the correctly UTC-shifted value and attaches reservedForLocal', async () => {
+      prisma.reservation.create.mockImplementation(({ data }) =>
+        Promise.resolve({ id: reservationId, ...data }),
+      );
+
+      const dto = {
+        ...baseDto,
+        reservedFor: '2026-08-01T14:00:00',
+        reservationType: ReservationType.INFORMAL,
+      };
+
+      const result = await service.create(dto as any, actorId);
+
+      expect(config.get).toHaveBeenCalledWith('restaurant.timezone');
+      // America/Lima is fixed UTC-5 — 14:00 local -> 19:00 UTC.
+      expect(result.reservedFor.toISOString()).toBe('2026-08-01T19:00:00.000Z');
+      expect(result.reservedForLocal).toBe('2026-08-01T14:00:00');
+    });
 
     it('WITH_PREORDER: computes depositCents as floor(order.totalCents / 2) and creates the pre-order via OrdersService', async () => {
       prisma.table.findUnique.mockResolvedValue(availableTable);

--- a/src/reservations/reservations.service.ts
+++ b/src/reservations/reservations.service.ts
@@ -15,6 +15,7 @@ import {
 import { PrismaService } from '../prisma/prisma.service';
 import { CreateOrderDto } from '../orders/dto/create-order.dto';
 import { OrdersService } from '../orders/orders.service';
+import { localToUtc, utcToLocalDisplay } from '../common/utils/local-time';
 import { CreateReservationDto } from './dto/create-reservation.dto';
 import { ListReservationsQueryDto } from './dto/list-reservations-query.dto';
 import { SeatReservationDto } from './dto/seat-reservation.dto';
@@ -53,9 +54,10 @@ export class ReservationsService {
           'tableId and items are not allowed for INFORMAL reservations',
         );
       }
-      return this.prisma.reservation.create({
+      const reservation = await this.prisma.reservation.create({
         data: this.baseReservationData(dto, actorId),
       });
+      return this.withReservedForLocal(reservation);
     }
 
     // WITH_PREORDER and DEPOSIT_ONLY both commit a specific table once the
@@ -95,7 +97,7 @@ export class ReservationsService {
         this.config.get<number>('reservations.depositCents') ?? 1000;
     }
 
-    return this.prisma.reservation.create({
+    const reservation = await this.prisma.reservation.create({
       data: {
         ...this.baseReservationData(dto, actorId),
         tableId: dto.tableId,
@@ -103,6 +105,7 @@ export class ReservationsService {
         depositCents,
       },
     });
+    return this.withReservedForLocal(reservation);
   }
 
   async findAll(query: ListReservationsQueryDto) {
@@ -116,12 +119,15 @@ export class ReservationsService {
       where.reservedFor = { gte: start, lt: end };
     }
 
-    return this.prisma.reservation.findMany({
+    const reservations = await this.prisma.reservation.findMany({
       where,
       skip: query.skip,
       take: query.limit,
       orderBy: { reservedFor: 'asc' },
     });
+    return reservations.map((reservation) =>
+      this.withReservedForLocal(reservation),
+    );
   }
 
   async findOne(id: string) {
@@ -131,7 +137,7 @@ export class ReservationsService {
     if (!reservation) {
       throw new NotFoundException('Reservation not found');
     }
-    return reservation;
+    return this.withReservedForLocal(reservation);
   }
 
   async confirm(id: string, actorId: string) {
@@ -143,16 +149,17 @@ export class ReservationsService {
     }
 
     if (reservation.reservationType === ReservationType.INFORMAL) {
-      return this.prisma.reservation.update({
+      const updated = await this.prisma.reservation.update({
         where: { id },
         data: { status: ReservationStatus.CONFIRMED },
       });
+      return this.withReservedForLocal(updated);
     }
 
     // WITH_PREORDER / DEPOSIT_ONLY: the deposit has just been confirmed
     // received by staff — this is the moment the table is actually
     // committed (AVAILABLE -> RESERVED).
-    return this.prisma.$transaction(async (tx) => {
+    const updated = await this.prisma.$transaction(async (tx) => {
       if (reservation.tableId) {
         await tx.table.update({
           where: { id: reservation.tableId },
@@ -168,6 +175,7 @@ export class ReservationsService {
         },
       });
     });
+    return this.withReservedForLocal(updated);
   }
 
   async seat(id: string, dto: SeatReservationDto, actorId: string) {
@@ -323,7 +331,7 @@ export class ReservationsService {
       );
     }
 
-    return this.prisma.$transaction(async (tx) => {
+    const updated = await this.prisma.$transaction(async (tx) => {
       if (reservation.tableId) {
         const table = await tx.table.findUnique({
           where: { id: reservation.tableId },
@@ -340,6 +348,7 @@ export class ReservationsService {
         data: { status: nextStatus },
       });
     });
+    return this.withReservedForLocal(updated);
   }
 
   private baseReservationData(
@@ -351,7 +360,12 @@ export class ReservationsService {
       customerPhone: dto.customerPhone,
       customerEmail: dto.customerEmail,
       partySize: dto.partySize,
-      reservedFor: new Date(dto.reservedFor),
+      // dto.reservedFor is a naive local wall-clock string (validated by
+      // CreateReservationDto to reject any Z/offset suffix) — convert it
+      // to UTC using the restaurant's configured timezone before
+      // persisting, so it lands on the correct absolute instant regardless
+      // of the DB's UTC storage.
+      reservedFor: localToUtc(dto.reservedFor, this.getTimezone()),
       toleranceMinutes:
         dto.toleranceMinutes ?? DEFAULT_TOLERANCE_BY_TYPE[dto.reservationType],
       allergies: dto.allergies,
@@ -359,6 +373,24 @@ export class ReservationsService {
       reservationType: dto.reservationType,
       status: ReservationStatus.PENDING,
       createdBy: actorId,
+    };
+  }
+
+  private getTimezone(): string {
+    return this.config.get<string>('restaurant.timezone') ?? 'America/Lima';
+  }
+
+  // Derived, display-only convenience — NOT persisted. Formats the stored
+  // UTC reservedFor back into the restaurant's local timezone.
+  private withReservedForLocal<T extends { reservedFor: Date }>(
+    reservation: T,
+  ): T & { reservedForLocal: string } {
+    return {
+      ...reservation,
+      reservedForLocal: utcToLocalDisplay(
+        reservation.reservedFor,
+        this.getTimezone(),
+      ),
     };
   }
 }

--- a/test/reservations.e2e-spec.ts
+++ b/test/reservations.e2e-spec.ts
@@ -102,11 +102,26 @@ describe('Reservations (e2e)', () => {
           customerName: 'Jane Doe',
           customerPhone: '+51999999999',
           partySize: 2,
-          reservedFor: '2026-08-01T20:00:00.000Z',
+          reservedFor: '2026-08-01T14:00:00',
           reservationType: 'DEPOSIT_ONLY',
           tableId,
         })
         .expect(403);
+    });
+
+    it('POST /api/reservations rejects a reservedFor value with a UTC (Z) suffix', async () => {
+      await request(app.getHttpServer())
+        .post('/api/reservations')
+        .set('Authorization', `Bearer ${cashierToken}`)
+        .send({
+          customerName: 'Jane Doe',
+          customerPhone: '+51999999999',
+          partySize: 2,
+          reservedFor: '2026-08-01T14:00:00.000Z',
+          reservationType: 'DEPOSIT_ONLY',
+          tableId,
+        })
+        .expect(400);
     });
 
     it('POST /api/reservations creates a PENDING DEPOSIT_ONLY reservation with the configured fixed deposit', async () => {
@@ -117,7 +132,7 @@ describe('Reservations (e2e)', () => {
           customerName: 'Jane Doe',
           customerPhone: '+51999999999',
           partySize: 2,
-          reservedFor: '2026-08-01T20:00:00.000Z',
+          reservedFor: '2026-08-01T14:00:00',
           reservationType: 'DEPOSIT_ONLY',
           tableId,
         })
@@ -126,6 +141,12 @@ describe('Reservations (e2e)', () => {
       expect(res.body.status).toBe('PENDING');
       expect(res.body.depositCents).toBe(DEPOSIT_CENTS);
       expect(res.body.orderId).toBeNull();
+      // reservedFor was sent as a naive local time ("14:00", no suffix),
+      // interpreted as America/Lima (UTC-5, default RESTAURANT_TIMEZONE)
+      // — stored/returned reservedFor must be the correctly shifted UTC
+      // instant, with reservedForLocal reflecting the original local time.
+      expect(res.body.reservedFor).toBe('2026-08-01T19:00:00.000Z');
+      expect(res.body.reservedForLocal).toBe('2026-08-01T14:00:00');
       reservationId = res.body.id;
 
       // Table is NOT committed yet — stays AVAILABLE until deposit confirmed.
@@ -295,7 +316,7 @@ describe('Reservations (e2e)', () => {
           customerName: 'Informal Guest',
           customerPhone: '+51988888888',
           partySize: 3,
-          reservedFor: '2026-08-02T19:00:00.000Z',
+          reservedFor: '2026-08-02T10:00:00',
           reservationType: 'INFORMAL',
           tableId: '00000000-0000-4000-8000-000000000000',
         })
@@ -310,7 +331,7 @@ describe('Reservations (e2e)', () => {
           customerName: 'Informal Guest',
           customerPhone: '+51988888888',
           partySize: 3,
-          reservedFor: '2026-08-02T19:00:00.000Z',
+          reservedFor: '2026-08-02T10:00:00',
           reservationType: 'INFORMAL',
         })
         .expect(201);
@@ -385,7 +406,7 @@ describe('Reservations (e2e)', () => {
           customerName: 'No Show Guest',
           customerPhone: '+51977777777',
           partySize: 2,
-          reservedFor: '2026-08-03T19:00:00.000Z',
+          reservedFor: '2026-08-03T10:00:00',
           reservationType: 'DEPOSIT_ONLY',
           tableId: table.body.id,
         })
@@ -429,7 +450,7 @@ describe('Reservations (e2e)', () => {
           customerName: 'Terminal Guest',
           customerPhone: '+51966666666',
           partySize: 2,
-          reservedFor: '2026-08-04T19:00:00.000Z',
+          reservedFor: '2026-08-04T10:00:00',
           reservationType: 'DEPOSIT_ONLY',
           tableId: table.body.id,
         })


### PR DESCRIPTION
## Problem
Reservation.reservedFor accepted UTC-suffixed ISO strings, but staff
naturally entered local wall-clock values without realizing the system
stored them as UTC — causing reservations to land hours off, sometimes
on the wrong calendar day. Confirmed manually during QA: "2pm today"
in Peru entered as "14:00Z" was stored incorrectly.

## Changes
- New `RESTAURANT_TIMEZONE` env var (default `America/Lima`)
- `CreateReservationDto.reservedFor` now requires a naive local
  datetime string (no Z/offset suffix) — explicitly rejects
  UTC-suffixed input to remove the ambiguity that caused the bug
- New `src/common/utils/local-time.ts` (kept separate from the
  existing dormant `timezone.ts`): `localToUtc()` / `utcToLocalDisplay()`
  using only Node's built-in `Intl` API — correct for both fixed-offset
  zones (Lima) and DST zones (verified with America/New_York)
- Reservation responses now include a derived, non-persisted
  `reservedForLocal` field for staff-friendly display

## Scope
Limited to `Reservation.reservedFor` only. Broader timezone-awareness
across the app (Orders, reports, etc.) remains deferred to future
multi-restaurant tenancy work — each restaurant will eventually have
its own configured timezone rather than one global env var.

## Tests
153/153 unit passing (including exact UTC-conversion assertions for
both Lima and a DST timezone), e2e updated for local-time fixtures,
manually verified end-to-end in local Docker: `14:00` local correctly
stored as `19:00Z` for America/Lima, with `reservedForLocal` reflecting
the original local time.