### PR TITLE
feat: multi-restaurant tenancy — Restaurant model, isolation enforcement, and onboarding

### DIFF
--- a/prisma/backfill-restaurant.ts
+++ b/prisma/backfill-restaurant.ts
@@ -1,0 +1,104 @@
+// One-time migration script for #149 (Restaurant model + restaurantId FK).
+//
+// This is NOT part of the regular seed flow (prisma/seed.ts). It exists to
+// backfill restaurantId on pre-existing rows created before multi-tenancy was
+// introduced, between migration Step A (nullable restaurantId columns) and
+// Step B (NOT NULL constraint). Run manually:
+//
+//   npx ts-node prisma/backfill-restaurant.ts
+//
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+const DEFAULT_RESTAURANT = {
+  name: 'El Buen Filo',
+  timezone: 'America/Lima',
+};
+
+// Every model that received a nullable restaurantId column in Step A.
+// Subscription is explicitly out of scope.
+const TENANT_TABLES = [
+  'user',
+  'category',
+  'menuItem',
+  'order',
+  'orderItem',
+  'table',
+  'inventoryItem',
+  'stockAdjustment',
+  'reservation',
+  'cashRegisterSession',
+  'payment',
+  'auditLog',
+] as const;
+
+async function main() {
+  const restaurant = await prisma.restaurant.upsert({
+    where: { id: await getOrCreateDefaultRestaurantId() },
+    update: {},
+    create: DEFAULT_RESTAURANT,
+  });
+
+  console.log(`Using restaurant: ${restaurant.name} (${restaurant.id})`);
+
+  const updatedCounts: Record<string, number> = {};
+
+  for (const model of TENANT_TABLES) {
+    const delegate = (prisma as any)[model];
+    const result = await delegate.updateMany({
+      where: { restaurantId: null },
+      data: { restaurantId: restaurant.id },
+    });
+    updatedCounts[model] = result.count;
+    console.log(`Backfilled ${result.count} row(s) in "${model}"`);
+  }
+
+  console.log('\nBackfill summary:');
+  console.table(updatedCounts);
+
+  // Explicit verification: zero rows with NULL restaurantId across all
+  // tenant-owned tables before Step B (NOT NULL constraint) is applied.
+  const remainingNulls: Record<string, number> = {};
+  let totalRemaining = 0;
+
+  for (const model of TENANT_TABLES) {
+    const delegate = (prisma as any)[model];
+    const count = await delegate.count({ where: { restaurantId: null } });
+    remainingNulls[model] = count;
+    totalRemaining += count;
+  }
+
+  console.log('\nVerification — remaining NULL restaurantId rows per table:');
+  console.table(remainingNulls);
+
+  if (totalRemaining > 0) {
+    throw new Error(
+      `Backfill incomplete: ${totalRemaining} row(s) still have a NULL restaurantId. ` +
+        'Do NOT proceed to migration Step B (require_tenant_ids) until this is zero.',
+    );
+  }
+
+  console.log(
+    '\nVerification passed: 0 rows with NULL restaurantId across all 12 tenant-owned tables.',
+  );
+}
+
+// The Restaurant row itself has no restaurantId to backfill against — this
+// helper just finds (or lazily prepares to create) the single default
+// restaurant used for all pre-multi-tenancy data.
+async function getOrCreateDefaultRestaurantId(): Promise<string> {
+  const existing = await prisma.restaurant.findFirst({
+    where: { name: DEFAULT_RESTAURANT.name },
+  });
+  return existing?.id ?? '00000000-0000-4000-8000-000000000001';
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/prisma/migrations/20260822223446_add_restaurant_and_nullable_tenant_ids/migration.sql
+++ b/prisma/migrations/20260822223446_add_restaurant_and_nullable_tenant_ids/migration.sql
@@ -1,0 +1,82 @@
+-- AlterTable
+ALTER TABLE "audit_logs" ADD COLUMN     "restaurantId" TEXT;
+
+-- AlterTable
+ALTER TABLE "cash_register_sessions" ADD COLUMN     "restaurantId" TEXT;
+
+-- AlterTable
+ALTER TABLE "categories" ADD COLUMN     "restaurantId" TEXT;
+
+-- AlterTable
+ALTER TABLE "inventory_items" ADD COLUMN     "restaurantId" TEXT;
+
+-- AlterTable
+ALTER TABLE "menu_items" ADD COLUMN     "restaurantId" TEXT;
+
+-- AlterTable
+ALTER TABLE "order_items" ADD COLUMN     "restaurantId" TEXT;
+
+-- AlterTable
+ALTER TABLE "orders" ADD COLUMN     "restaurantId" TEXT;
+
+-- AlterTable
+ALTER TABLE "payments" ADD COLUMN     "restaurantId" TEXT;
+
+-- AlterTable
+ALTER TABLE "reservations" ADD COLUMN     "restaurantId" TEXT;
+
+-- AlterTable
+ALTER TABLE "stock_adjustments" ADD COLUMN     "restaurantId" TEXT;
+
+-- AlterTable
+ALTER TABLE "tables" ADD COLUMN     "restaurantId" TEXT;
+
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "restaurantId" TEXT;
+
+-- CreateTable
+CREATE TABLE "restaurants" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "timezone" TEXT NOT NULL DEFAULT 'America/Lima',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "restaurants_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "audit_logs_restaurantId_idx" ON "audit_logs"("restaurantId");
+
+-- CreateIndex
+CREATE INDEX "cash_register_sessions_restaurantId_idx" ON "cash_register_sessions"("restaurantId");
+
+-- CreateIndex
+CREATE INDEX "categories_restaurantId_idx" ON "categories"("restaurantId");
+
+-- CreateIndex
+CREATE INDEX "inventory_items_restaurantId_idx" ON "inventory_items"("restaurantId");
+
+-- CreateIndex
+CREATE INDEX "menu_items_restaurantId_idx" ON "menu_items"("restaurantId");
+
+-- CreateIndex
+CREATE INDEX "order_items_restaurantId_idx" ON "order_items"("restaurantId");
+
+-- CreateIndex
+CREATE INDEX "orders_restaurantId_idx" ON "orders"("restaurantId");
+
+-- CreateIndex
+CREATE INDEX "payments_restaurantId_idx" ON "payments"("restaurantId");
+
+-- CreateIndex
+CREATE INDEX "reservations_restaurantId_idx" ON "reservations"("restaurantId");
+
+-- CreateIndex
+CREATE INDEX "stock_adjustments_restaurantId_idx" ON "stock_adjustments"("restaurantId");
+
+-- CreateIndex
+CREATE INDEX "tables_restaurantId_idx" ON "tables"("restaurantId");
+
+-- CreateIndex
+CREATE INDEX "users_restaurantId_idx" ON "users"("restaurantId");

--- a/prisma/migrations/20260822223610_require_tenant_ids/migration.sql
+++ b/prisma/migrations/20260822223610_require_tenant_ids/migration.sql
@@ -1,0 +1,88 @@
+/*
+  Warnings:
+
+  - Made the column `restaurantId` on table `audit_logs` required. This step will fail if there are existing NULL values in that column.
+  - Made the column `restaurantId` on table `cash_register_sessions` required. This step will fail if there are existing NULL values in that column.
+  - Made the column `restaurantId` on table `categories` required. This step will fail if there are existing NULL values in that column.
+  - Made the column `restaurantId` on table `inventory_items` required. This step will fail if there are existing NULL values in that column.
+  - Made the column `restaurantId` on table `menu_items` required. This step will fail if there are existing NULL values in that column.
+  - Made the column `restaurantId` on table `order_items` required. This step will fail if there are existing NULL values in that column.
+  - Made the column `restaurantId` on table `orders` required. This step will fail if there are existing NULL values in that column.
+  - Made the column `restaurantId` on table `payments` required. This step will fail if there are existing NULL values in that column.
+  - Made the column `restaurantId` on table `reservations` required. This step will fail if there are existing NULL values in that column.
+  - Made the column `restaurantId` on table `stock_adjustments` required. This step will fail if there are existing NULL values in that column.
+  - Made the column `restaurantId` on table `tables` required. This step will fail if there are existing NULL values in that column.
+  - Made the column `restaurantId` on table `users` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+ALTER TABLE "audit_logs" ALTER COLUMN "restaurantId" SET NOT NULL;
+
+-- AlterTable
+ALTER TABLE "cash_register_sessions" ALTER COLUMN "restaurantId" SET NOT NULL;
+
+-- AlterTable
+ALTER TABLE "categories" ALTER COLUMN "restaurantId" SET NOT NULL;
+
+-- AlterTable
+ALTER TABLE "inventory_items" ALTER COLUMN "restaurantId" SET NOT NULL;
+
+-- AlterTable
+ALTER TABLE "menu_items" ALTER COLUMN "restaurantId" SET NOT NULL;
+
+-- AlterTable
+ALTER TABLE "order_items" ALTER COLUMN "restaurantId" SET NOT NULL;
+
+-- AlterTable
+ALTER TABLE "orders" ALTER COLUMN "restaurantId" SET NOT NULL;
+
+-- AlterTable
+ALTER TABLE "payments" ALTER COLUMN "restaurantId" SET NOT NULL;
+
+-- AlterTable
+ALTER TABLE "reservations" ALTER COLUMN "restaurantId" SET NOT NULL;
+
+-- AlterTable
+ALTER TABLE "stock_adjustments" ALTER COLUMN "restaurantId" SET NOT NULL;
+
+-- AlterTable
+ALTER TABLE "tables" ALTER COLUMN "restaurantId" SET NOT NULL;
+
+-- AlterTable
+ALTER TABLE "users" ALTER COLUMN "restaurantId" SET NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "users" ADD CONSTRAINT "users_restaurantId_fkey" FOREIGN KEY ("restaurantId") REFERENCES "restaurants"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "categories" ADD CONSTRAINT "categories_restaurantId_fkey" FOREIGN KEY ("restaurantId") REFERENCES "restaurants"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "menu_items" ADD CONSTRAINT "menu_items_restaurantId_fkey" FOREIGN KEY ("restaurantId") REFERENCES "restaurants"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "tables" ADD CONSTRAINT "tables_restaurantId_fkey" FOREIGN KEY ("restaurantId") REFERENCES "restaurants"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "orders" ADD CONSTRAINT "orders_restaurantId_fkey" FOREIGN KEY ("restaurantId") REFERENCES "restaurants"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "order_items" ADD CONSTRAINT "order_items_restaurantId_fkey" FOREIGN KEY ("restaurantId") REFERENCES "restaurants"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "reservations" ADD CONSTRAINT "reservations_restaurantId_fkey" FOREIGN KEY ("restaurantId") REFERENCES "restaurants"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "payments" ADD CONSTRAINT "payments_restaurantId_fkey" FOREIGN KEY ("restaurantId") REFERENCES "restaurants"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "cash_register_sessions" ADD CONSTRAINT "cash_register_sessions_restaurantId_fkey" FOREIGN KEY ("restaurantId") REFERENCES "restaurants"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "inventory_items" ADD CONSTRAINT "inventory_items_restaurantId_fkey" FOREIGN KEY ("restaurantId") REFERENCES "restaurants"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "stock_adjustments" ADD CONSTRAINT "stock_adjustments_restaurantId_fkey" FOREIGN KEY ("restaurantId") REFERENCES "restaurants"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "audit_logs" ADD CONSTRAINT "audit_logs_restaurantId_fkey" FOREIGN KEY ("restaurantId") REFERENCES "restaurants"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,6 +7,30 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+// ---------- Tenancy ----------
+
+model Restaurant {
+  id                   String                @id @default(uuid())
+  name                 String
+  timezone             String                @default("America/Lima")
+  users                User[]
+  categories           Category[]
+  menuItems            MenuItem[]
+  orders               Order[]
+  orderItems           OrderItem[]
+  tables               Table[]
+  inventoryItems       InventoryItem[]
+  stockAdjustments     StockAdjustment[]
+  reservations         Reservation[]
+  cashRegisterSessions CashRegisterSession[]
+  payments             Payment[]
+  auditLogs            AuditLog[]
+  createdAt            DateTime              @default(now())
+  updatedAt            DateTime              @updatedAt
+
+  @@map("restaurants")
+}
+
 // ---------- Auth / Users ----------
 
 enum Role {
@@ -27,6 +51,8 @@ model User {
   lastName         String?
   role             Role                  @default(CUSTOMER)
   active           Boolean               @default(true)
+  restaurantId     String
+  restaurant       Restaurant            @relation(fields: [restaurantId], references: [id])
   orders           Order[]
   openedSessions   CashRegisterSession[] @relation("OpenedSessions")
   closedSessions   CashRegisterSession[] @relation("ClosedSessions")
@@ -35,6 +61,7 @@ model User {
   createdAt        DateTime              @default(now())
   updatedAt        DateTime              @updatedAt
 
+  @@index([restaurantId])
   @@map("users")
 }
 
@@ -55,14 +82,17 @@ model Session {
 // ---------- Menu ----------
 
 model Category {
-  id        String     @id @default(uuid())
-  name      String
-  sortOrder Int        @default(0)
-  active    Boolean    @default(true)
-  items     MenuItem[]
-  createdAt DateTime   @default(now())
-  updatedAt DateTime   @updatedAt
+  id           String     @id @default(uuid())
+  name         String
+  sortOrder    Int        @default(0)
+  active       Boolean    @default(true)
+  restaurantId String
+  restaurant   Restaurant @relation(fields: [restaurantId], references: [id])
+  items        MenuItem[]
+  createdAt    DateTime   @default(now())
+  updatedAt    DateTime   @updatedAt
 
+  @@index([restaurantId])
   @@map("categories")
 }
 
@@ -76,12 +106,15 @@ model MenuItem {
   available     Boolean        @default(true)
   categoryId    String
   category      Category       @relation(fields: [categoryId], references: [id], onDelete: Restrict)
+  restaurantId  String
+  restaurant    Restaurant     @relation(fields: [restaurantId], references: [id])
   orderItems    OrderItem[]
   inventoryItem InventoryItem?
   createdAt     DateTime       @default(now())
   updatedAt     DateTime       @updatedAt
 
   @@index([categoryId])
+  @@index([restaurantId])
   @@map("menu_items")
 }
 
@@ -118,11 +151,14 @@ model Table {
   name         String        @unique
   capacity     Int?
   status       TableStatus   @default(AVAILABLE)
+  restaurantId String
+  restaurant   Restaurant    @relation(fields: [restaurantId], references: [id])
   orders       Order[]
   reservations Reservation[]
   createdAt    DateTime      @default(now())
   updatedAt    DateTime      @updatedAt
 
+  @@index([restaurantId])
   @@map("tables")
 }
 
@@ -146,6 +182,8 @@ model Order {
   discountReason    String?
   currency          String       @default("usd")
   notes             String?
+  restaurantId      String
+  restaurant        Restaurant   @relation(fields: [restaurantId], references: [id])
   items             OrderItem[]
   payments          Payment[]
   reservation       Reservation?
@@ -155,15 +193,16 @@ model Order {
   @@index([customerId])
   @@index([status])
   @@index([tableId])
+  @@index([restaurantId])
   @@map("orders")
 }
 
 model OrderItem {
-  id             String   @id @default(uuid())
+  id             String     @id @default(uuid())
   orderId        String
-  order          Order    @relation(fields: [orderId], references: [id], onDelete: Cascade)
+  order          Order      @relation(fields: [orderId], references: [id], onDelete: Cascade)
   menuItemId     String
-  menuItem       MenuItem @relation(fields: [menuItemId], references: [id], onDelete: Restrict)
+  menuItem       MenuItem   @relation(fields: [menuItemId], references: [id], onDelete: Restrict)
   // Snapshot of menu item at order time — prices must not change retroactively.
   nameSnapshot   String
   priceCents     Int
@@ -171,8 +210,11 @@ model OrderItem {
   modifiers      Json?
   notes          String?
   lineTotalCents Int
+  restaurantId   String
+  restaurant     Restaurant @relation(fields: [restaurantId], references: [id])
 
   @@index([orderId])
+  @@index([restaurantId])
   @@map("order_items")
 }
 
@@ -212,12 +254,15 @@ model Reservation {
   depositConfirmedAt DateTime?
   status             ReservationStatus @default(PENDING)
   createdBy          String // staff user who registered it
+  restaurantId       String
+  restaurant         Restaurant        @relation(fields: [restaurantId], references: [id])
   createdAt          DateTime          @default(now())
   updatedAt          DateTime          @updatedAt
 
   @@index([status])
   @@index([reservedFor])
   @@index([tableId])
+  @@index([restaurantId])
   @@map("reservations")
 }
 
@@ -239,47 +284,53 @@ enum PaymentStatus {
 }
 
 model Payment {
-  id          String               @id @default(uuid())
-  orderId     String
-  order       Order                @relation(fields: [orderId], references: [id], onDelete: Cascade)
-  method      PaymentMethod        @default(CASH)
-  provider    String               @default("stripe")
-  providerRef String?              @unique // Stripe PaymentIntent id (null for CASH/CARD/TRANSFER)
-  amountCents Int
-  paidCents   Int                  @default(0) // amount physically received
-  changeCents Int                  @default(0) // change given back to customer
-  currency    String               @default("usd")
-  status      PaymentStatus        @default(REQUIRES_PAYMENT)
-  lastEventId String? // last processed webhook event id (idempotency)
-  sessionId   String?
-  session     CashRegisterSession? @relation(fields: [sessionId], references: [id])
-  rawEvent    Json?
-  createdAt   DateTime             @default(now())
-  updatedAt   DateTime             @updatedAt
+  id           String               @id @default(uuid())
+  orderId      String
+  order        Order                @relation(fields: [orderId], references: [id], onDelete: Cascade)
+  method       PaymentMethod        @default(CASH)
+  provider     String               @default("stripe")
+  providerRef  String?              @unique // Stripe PaymentIntent id (null for CASH/CARD/TRANSFER)
+  amountCents  Int
+  paidCents    Int                  @default(0) // amount physically received
+  changeCents  Int                  @default(0) // change given back to customer
+  currency     String               @default("usd")
+  status       PaymentStatus        @default(REQUIRES_PAYMENT)
+  lastEventId  String? // last processed webhook event id (idempotency)
+  sessionId    String?
+  session      CashRegisterSession? @relation(fields: [sessionId], references: [id])
+  rawEvent     Json?
+  restaurantId String
+  restaurant   Restaurant           @relation(fields: [restaurantId], references: [id])
+  createdAt    DateTime             @default(now())
+  updatedAt    DateTime             @updatedAt
 
   @@index([orderId])
+  @@index([restaurantId])
   @@map("payments")
 }
 
 // ---------- Cash Register ----------
 
 model CashRegisterSession {
-  id                String    @id @default(uuid())
+  id                String     @id @default(uuid())
   openedById        String
-  openedBy          User      @relation("OpenedSessions", fields: [openedById], references: [id])
-  openedAt          DateTime  @default(now())
+  openedBy          User       @relation("OpenedSessions", fields: [openedById], references: [id])
+  openedAt          DateTime   @default(now())
   closedById        String?
-  closedBy          User?     @relation("ClosedSessions", fields: [closedById], references: [id])
+  closedBy          User?      @relation("ClosedSessions", fields: [closedById], references: [id])
   closedAt          DateTime?
-  openingFloatCents Int       @default(0)
+  openingFloatCents Int        @default(0)
   expectedCents     Int? // computed from sales at close
   countedCents      Int? // physically counted by cashier
   differenceCents   Int? // countedCents - expectedCents
   notes             String?
+  restaurantId      String
+  restaurant        Restaurant @relation(fields: [restaurantId], references: [id])
   payments          Payment[]
-  createdAt         DateTime  @default(now())
-  updatedAt         DateTime  @updatedAt
+  createdAt         DateTime   @default(now())
+  updatedAt         DateTime   @updatedAt
 
+  @@index([restaurantId])
   @@map("cash_register_sessions")
 }
 
@@ -300,10 +351,13 @@ model InventoryItem {
   lowStockThreshold Float             @default(0)
   menuItemId        String?           @unique
   menuItem          MenuItem?         @relation(fields: [menuItemId], references: [id], onDelete: SetNull)
+  restaurantId      String
+  restaurant        Restaurant        @relation(fields: [restaurantId], references: [id])
   adjustments       StockAdjustment[]
   createdAt         DateTime          @default(now())
   updatedAt         DateTime          @updatedAt
 
+  @@index([restaurantId])
   @@map("inventory_items")
 }
 
@@ -316,26 +370,32 @@ model StockAdjustment {
   reason          String?
   performedById   String
   performedBy     User           @relation(fields: [performedById], references: [id])
+  restaurantId    String
+  restaurant      Restaurant     @relation(fields: [restaurantId], references: [id])
   createdAt       DateTime       @default(now())
 
   @@index([inventoryItemId])
+  @@index([restaurantId])
   @@map("stock_adjustments")
 }
 
 // ---------- Audit ----------
 
 model AuditLog {
-  id         String   @id @default(uuid())
-  entityType String // e.g. "Order", "MenuItem", "InventoryItem"
-  entityId   String
-  action     String // e.g. "DISCOUNT_APPLIED", "PRICE_CHANGED", "STOCK_ADJUSTED"
-  userId     String
-  metadata   Json?
-  createdAt  DateTime @default(now())
+  id           String     @id @default(uuid())
+  entityType   String // e.g. "Order", "MenuItem", "InventoryItem"
+  entityId     String
+  action       String // e.g. "DISCOUNT_APPLIED", "PRICE_CHANGED", "STOCK_ADJUSTED"
+  userId       String
+  metadata     Json?
+  restaurantId String
+  restaurant   Restaurant @relation(fields: [restaurantId], references: [id])
+  createdAt    DateTime   @default(now())
 
   @@index([entityType, entityId])
   @@index([userId])
   @@index([createdAt])
+  @@index([restaurantId])
   @@map("audit_logs")
 }
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -4,6 +4,18 @@ import * as bcrypt from 'bcryptjs';
 const prisma = new PrismaClient();
 
 async function main() {
+  // All demo data belongs to a single default restaurant. Reuses the same
+  // row the #149 backfill script creates if it already ran.
+  const restaurant = await prisma.restaurant.upsert({
+    where: { id: '00000000-0000-4000-8000-000000000001' },
+    update: {},
+    create: {
+      id: '00000000-0000-4000-8000-000000000001',
+      name: 'El Buen Filo',
+      timezone: 'America/Lima',
+    },
+  });
+
   const adminEmail = 'admin@restosync.local';
   const passwordHash = await bcrypt.hash('Admin123!', 10);
 
@@ -16,6 +28,7 @@ async function main() {
       firstName: 'Resto',
       lastName: 'Admin',
       role: Role.ADMIN,
+      restaurantId: restaurant.id,
     },
   });
 
@@ -27,6 +40,7 @@ async function main() {
       id: categoryId,
       name: 'Burgers',
       sortOrder: 1,
+      restaurantId: restaurant.id,
     },
   });
 
@@ -39,6 +53,7 @@ async function main() {
       description: 'Beef patty, cheddar, lettuce, tomato',
       priceCents: 1200,
       categoryId: category.id,
+      restaurantId: restaurant.id,
     },
   });
 
@@ -53,6 +68,7 @@ async function main() {
       firstName: 'Regina',
       lastName: 'Cashier',
       role: Role.CASHIER,
+      restaurantId: restaurant.id,
     },
   });
 
@@ -67,6 +83,7 @@ async function main() {
       firstName: 'Walter',
       lastName: 'Waiter',
       role: Role.WAITER,
+      restaurantId: restaurant.id,
     },
   });
 
@@ -81,6 +98,7 @@ async function main() {
       firstName: 'Manuel',
       lastName: 'Manager',
       role: Role.MANAGER,
+      restaurantId: restaurant.id,
     },
   });
 
@@ -102,7 +120,7 @@ async function main() {
     await prisma.category.upsert({
       where: { id: cat.id },
       update: { name: cat.name, sortOrder: cat.sortOrder },
-      create: cat,
+      create: { ...cat, restaurantId: restaurant.id },
     });
   }
 
@@ -130,7 +148,7 @@ async function main() {
     await prisma.menuItem.upsert({
       where: { id: item.id },
       update: { name: item.name, priceCents: item.priceCents, categoryId: item.categoryId },
-      create: item,
+      create: { ...item, restaurantId: restaurant.id },
     });
   }
 
@@ -143,6 +161,7 @@ async function main() {
       id: '55555555-5555-4555-8555-555555555501',
       name: 'Mesa 1',
       capacity: 4,
+      restaurantId: restaurant.id,
     },
   });
 
@@ -189,6 +208,7 @@ async function main() {
         status: demo.status,
         tableId: demo.tableId,
         customerId: admin.id,
+        restaurantId: restaurant.id,
       },
     });
 
@@ -201,6 +221,7 @@ async function main() {
         priceCents: menuItem.priceCents,
         quantity: di.quantity,
         lineTotalCents: menuItem.priceCents * di.quantity,
+        restaurantId: restaurant.id,
       };
     });
 

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -17,6 +17,7 @@ import { PrismaModule } from './prisma/prisma.module';
 import { RealtimeModule } from './realtime/realtime.module';
 import { ReportsModule } from './reports/reports.module';
 import { ReservationsModule } from './reservations/reservations.module';
+import { RestaurantsModule } from './restaurants/restaurants.module';
 import { TablesModule } from './tables/tables.module';
 import { UsersModule } from './users/users.module';
 
@@ -39,6 +40,7 @@ import { UsersModule } from './users/users.module';
     BillingModule,
     TablesModule,
     ReservationsModule,
+    RestaurantsModule,
     RealtimeModule,
   ],
   controllers: [AppController],

--- a/src/audit/audit.service.spec.ts
+++ b/src/audit/audit.service.spec.ts
@@ -1,5 +1,4 @@
 import { PrismaService } from '../prisma/prisma.service';
-import { DEFAULT_RESTAURANT_ID } from '../common/constants/tenancy';
 import { AuditService } from './audit.service';
 
 type MockPrisma = {
@@ -28,7 +27,7 @@ describe('AuditService', () => {
   });
 
   describe('log', () => {
-    it('creates the audit record with the provided fields', async () => {
+    it('creates the audit record with the provided fields, including restaurantId', async () => {
       prisma.auditLog.create.mockResolvedValue({});
 
       await service.log({
@@ -36,6 +35,7 @@ describe('AuditService', () => {
         entityId: 'order-1',
         action: 'DISCOUNT_APPLIED',
         userId: 'user-1',
+        restaurantId: 'restaurant-A',
         metadata: { discountCents: 100 },
       });
 
@@ -46,8 +46,8 @@ describe('AuditService', () => {
           entityId: 'order-1',
           action: 'DISCOUNT_APPLIED',
           userId: 'user-1',
+          restaurantId: 'restaurant-A',
           metadata: { discountCents: 100 },
-          restaurantId: DEFAULT_RESTAURANT_ID,
         },
       });
     });
@@ -60,6 +60,7 @@ describe('AuditService', () => {
         entityId: 'item-1',
         action: 'STOCK_ADJUSTED',
         userId: 'user-2',
+        restaurantId: 'restaurant-A',
       });
 
       expect(prisma.auditLog.create).toHaveBeenCalledWith({
@@ -68,21 +69,22 @@ describe('AuditService', () => {
           entityId: 'item-1',
           action: 'STOCK_ADJUSTED',
           userId: 'user-2',
+          restaurantId: 'restaurant-A',
           metadata: undefined,
-          restaurantId: DEFAULT_RESTAURANT_ID,
         },
       });
     });
   });
 
   describe('findByEntity', () => {
-    it('queries by entityType/entityId ordered by createdAt desc', async () => {
+    it('queries by entityType/entityId AND the caller restaurantId, ordered by createdAt desc', async () => {
       const newest = {
         id: 'log-2',
         entityType: 'Order',
         entityId: 'order-1',
         action: 'DISCOUNT_APPLIED',
         userId: 'user-1',
+        restaurantId: 'restaurant-A',
         metadata: null,
         createdAt: new Date('2026-01-02'),
       };
@@ -92,6 +94,7 @@ describe('AuditService', () => {
         entityId: 'order-1',
         action: 'DISCOUNT_APPLIED',
         userId: 'user-1',
+        restaurantId: 'restaurant-A',
         metadata: null,
         createdAt: new Date('2026-01-01'),
       };
@@ -99,16 +102,46 @@ describe('AuditService', () => {
       // `orderBy` clause (newest first).
       prisma.auditLog.findMany.mockResolvedValue([newest, oldest]);
 
-      const result = await service.findByEntity('Order', 'order-1');
+      const result = await service.findByEntity(
+        'Order',
+        'order-1',
+        'restaurant-A',
+      );
 
       expect(prisma.auditLog.findMany).toHaveBeenCalledWith({
-        where: { entityType: 'Order', entityId: 'order-1' },
+        where: {
+          entityType: 'Order',
+          entityId: 'order-1',
+          restaurantId: 'restaurant-A',
+        },
         orderBy: { createdAt: 'desc' },
       });
       expect(result).toEqual([newest, oldest]);
       expect(result[0].createdAt.getTime()).toBeGreaterThan(
         result[1].createdAt.getTime(),
       );
+    });
+
+    it("never returns another restaurant's audit entries for the same entityId", async () => {
+      // Simulates the DB correctly filtering by restaurantId — a
+      // cross-restaurant log for the same entityId is never returned.
+      prisma.auditLog.findMany.mockResolvedValue([]);
+
+      const result = await service.findByEntity(
+        'Order',
+        'order-1',
+        'restaurant-B',
+      );
+
+      expect(prisma.auditLog.findMany).toHaveBeenCalledWith({
+        where: {
+          entityType: 'Order',
+          entityId: 'order-1',
+          restaurantId: 'restaurant-B',
+        },
+        orderBy: { createdAt: 'desc' },
+      });
+      expect(result).toEqual([]);
     });
   });
 });

--- a/src/audit/audit.service.spec.ts
+++ b/src/audit/audit.service.spec.ts
@@ -1,4 +1,5 @@
 import { PrismaService } from '../prisma/prisma.service';
+import { DEFAULT_RESTAURANT_ID } from '../common/constants/tenancy';
 import { AuditService } from './audit.service';
 
 type MockPrisma = {
@@ -46,6 +47,7 @@ describe('AuditService', () => {
           action: 'DISCOUNT_APPLIED',
           userId: 'user-1',
           metadata: { discountCents: 100 },
+          restaurantId: DEFAULT_RESTAURANT_ID,
         },
       });
     });
@@ -67,6 +69,7 @@ describe('AuditService', () => {
           action: 'STOCK_ADJUSTED',
           userId: 'user-2',
           metadata: undefined,
+          restaurantId: DEFAULT_RESTAURANT_ID,
         },
       });
     });

--- a/src/audit/audit.service.ts
+++ b/src/audit/audit.service.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
-import { DEFAULT_RESTAURANT_ID } from '../common/constants/tenancy';
 
 @Injectable()
 export class AuditService {
@@ -12,20 +11,24 @@ export class AuditService {
     entityId: string;
     action: string;
     userId: string;
+    restaurantId: string;
     metadata?: Record<string, unknown>;
   }): Promise<void> {
     await this.prisma.auditLog.create({
       data: {
         ...params,
         metadata: params.metadata as Prisma.InputJsonValue | undefined,
-        restaurantId: DEFAULT_RESTAURANT_ID,
       },
     });
   }
 
-  async findByEntity(entityType: string, entityId: string) {
+  async findByEntity(
+    entityType: string,
+    entityId: string,
+    restaurantId: string,
+  ) {
     return this.prisma.auditLog.findMany({
-      where: { entityType, entityId },
+      where: { entityType, entityId, restaurantId },
       orderBy: { createdAt: 'desc' },
     });
   }

--- a/src/audit/audit.service.ts
+++ b/src/audit/audit.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
+import { DEFAULT_RESTAURANT_ID } from '../common/constants/tenancy';
 
 @Injectable()
 export class AuditService {
@@ -17,6 +18,7 @@ export class AuditService {
       data: {
         ...params,
         metadata: params.metadata as Prisma.InputJsonValue | undefined,
+        restaurantId: DEFAULT_RESTAURANT_ID,
       },
     });
   }

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -1,0 +1,173 @@
+import { UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { JwtService } from '@nestjs/jwt';
+import { Role, User } from '@prisma/client';
+import * as bcrypt from 'bcryptjs';
+import { PrismaService } from '../prisma/prisma.service';
+import { DEFAULT_RESTAURANT_ID } from '../common/constants/tenancy';
+import { AuthService } from './auth.service';
+
+type MockPrisma = {
+  user: {
+    create: jest.Mock;
+    findUnique: jest.Mock;
+  };
+  session: {
+    create: jest.Mock;
+    findMany: jest.Mock;
+    update: jest.Mock;
+    updateMany: jest.Mock;
+  };
+};
+
+function createMockPrisma(): MockPrisma {
+  return {
+    user: {
+      create: jest.fn(),
+      findUnique: jest.fn(),
+    },
+    session: {
+      create: jest.fn(),
+      findMany: jest.fn(),
+      update: jest.fn(),
+      updateMany: jest.fn(),
+    },
+  };
+}
+
+function createMockJwt() {
+  return {
+    signAsync: jest.fn().mockResolvedValue('signed-token'),
+    verifyAsync: jest.fn(),
+    decode: jest
+      .fn()
+      .mockReturnValue({ exp: Math.floor(Date.now() / 1000) + 3600 }),
+  };
+}
+
+function createMockConfig() {
+  const values: Record<string, string> = {
+    'jwt.secret': 'access-secret',
+    'jwt.refreshSecret': 'refresh-secret',
+    'jwt.expiresIn': '15m',
+    'jwt.refreshExpiresIn': '7d',
+  };
+  return { get: jest.fn((key: string) => values[key]) };
+}
+
+function buildUser(overrides: Partial<User> = {}): User {
+  return {
+    id: 'user-1',
+    email: 'admin@restosync.local',
+    passwordHash: 'irrelevant-in-most-tests',
+    firstName: 'Resto',
+    lastName: 'Admin',
+    role: Role.ADMIN,
+    active: true,
+    restaurantId: 'restaurant-123',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+describe('AuthService', () => {
+  let service: AuthService;
+  let prisma: MockPrisma;
+  let jwt: ReturnType<typeof createMockJwt>;
+  let config: ReturnType<typeof createMockConfig>;
+
+  beforeEach(() => {
+    prisma = createMockPrisma();
+    jwt = createMockJwt();
+    config = createMockConfig();
+    service = new AuthService(
+      prisma as unknown as PrismaService,
+      jwt as unknown as JwtService,
+      config as unknown as ConfigService,
+    );
+  });
+
+  describe('register', () => {
+    it('creates a new User with a valid restaurantId assigned', async () => {
+      prisma.user.create.mockResolvedValue(
+        buildUser({ role: Role.CUSTOMER, restaurantId: DEFAULT_RESTAURANT_ID }),
+      );
+
+      await service.register({
+        email: 'new-customer@restosync.local',
+        password: 'Secret123!',
+      });
+
+      expect(prisma.user.create).toHaveBeenCalledTimes(1);
+      const { data } = prisma.user.create.mock.calls[0][0];
+      expect(data.restaurantId).toBeDefined();
+      expect(data.restaurantId).not.toBeNull();
+      expect(data.restaurantId).toBe(DEFAULT_RESTAURANT_ID);
+    });
+
+    it('issues tokens for the newly created user', async () => {
+      prisma.user.create.mockResolvedValue(
+        buildUser({ role: Role.CUSTOMER, restaurantId: DEFAULT_RESTAURANT_ID }),
+      );
+
+      const tokens = await service.register({
+        email: 'new-customer@restosync.local',
+        password: 'Secret123!',
+      });
+
+      expect(tokens).toEqual({
+        accessToken: 'signed-token',
+        refreshToken: 'signed-token',
+      });
+      expect(prisma.session.create).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('login', () => {
+    it('issues a JWT containing the correct restaurantId', async () => {
+      const passwordHash = await bcrypt.hash('Secret123!', 10);
+      const user = buildUser({ passwordHash, restaurantId: 'restaurant-abc' });
+      prisma.user.findUnique.mockResolvedValue(user);
+
+      await service.login({ email: user.email, password: 'Secret123!' });
+
+      expect(jwt.signAsync).toHaveBeenCalledTimes(2);
+      const [accessPayload] = jwt.signAsync.mock.calls[0];
+      const [refreshPayload] = jwt.signAsync.mock.calls[1];
+
+      expect(accessPayload).toEqual({
+        sub: user.id,
+        email: user.email,
+        role: user.role,
+        restaurantId: user.restaurantId,
+      });
+      expect(refreshPayload).toEqual({
+        sub: user.id,
+        email: user.email,
+        role: user.role,
+        restaurantId: user.restaurantId,
+      });
+    });
+
+    it('rejects invalid credentials when the user does not exist', async () => {
+      prisma.user.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.login({ email: 'ghost@restosync.local', password: 'whatever' }),
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('rejects invalid credentials when the password does not match', async () => {
+      const passwordHash = await bcrypt.hash('CorrectPassword1!', 10);
+      prisma.user.findUnique.mockResolvedValue(buildUser({ passwordHash }));
+
+      await expect(
+        service.login({
+          email: 'admin@restosync.local',
+          password: 'WrongPassword1!',
+        }),
+      ).rejects.toThrow(UnauthorizedException);
+    });
+  });
+});

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -4,6 +4,7 @@ import { JwtService } from '@nestjs/jwt';
 import { Role, User } from '@prisma/client';
 import * as bcrypt from 'bcryptjs';
 import { PrismaService } from '../prisma/prisma.service';
+import { DEFAULT_RESTAURANT_ID } from '../common/constants/tenancy';
 import { LoginDto } from './dto/login.dto';
 import { RegisterDto } from './dto/register.dto';
 import { JwtPayload } from './strategies/jwt.strategy';
@@ -30,6 +31,7 @@ export class AuthService {
         firstName: dto.firstName,
         lastName: dto.lastName,
         role: Role.CUSTOMER,
+        restaurantId: DEFAULT_RESTAURANT_ID,
       },
     });
     return this.issueTokens(user);

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -113,6 +113,7 @@ export class AuthService {
       sub: user.id,
       email: user.email,
       role: user.role,
+      restaurantId: user.restaurantId,
     };
 
     const accessToken = await this.jwt.signAsync(payload, {

--- a/src/auth/decorators/current-user.decorator.ts
+++ b/src/auth/decorators/current-user.decorator.ts
@@ -4,6 +4,7 @@ export interface AuthUser {
   id: string;
   email: string;
   role: string;
+  restaurantId: string;
 }
 
 export const CurrentUser = createParamDecorator(

--- a/src/auth/strategies/jwt.strategy.spec.ts
+++ b/src/auth/strategies/jwt.strategy.spec.ts
@@ -1,0 +1,90 @@
+import { UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Role } from '@prisma/client';
+import { PrismaService } from '../../prisma/prisma.service';
+import { JwtStrategy } from './jwt.strategy';
+
+type MockPrisma = {
+  user: { findUnique: jest.Mock };
+};
+
+function createMockPrisma(): MockPrisma {
+  return { user: { findUnique: jest.fn() } };
+}
+
+function createMockConfig(): ConfigService {
+  return {
+    get: jest.fn().mockReturnValue('access-secret'),
+  } as unknown as ConfigService;
+}
+
+describe('JwtStrategy', () => {
+  let strategy: JwtStrategy;
+  let prisma: MockPrisma;
+
+  beforeEach(() => {
+    prisma = createMockPrisma();
+    strategy = new JwtStrategy(
+      createMockConfig(),
+      prisma as unknown as PrismaService,
+    );
+  });
+
+  describe('validate', () => {
+    it('correctly extracts restaurantId from a valid token payload', async () => {
+      prisma.user.findUnique.mockResolvedValue({
+        id: 'user-1',
+        email: 'admin@restosync.local',
+        role: Role.ADMIN,
+        active: true,
+        restaurantId: 'restaurant-123',
+      });
+
+      const result = await strategy.validate({
+        sub: 'user-1',
+        email: 'admin@restosync.local',
+        role: Role.ADMIN,
+        restaurantId: 'restaurant-123',
+      });
+
+      expect(result).toEqual({
+        id: 'user-1',
+        email: 'admin@restosync.local',
+        role: Role.ADMIN,
+        restaurantId: 'restaurant-123',
+      });
+    });
+
+    it('throws when the user no longer exists', async () => {
+      prisma.user.findUnique.mockResolvedValue(null);
+
+      await expect(
+        strategy.validate({
+          sub: 'ghost',
+          email: 'ghost@restosync.local',
+          role: Role.CUSTOMER,
+          restaurantId: 'restaurant-123',
+        }),
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('throws when the user is deactivated', async () => {
+      prisma.user.findUnique.mockResolvedValue({
+        id: 'user-2',
+        email: 'inactive@restosync.local',
+        role: Role.STAFF,
+        active: false,
+        restaurantId: 'restaurant-123',
+      });
+
+      await expect(
+        strategy.validate({
+          sub: 'user-2',
+          email: 'inactive@restosync.local',
+          role: Role.STAFF,
+          restaurantId: 'restaurant-123',
+        }),
+      ).rejects.toThrow(UnauthorizedException);
+    });
+  });
+});

--- a/src/auth/strategies/jwt.strategy.ts
+++ b/src/auth/strategies/jwt.strategy.ts
@@ -9,6 +9,7 @@ export interface JwtPayload {
   sub: string;
   email: string;
   role: string;
+  restaurantId: string;
 }
 
 @Injectable()
@@ -31,6 +32,11 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     if (!user || !user.active) {
       throw new UnauthorizedException();
     }
-    return { id: user.id, email: user.email, role: user.role };
+    return {
+      id: user.id,
+      email: user.email,
+      role: user.role,
+      restaurantId: user.restaurantId,
+    };
   }
 }

--- a/src/cash-register/cash-register.controller.ts
+++ b/src/cash-register/cash-register.controller.ts
@@ -14,7 +14,10 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 import { Role } from '@prisma/client';
-import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import {
+  AuthUser,
+  CurrentUser,
+} from '../auth/decorators/current-user.decorator';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { CashRegisterService } from './cash-register.service';
 import { CloseSessionDto } from './dto/close-session.dto';
@@ -33,8 +36,8 @@ export class CashRegisterController {
   @ApiResponse({ status: 201, description: 'Session opened' })
   @ApiResponse({ status: 400, description: 'Session already open' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
-  openSession(@Body() dto: OpenSessionDto, @CurrentUser('id') userId: string) {
-    return this.cashRegisterService.openSession(dto, userId);
+  openSession(@Body() dto: OpenSessionDto, @CurrentUser() user: AuthUser) {
+    return this.cashRegisterService.openSession(dto, user);
   }
 
   @Roles(Role.CASHIER, Role.MANAGER, Role.ADMIN)
@@ -47,11 +50,8 @@ export class CashRegisterController {
   })
   @ApiResponse({ status: 400, description: 'No active session' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
-  closeSession(
-    @Body() dto: CloseSessionDto,
-    @CurrentUser('id') userId: string,
-  ) {
-    return this.cashRegisterService.closeSession(dto, userId);
+  closeSession(@Body() dto: CloseSessionDto, @CurrentUser() user: AuthUser) {
+    return this.cashRegisterService.closeSession(dto, user);
   }
 
   @Roles(Role.CASHIER, Role.MANAGER, Role.ADMIN)
@@ -62,8 +62,8 @@ export class CashRegisterController {
     description: 'Session summary with totals by payment method',
   })
   @ApiResponse({ status: 404, description: 'Session not found' })
-  getSessionSummary(@Param('id') id: string) {
-    return this.cashRegisterService.getSessionSummary(id);
+  getSessionSummary(@Param('id') id: string, @CurrentUser() user: AuthUser) {
+    return this.cashRegisterService.getSessionSummary(id, user);
   }
 
   @Roles(Role.CASHIER, Role.MANAGER, Role.ADMIN)
@@ -71,7 +71,7 @@ export class CashRegisterController {
   @ApiOperation({ summary: 'Get summary for the current active session' })
   @ApiResponse({ status: 200, description: 'Current session summary' })
   @ApiResponse({ status: 404, description: 'No active session' })
-  getCurrentSummary() {
-    return this.cashRegisterService.getCurrentSummary();
+  getCurrentSummary(@CurrentUser() user: AuthUser) {
+    return this.cashRegisterService.getCurrentSummary(user);
   }
 }

--- a/src/cash-register/cash-register.service.spec.ts
+++ b/src/cash-register/cash-register.service.spec.ts
@@ -1,7 +1,7 @@
 import { BadRequestException, NotFoundException } from '@nestjs/common';
-import { PaymentMethod, PaymentStatus } from '@prisma/client';
+import { PaymentMethod, PaymentStatus, Role } from '@prisma/client';
+import { AuthUser } from '../auth/decorators/current-user.decorator';
 import { PrismaService } from '../prisma/prisma.service';
-import { DEFAULT_RESTAURANT_ID } from '../common/constants/tenancy';
 import { CashRegisterService } from './cash-register.service';
 
 type MockPrisma = {
@@ -32,11 +32,21 @@ function createMockPrisma(): MockPrisma {
   };
 }
 
+function buildUser(overrides: Partial<AuthUser> = {}): AuthUser {
+  return {
+    id: 'user-1',
+    email: 'cashier@restosync.local',
+    role: Role.CASHIER,
+    restaurantId: 'restaurant-A',
+    ...overrides,
+  };
+}
+
 describe('CashRegisterService', () => {
   let service: CashRegisterService;
   let prisma: MockPrisma;
 
-  const actorId = 'user-1';
+  const user = buildUser();
   const sessionId = 'session-1';
 
   beforeEach(() => {
@@ -45,41 +55,75 @@ describe('CashRegisterService', () => {
   });
 
   describe('openSession', () => {
-    it('creates a session with openingFloatCents and openedById', async () => {
+    it('creates a session with openingFloatCents, openedById and the caller restaurantId', async () => {
       prisma.cashRegisterSession.findFirst.mockResolvedValue(null);
       const created = {
         id: sessionId,
-        openedById: actorId,
+        openedById: user.id,
         openingFloatCents: 10000,
         notes: null,
         closedAt: null,
+        restaurantId: user.restaurantId,
       };
       prisma.cashRegisterSession.create.mockResolvedValue(created);
 
       const result = await service.openSession(
         { openingFloatCents: 10000 },
-        actorId,
+        user,
       );
 
+      expect(prisma.cashRegisterSession.findFirst).toHaveBeenCalledWith({
+        where: { closedAt: null, restaurantId: user.restaurantId },
+      });
       expect(prisma.cashRegisterSession.create).toHaveBeenCalledWith({
         data: {
-          openedById: actorId,
+          openedById: user.id,
           openingFloatCents: 10000,
           notes: null,
-          restaurantId: DEFAULT_RESTAURANT_ID,
+          restaurantId: user.restaurantId,
         },
       });
       expect(result).toBe(created);
     });
 
-    it('throws BadRequestException if a session is already open', async () => {
+    it("ignores a client-supplied restaurantId and always uses the caller's own", async () => {
+      prisma.cashRegisterSession.findFirst.mockResolvedValue(null);
+      prisma.cashRegisterSession.create.mockResolvedValue({});
+
+      await service.openSession(
+        {
+          openingFloatCents: 10000,
+          // @ts-expect-error simulating a malicious/naive client payload
+          restaurantId: 'restaurant-EVIL',
+        },
+        user,
+      );
+
+      const { data } = prisma.cashRegisterSession.create.mock.calls[0][0];
+      expect(data.restaurantId).toBe(user.restaurantId);
+    });
+
+    it('an open session in another restaurant does not block opening one here', async () => {
+      // findFirst is itself scoped by restaurantId, so a session open in
+      // a different restaurant is invisible to this check.
+      prisma.cashRegisterSession.findFirst.mockResolvedValue(null);
+      prisma.cashRegisterSession.create.mockResolvedValue({});
+
+      await service.openSession({ openingFloatCents: 10000 }, user);
+
+      expect(prisma.cashRegisterSession.findFirst).toHaveBeenCalledWith({
+        where: { closedAt: null, restaurantId: 'restaurant-A' },
+      });
+    });
+
+    it('throws BadRequestException if a session is already open in the caller restaurant', async () => {
       prisma.cashRegisterSession.findFirst.mockResolvedValue({
         id: sessionId,
         closedAt: null,
       });
 
       await expect(
-        service.openSession({ openingFloatCents: 10000 }, actorId),
+        service.openSession({ openingFloatCents: 10000 }, user),
       ).rejects.toThrow(BadRequestException);
       expect(prisma.cashRegisterSession.create).not.toHaveBeenCalled();
     });
@@ -92,14 +136,14 @@ describe('CashRegisterService', () => {
       notes: null,
     };
 
-    it('computes expectedCents from SUCCEEDED payments and differenceCents', async () => {
+    it('computes expectedCents from SUCCEEDED payments and differenceCents, scoped by restaurantId', async () => {
       prisma.cashRegisterSession.findFirst.mockResolvedValue(activeSession);
       prisma.payment.aggregate.mockResolvedValue({
         _sum: { amountCents: 5000 },
       });
       const updated = {
         ...activeSession,
-        closedById: actorId,
+        closedById: user.id,
         closedAt: new Date(),
         expectedCents: 5000,
         countedCents: 5200,
@@ -107,19 +151,20 @@ describe('CashRegisterService', () => {
       };
       prisma.cashRegisterSession.update.mockResolvedValue(updated);
 
-      const result = await service.closeSession(
-        { countedCents: 5200 },
-        actorId,
-      );
+      const result = await service.closeSession({ countedCents: 5200 }, user);
 
       expect(prisma.payment.aggregate).toHaveBeenCalledWith({
         _sum: { amountCents: true },
-        where: { sessionId, status: PaymentStatus.SUCCEEDED },
+        where: {
+          sessionId,
+          status: PaymentStatus.SUCCEEDED,
+          restaurantId: user.restaurantId,
+        },
       });
       expect(prisma.cashRegisterSession.update).toHaveBeenCalledWith({
         where: { id: sessionId },
         data: expect.objectContaining({
-          closedById: actorId,
+          closedById: user.id,
           closedAt: expect.any(Date),
           expectedCents: 5000,
           countedCents: 5200,
@@ -134,27 +179,28 @@ describe('CashRegisterService', () => {
       prisma.payment.aggregate.mockResolvedValue({ _sum: { amountCents: 0 } });
       prisma.cashRegisterSession.update.mockResolvedValue({});
 
-      await service.closeSession({ countedCents: 0 }, actorId);
+      await service.closeSession({ countedCents: 0 }, user);
 
       const updateCall = prisma.cashRegisterSession.update.mock.calls[0][0];
-      expect(updateCall.data.closedById).toBe(actorId);
+      expect(updateCall.data.closedById).toBe(user.id);
       expect(updateCall.data.closedAt).toBeInstanceOf(Date);
     });
 
-    it('throws if no active session exists', async () => {
+    it('throws if no active session exists in the caller restaurant', async () => {
       prisma.cashRegisterSession.findFirst.mockResolvedValue(null);
 
       await expect(
-        service.closeSession({ countedCents: 0 }, actorId),
+        service.closeSession({ countedCents: 0 }, user),
       ).rejects.toThrow(BadRequestException);
       expect(prisma.cashRegisterSession.update).not.toHaveBeenCalled();
     });
   });
 
   describe('getSessionSummary', () => {
-    it('returns correct totalSalesCents and ticketCount', async () => {
+    it('returns correct totalSalesCents and ticketCount when the session belongs to the caller restaurant', async () => {
       prisma.cashRegisterSession.findUnique.mockResolvedValue({
         id: sessionId,
+        restaurantId: user.restaurantId,
       });
       prisma.payment.findMany.mockResolvedValue([
         { method: PaymentMethod.CASH, amountCents: 1000 },
@@ -162,8 +208,15 @@ describe('CashRegisterService', () => {
         { method: PaymentMethod.CASH, amountCents: 500 },
       ]);
 
-      const result = await service.getSessionSummary(sessionId);
+      const result = await service.getSessionSummary(sessionId, user);
 
+      expect(prisma.payment.findMany).toHaveBeenCalledWith({
+        where: {
+          sessionId,
+          status: PaymentStatus.SUCCEEDED,
+          restaurantId: user.restaurantId,
+        },
+      });
       expect(result.summary.totalSalesCents).toBe(3500);
       expect(result.summary.ticketCount).toBe(3);
       expect(result.summary.byMethod).toEqual({
@@ -175,10 +228,11 @@ describe('CashRegisterService', () => {
     it('byMethod breakdown only includes methods with amount > 0', async () => {
       prisma.cashRegisterSession.findUnique.mockResolvedValue({
         id: sessionId,
+        restaurantId: user.restaurantId,
       });
       prisma.payment.findMany.mockResolvedValue([]);
 
-      const result = await service.getSessionSummary(sessionId);
+      const result = await service.getSessionSummary(sessionId, user);
 
       expect(result.summary.totalSalesCents).toBe(0);
       expect(result.summary.ticketCount).toBe(0);
@@ -188,7 +242,48 @@ describe('CashRegisterService', () => {
     it('throws NotFoundException if the session does not exist', async () => {
       prisma.cashRegisterSession.findUnique.mockResolvedValue(null);
 
-      await expect(service.getSessionSummary(sessionId)).rejects.toThrow(
+      await expect(service.getSessionSummary(sessionId, user)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('throws NotFoundException (not the session) for a session belonging to another restaurant', async () => {
+      prisma.cashRegisterSession.findUnique.mockResolvedValue({
+        id: sessionId,
+        restaurantId: 'restaurant-B',
+      });
+
+      await expect(service.getSessionSummary(sessionId, user)).rejects.toThrow(
+        NotFoundException,
+      );
+      expect(prisma.payment.findMany).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getCurrentSummary', () => {
+    it('scopes the active-session lookup by the caller restaurantId', async () => {
+      prisma.cashRegisterSession.findFirst.mockResolvedValue({
+        id: sessionId,
+        restaurantId: user.restaurantId,
+      });
+      prisma.cashRegisterSession.findUnique.mockResolvedValue({
+        id: sessionId,
+        restaurantId: user.restaurantId,
+      });
+      prisma.payment.findMany.mockResolvedValue([]);
+
+      await service.getCurrentSummary(user);
+
+      expect(prisma.cashRegisterSession.findFirst).toHaveBeenCalledWith({
+        where: { closedAt: null, restaurantId: user.restaurantId },
+        orderBy: { openedAt: 'desc' },
+      });
+    });
+
+    it('throws NotFoundException when no active session exists for the caller restaurant', async () => {
+      prisma.cashRegisterSession.findFirst.mockResolvedValue(null);
+
+      await expect(service.getCurrentSummary(user)).rejects.toThrow(
         NotFoundException,
       );
     });

--- a/src/cash-register/cash-register.service.spec.ts
+++ b/src/cash-register/cash-register.service.spec.ts
@@ -1,6 +1,7 @@
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { PaymentMethod, PaymentStatus } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
+import { DEFAULT_RESTAURANT_ID } from '../common/constants/tenancy';
 import { CashRegisterService } from './cash-register.service';
 
 type MockPrisma = {
@@ -65,6 +66,7 @@ describe('CashRegisterService', () => {
           openedById: actorId,
           openingFloatCents: 10000,
           notes: null,
+          restaurantId: DEFAULT_RESTAURANT_ID,
         },
       });
       expect(result).toBe(created);

--- a/src/cash-register/cash-register.service.ts
+++ b/src/cash-register/cash-register.service.ts
@@ -4,8 +4,8 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { PaymentMethod, PaymentStatus } from '@prisma/client';
+import { AuthUser } from '../auth/decorators/current-user.decorator';
 import { PrismaService } from '../prisma/prisma.service';
-import { DEFAULT_RESTAURANT_ID } from '../common/constants/tenancy';
 import { CloseSessionDto } from './dto/close-session.dto';
 import { OpenSessionDto } from './dto/open-session.dto';
 
@@ -13,9 +13,9 @@ import { OpenSessionDto } from './dto/open-session.dto';
 export class CashRegisterService {
   constructor(private readonly prisma: PrismaService) {}
 
-  async openSession(dto: OpenSessionDto, actorId: string) {
+  async openSession(dto: OpenSessionDto, user: AuthUser) {
     const active = await this.prisma.cashRegisterSession.findFirst({
-      where: { closedAt: null },
+      where: { closedAt: null, restaurantId: user.restaurantId },
     });
     if (active) {
       throw new BadRequestException('A register session is already open');
@@ -23,17 +23,17 @@ export class CashRegisterService {
 
     return this.prisma.cashRegisterSession.create({
       data: {
-        openedById: actorId,
+        openedById: user.id,
         openingFloatCents: dto.openingFloatCents,
         notes: dto.notes ?? null,
-        restaurantId: DEFAULT_RESTAURANT_ID,
+        restaurantId: user.restaurantId,
       },
     });
   }
 
-  async closeSession(dto: CloseSessionDto, actorId: string) {
+  async closeSession(dto: CloseSessionDto, user: AuthUser) {
     const session = await this.prisma.cashRegisterSession.findFirst({
-      where: { closedAt: null },
+      where: { closedAt: null, restaurantId: user.restaurantId },
       orderBy: { openedAt: 'desc' },
     });
     if (!session) {
@@ -45,6 +45,7 @@ export class CashRegisterService {
       where: {
         sessionId: session.id,
         status: PaymentStatus.SUCCEEDED,
+        restaurantId: user.restaurantId,
       },
     });
     const expectedCents = paymentsAgg._sum.amountCents ?? 0;
@@ -53,7 +54,7 @@ export class CashRegisterService {
     return this.prisma.cashRegisterSession.update({
       where: { id: session.id },
       data: {
-        closedById: actorId,
+        closedById: user.id,
         closedAt: new Date(),
         expectedCents,
         countedCents: dto.countedCents,
@@ -63,16 +64,20 @@ export class CashRegisterService {
     });
   }
 
-  async getSessionSummary(sessionId: string) {
+  async getSessionSummary(sessionId: string, user: AuthUser) {
     const session = await this.prisma.cashRegisterSession.findUnique({
       where: { id: sessionId },
     });
-    if (!session) {
+    if (!session || session.restaurantId !== user.restaurantId) {
       throw new NotFoundException('Session not found');
     }
 
     const payments = await this.prisma.payment.findMany({
-      where: { sessionId, status: PaymentStatus.SUCCEEDED },
+      where: {
+        sessionId,
+        status: PaymentStatus.SUCCEEDED,
+        restaurantId: user.restaurantId,
+      },
     });
 
     const totalSalesCents = payments.reduce((sum, p) => sum + p.amountCents, 0);
@@ -97,15 +102,15 @@ export class CashRegisterService {
     };
   }
 
-  async getCurrentSummary() {
+  async getCurrentSummary(user: AuthUser) {
     const session = await this.prisma.cashRegisterSession.findFirst({
-      where: { closedAt: null },
+      where: { closedAt: null, restaurantId: user.restaurantId },
       orderBy: { openedAt: 'desc' },
     });
     if (!session) {
       throw new NotFoundException('No active session');
     }
 
-    return this.getSessionSummary(session.id);
+    return this.getSessionSummary(session.id, user);
   }
 }

--- a/src/cash-register/cash-register.service.ts
+++ b/src/cash-register/cash-register.service.ts
@@ -5,6 +5,7 @@ import {
 } from '@nestjs/common';
 import { PaymentMethod, PaymentStatus } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
+import { DEFAULT_RESTAURANT_ID } from '../common/constants/tenancy';
 import { CloseSessionDto } from './dto/close-session.dto';
 import { OpenSessionDto } from './dto/open-session.dto';
 
@@ -25,6 +26,7 @@ export class CashRegisterService {
         openedById: actorId,
         openingFloatCents: dto.openingFloatCents,
         notes: dto.notes ?? null,
+        restaurantId: DEFAULT_RESTAURANT_ID,
       },
     });
   }

--- a/src/common/constants/tenancy.ts
+++ b/src/common/constants/tenancy.ts
@@ -1,0 +1,13 @@
+// TEMPORARY placeholder for #149. Prisma now requires `restaurantId` on
+// every tenant-owned model (see prisma/schema.prisma), but nothing yet
+// resolves the caller's actual restaurant — that requires #151 (restaurantId
+// on the JWT payload) and #152 (services scoping every query/create by the
+// authenticated caller's restaurantId, with a Prisma Client Extension as a
+// backstop). Until those land, every row is minimally satisfied with this
+// single default restaurant (matches prisma/seed.ts and
+// prisma/backfill-restaurant.ts) so existing code keeps compiling and
+// behaving exactly as before multi-tenancy was introduced.
+//
+// Do NOT build new features on top of this constant — it is scaffolding for
+// #149 only, not a substitute for #152's real per-request scoping.
+export const DEFAULT_RESTAURANT_ID = '00000000-0000-4000-8000-000000000001';

--- a/src/common/prisma-tenant-guard.extension.spec.ts
+++ b/src/common/prisma-tenant-guard.extension.spec.ts
@@ -1,0 +1,118 @@
+import { tenantGuardOperation } from './prisma-tenant-guard.extension';
+
+describe('tenantGuardOperation', () => {
+  it('throws when a guarded operation on a tenant-owned model is missing restaurantId in where', async () => {
+    const query = jest.fn().mockResolvedValue([]);
+
+    await expect(
+      tenantGuardOperation({
+        model: 'Order',
+        operation: 'findMany',
+        args: { where: { status: 'PENDING' } },
+        query,
+      }),
+    ).rejects.toThrow(/Tenant guard: Order\.findMany\(\)/);
+
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('throws when the where clause is entirely absent', async () => {
+    const query = jest.fn().mockResolvedValue([]);
+
+    await expect(
+      tenantGuardOperation({
+        model: 'Payment',
+        operation: 'count',
+        args: {},
+        query,
+      }),
+    ).rejects.toThrow(/Tenant guard: Payment\.count\(\)/);
+
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('passes through when restaurantId is present at the top level of where', async () => {
+    const query = jest.fn().mockResolvedValue([{ id: 'order-1' }]);
+
+    const result = await tenantGuardOperation({
+      model: 'Order',
+      operation: 'findMany',
+      args: { where: { restaurantId: 'restaurant-1' } },
+      query,
+    });
+
+    expect(result).toEqual([{ id: 'order-1' }]);
+    expect(query).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes through when restaurantId is nested inside an AND clause', async () => {
+    const query = jest.fn().mockResolvedValue([]);
+
+    await tenantGuardOperation({
+      model: 'Order',
+      operation: 'findMany',
+      args: {
+        where: {
+          AND: [{ restaurantId: 'restaurant-1' }, { status: 'PENDING' }],
+        },
+      },
+      query,
+    });
+
+    expect(query).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes through unguarded operations (e.g. findUnique) even without restaurantId', async () => {
+    const query = jest.fn().mockResolvedValue({ id: 'order-1' });
+
+    const result = await tenantGuardOperation({
+      model: 'Order',
+      operation: 'findUnique',
+      args: { where: { id: 'order-1' } },
+      query,
+    });
+
+    expect(result).toEqual({ id: 'order-1' });
+    expect(query).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes through operations on non-tenant-owned models (e.g. Subscription) without restaurantId', async () => {
+    const query = jest.fn().mockResolvedValue([]);
+
+    await tenantGuardOperation({
+      model: 'Subscription',
+      operation: 'findMany',
+      args: { where: {} },
+      query,
+    });
+
+    expect(query).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes through create (no where clause to validate)', async () => {
+    const query = jest.fn().mockResolvedValue({ id: 'order-1' });
+
+    const result = await tenantGuardOperation({
+      model: 'Order',
+      operation: 'create',
+      args: { data: { restaurantId: 'restaurant-1' } },
+      query,
+    });
+
+    expect(result).toEqual({ id: 'order-1' });
+    expect(query).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws for updateMany missing restaurantId', async () => {
+    const query = jest.fn().mockResolvedValue({ count: 0 });
+
+    await expect(
+      tenantGuardOperation({
+        model: 'Table',
+        operation: 'updateMany',
+        args: { where: { status: 'AVAILABLE' }, data: {} },
+        query,
+      }),
+    ).rejects.toThrow(/Tenant guard: Table\.updateMany\(\)/);
+  });
+});

--- a/src/common/prisma-tenant-guard.extension.ts
+++ b/src/common/prisma-tenant-guard.extension.ts
@@ -1,0 +1,129 @@
+import { Prisma } from '@prisma/client';
+
+// #152: a validating backstop, not an auto-injector. This extension NEVER
+// adds or fixes a missing restaurantId filter — every service must still
+// explicitly write it. It only throws when a query against a tenant-owned
+// model is missing that filter, catching an omission before it can leak or
+// mutate another restaurant's data.
+//
+// Models: the same 12 tenant-owned models from #149 (User, Category,
+// MenuItem, Order, OrderItem, Table, InventoryItem, StockAdjustment,
+// Reservation, CashRegisterSession, Payment, AuditLog). User IS included:
+// its only unscoped lookups (login/JWT validation, by email or by id) use
+// findUnique, which is structurally exempt from this guard (see below), so
+// including User here adds real protection for UsersService.findAll/count
+// with no impact on auth flows. Subscription is explicitly out of scope
+// per #9's epic description.
+export const TENANT_GUARDED_MODELS = new Set<string>([
+  'User',
+  'Category',
+  'MenuItem',
+  'Order',
+  'OrderItem',
+  'Table',
+  'InventoryItem',
+  'StockAdjustment',
+  'Reservation',
+  'CashRegisterSession',
+  'Payment',
+  'AuditLog',
+]);
+
+// Operations guarded: every read/bulk-write operation whose `where` clause
+// is a general WhereInput, i.e. CAN legally carry a restaurantId filter.
+//
+// Deliberately EXCLUDED, for a structural (not a laziness) reason:
+// - findUnique, update, delete: Prisma types these operations' `where` as
+//   a *WhereUniqueInput*, which only accepts fields that are part of a
+//   unique index (id, or an explicit @@unique). None of our 12 models has
+//   a compound unique including restaurantId, so a bare
+//   findUnique/update/delete({ where: { id } }) by the global UUID primary
+//   key CANNOT carry restaurantId in its where clause at all — that isn't
+//   a missing filter, it's how a single global-id lookup/mutation is
+//   expressed in Prisma. This is exactly why every findOne/update/remove
+//   in this codebase follows the established fetch-by-id-then-verify
+//   pattern (see OrdersService.findOne): fetch/mutate via the unique id,
+//   then compare the row's restaurantId to the caller's and throw
+//   NotFoundException on mismatch *before* trusting or returning it. The
+//   extension cannot see or enforce that downstream check — that
+//   responsibility stays with each service, exactly as decision 2
+//   requires. Guarding these operations would make every single
+//   by-id lookup in the app throw, which is not the bug this guard exists
+//   to catch.
+// - create, upsert: no `where` clause to validate; restaurantId on create
+//   is enforced by each service setting it explicitly from the caller's
+//   AuthUser (decision 4), not by this guard.
+//
+// ADDED beyond decision 1's literal list, for the same defense-in-depth
+// reasoning applied consistently: count, aggregate, groupBy. These accept
+// a general WhereInput exactly like findMany/findFirst and are exactly the
+// operations ReportsService (explicitly in scope for this prompt) and
+// pagination `count()` calls elsewhere use — omitting them would leave a
+// real gap in the safety net for aggregate reporting queries.
+const GUARDED_OPERATIONS = new Set<string>([
+  'findMany',
+  'findFirst',
+  'count',
+  'aggregate',
+  'groupBy',
+  'updateMany',
+  'deleteMany',
+]);
+
+function hasRestaurantIdFilter(where: unknown): boolean {
+  if (!where || typeof where !== 'object') {
+    return false;
+  }
+  const clause = where as Record<string, unknown>;
+  if ('restaurantId' in clause && clause.restaurantId !== undefined) {
+    return true;
+  }
+  for (const key of ['AND', 'OR'] as const) {
+    const nested = clause[key];
+    if (Array.isArray(nested) && nested.some(hasRestaurantIdFilter)) {
+      return true;
+    }
+    if (nested && typeof nested === 'object' && hasRestaurantIdFilter(nested)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// Exported standalone so it can be unit-tested directly, without needing a
+// real PrismaClient/$extends instance or a live database connection (the
+// guard throws BEFORE calling `query`, so the underlying query never runs
+// for the failing case; for the passing case, tests supply a stub `query`).
+export async function tenantGuardOperation(params: {
+  model?: string;
+  operation: string;
+  args: unknown;
+  query: (args: unknown) => Promise<unknown>;
+}): Promise<unknown> {
+  const { model, operation, args, query } = params;
+
+  if (
+    model &&
+    TENANT_GUARDED_MODELS.has(model) &&
+    GUARDED_OPERATIONS.has(operation)
+  ) {
+    const where = (args as { where?: unknown } | undefined)?.where;
+    if (!hasRestaurantIdFilter(where)) {
+      throw new Error(
+        `Tenant guard: ${model}.${operation}() is missing a restaurantId filter in its where clause. ` +
+          `Every query against a tenant-owned model must explicitly scope by the caller's restaurantId.`,
+      );
+    }
+  }
+
+  return query(args);
+}
+
+export const tenantGuardExtension = Prisma.defineExtension({
+  name: 'tenant-guard',
+  query: {
+    $allModels: {
+      $allOperations: tenantGuardOperation,
+    },
+  },
+});

--- a/src/inventory/inventory.controller.ts
+++ b/src/inventory/inventory.controller.ts
@@ -14,7 +14,10 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 import { Role } from '@prisma/client';
-import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import {
+  AuthUser,
+  CurrentUser,
+} from '../auth/decorators/current-user.decorator';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { AdjustStockDto } from './dto/adjust-stock.dto';
 import { CreateInventoryItemDto } from './dto/create-inventory-item.dto';
@@ -30,8 +33,8 @@ export class InventoryController {
   @Get()
   @ApiOperation({ summary: 'List all inventory items' })
   @ApiResponse({ status: 200, description: 'List of inventory items' })
-  findAll() {
-    return this.inventoryService.findAll();
+  findAll(@CurrentUser() user: AuthUser) {
+    return this.inventoryService.findAll(user);
   }
 
   @Get('low-stock')
@@ -43,24 +46,24 @@ export class InventoryController {
     status: 200,
     description: 'Items where quantityOnHand <= lowStockThreshold',
   })
-  findLowStock() {
-    return this.inventoryService.findLowStock();
+  findLowStock(@CurrentUser() user: AuthUser) {
+    return this.inventoryService.findLowStock(user);
   }
 
   @Get(':id')
   @ApiOperation({ summary: 'Get a single inventory item' })
   @ApiResponse({ status: 200, description: 'Inventory item details' })
   @ApiResponse({ status: 404, description: 'Item not found' })
-  findOne(@Param('id') id: string) {
-    return this.inventoryService.findOne(id);
+  findOne(@Param('id') id: string, @CurrentUser() user: AuthUser) {
+    return this.inventoryService.findOne(id, user);
   }
 
   @Post()
   @ApiOperation({ summary: 'Create a new inventory item' })
   @ApiResponse({ status: 201, description: 'Inventory item created' })
   @ApiResponse({ status: 400, description: 'Validation error' })
-  create(@Body() dto: CreateInventoryItemDto) {
-    return this.inventoryService.create(dto);
+  create(@Body() dto: CreateInventoryItemDto, @CurrentUser() user: AuthUser) {
+    return this.inventoryService.create(dto, user);
   }
 
   @Patch(':id')
@@ -70,16 +73,17 @@ export class InventoryController {
   update(
     @Param('id') id: string,
     @Body() dto: Partial<CreateInventoryItemDto>,
+    @CurrentUser() user: AuthUser,
   ) {
-    return this.inventoryService.update(id, dto);
+    return this.inventoryService.update(id, dto, user);
   }
 
   @Delete(':id')
   @ApiOperation({ summary: 'Delete an inventory item' })
   @ApiResponse({ status: 200, description: 'Inventory item deleted' })
   @ApiResponse({ status: 404, description: 'Item not found' })
-  remove(@Param('id') id: string) {
-    return this.inventoryService.remove(id);
+  remove(@Param('id') id: string, @CurrentUser() user: AuthUser) {
+    return this.inventoryService.remove(id, user);
   }
 
   @Post(':id/adjust')
@@ -89,8 +93,8 @@ export class InventoryController {
   adjust(
     @Param('id') id: string,
     @Body() dto: AdjustStockDto,
-    @CurrentUser('id') userId: string,
+    @CurrentUser() user: AuthUser,
   ) {
-    return this.inventoryService.adjust(id, dto, userId);
+    return this.inventoryService.adjust(id, dto, user.id, user.restaurantId);
   }
 }

--- a/src/inventory/inventory.service.spec.ts
+++ b/src/inventory/inventory.service.spec.ts
@@ -1,7 +1,7 @@
 import { NotFoundException } from '@nestjs/common';
-import { AdjustmentType } from '@prisma/client';
+import { AdjustmentType, Role } from '@prisma/client';
+import { AuthUser } from '../auth/decorators/current-user.decorator';
 import { PrismaService } from '../prisma/prisma.service';
-import { DEFAULT_RESTAURANT_ID } from '../common/constants/tenancy';
 import { InventoryService } from './inventory.service';
 
 type MockPrisma = {
@@ -34,6 +34,16 @@ function createMockPrisma(): MockPrisma {
   };
 }
 
+function buildUser(overrides: Partial<AuthUser> = {}): AuthUser {
+  return {
+    id: 'user-1',
+    email: 'manager@restosync.local',
+    role: Role.MANAGER,
+    restaurantId: 'restaurant-A',
+    ...overrides,
+  };
+}
+
 describe('InventoryService', () => {
   let service: InventoryService;
   let prisma: MockPrisma;
@@ -41,7 +51,7 @@ describe('InventoryService', () => {
   let txInventoryItemUpdate: jest.Mock;
 
   const itemId = 'item-1';
-  const actorId = 'user-1';
+  const user = buildUser();
 
   beforeEach(() => {
     prisma = createMockPrisma();
@@ -58,8 +68,22 @@ describe('InventoryService', () => {
     service = new InventoryService(prisma as unknown as PrismaService);
   });
 
+  describe('findAll', () => {
+    it('scopes the query to the caller restaurantId', async () => {
+      prisma.inventoryItem.findMany.mockResolvedValue([]);
+
+      await service.findAll(user);
+
+      expect(prisma.inventoryItem.findMany).toHaveBeenCalledWith({
+        where: { restaurantId: user.restaurantId },
+        include: { menuItem: true },
+        orderBy: { name: 'asc' },
+      });
+    });
+  });
+
   describe('create', () => {
-    it('creates an item with the correct fields', async () => {
+    it('creates an item with the correct fields, using the caller restaurantId', async () => {
       prisma.inventoryItem.create.mockResolvedValue({
         id: itemId,
         name: 'Tomato',
@@ -67,14 +91,18 @@ describe('InventoryService', () => {
         quantityOnHand: 10,
         lowStockThreshold: 3,
         menuItemId: null,
+        restaurantId: user.restaurantId,
       });
 
-      await service.create({
-        name: 'Tomato',
-        unit: 'kg',
-        quantityOnHand: 10,
-        lowStockThreshold: 3,
-      });
+      await service.create(
+        {
+          name: 'Tomato',
+          unit: 'kg',
+          quantityOnHand: 10,
+          lowStockThreshold: 3,
+        },
+        user,
+      );
 
       expect(prisma.inventoryItem.create).toHaveBeenCalledWith({
         data: {
@@ -83,7 +111,7 @@ describe('InventoryService', () => {
           quantityOnHand: 10,
           lowStockThreshold: 3,
           menuItemId: null,
-          restaurantId: DEFAULT_RESTAURANT_ID,
+          restaurantId: user.restaurantId,
         },
       });
     });
@@ -91,7 +119,7 @@ describe('InventoryService', () => {
     it('applies defaults when optional fields are omitted', async () => {
       prisma.inventoryItem.create.mockResolvedValue({});
 
-      await service.create({ name: 'Salt' });
+      await service.create({ name: 'Salt' }, user);
 
       expect(prisma.inventoryItem.create).toHaveBeenCalledWith({
         data: {
@@ -100,23 +128,40 @@ describe('InventoryService', () => {
           quantityOnHand: 0,
           lowStockThreshold: 0,
           menuItemId: null,
-          restaurantId: DEFAULT_RESTAURANT_ID,
+          restaurantId: user.restaurantId,
         },
       });
+    });
+
+    it("ignores a client-supplied restaurantId and always uses the caller's own", async () => {
+      prisma.inventoryItem.create.mockResolvedValue({});
+
+      await service.create(
+        {
+          name: 'Salt',
+          // @ts-expect-error simulating a malicious/naive client payload
+          restaurantId: 'restaurant-EVIL',
+        },
+        user,
+      );
+
+      const { data } = prisma.inventoryItem.create.mock.calls[0][0];
+      expect(data.restaurantId).toBe(user.restaurantId);
     });
   });
 
   describe('findOne', () => {
-    it('returns the item with its relations', async () => {
+    it('returns the item with its relations when it belongs to the caller restaurant', async () => {
       const item = {
         id: itemId,
         name: 'Tomato',
+        restaurantId: user.restaurantId,
         menuItem: null,
         adjustments: [],
       };
       prisma.inventoryItem.findUnique.mockResolvedValue(item);
 
-      const result = await service.findOne(itemId);
+      const result = await service.findOne(itemId, user);
 
       expect(prisma.inventoryItem.findUnique).toHaveBeenCalledWith({
         where: { id: itemId },
@@ -128,7 +173,21 @@ describe('InventoryService', () => {
     it('throws NotFoundException if the item does not exist', async () => {
       prisma.inventoryItem.findUnique.mockResolvedValue(null);
 
-      await expect(service.findOne(itemId)).rejects.toThrow(NotFoundException);
+      await expect(service.findOne(itemId, user)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('throws NotFoundException (not the item) for an item belonging to another restaurant', async () => {
+      prisma.inventoryItem.findUnique.mockResolvedValue({
+        id: itemId,
+        name: 'Secret Sauce',
+        restaurantId: 'restaurant-B',
+      });
+
+      await expect(service.findOne(itemId, user)).rejects.toThrow(
+        NotFoundException,
+      );
     });
   });
 
@@ -137,12 +196,14 @@ describe('InventoryService', () => {
       prisma.inventoryItem.findUnique.mockResolvedValue({
         id: itemId,
         quantityOnHand: 10,
+        restaurantId: user.restaurantId,
       });
 
       await service.adjust(
         itemId,
         { type: AdjustmentType.RESTOCK, quantityDelta: 5 },
-        actorId,
+        user.id,
+        user.restaurantId,
       );
 
       expect(txInventoryItemUpdate).toHaveBeenCalledWith({
@@ -156,12 +217,14 @@ describe('InventoryService', () => {
       prisma.inventoryItem.findUnique.mockResolvedValue({
         id: itemId,
         quantityOnHand: 15,
+        restaurantId: user.restaurantId,
       });
 
       await service.adjust(
         itemId,
         { type: AdjustmentType.WASTE, quantityDelta: -13 },
-        actorId,
+        user.id,
+        user.restaurantId,
       );
 
       expect(txInventoryItemUpdate).toHaveBeenCalledWith({
@@ -175,12 +238,14 @@ describe('InventoryService', () => {
       prisma.inventoryItem.findUnique.mockResolvedValue({
         id: itemId,
         quantityOnHand: 2,
+        restaurantId: user.restaurantId,
       });
 
       await service.adjust(
         itemId,
         { type: AdjustmentType.WASTE, quantityDelta: -99 },
-        actorId,
+        user.id,
+        user.restaurantId,
       );
 
       expect(txInventoryItemUpdate).toHaveBeenCalledWith({
@@ -194,12 +259,14 @@ describe('InventoryService', () => {
       prisma.inventoryItem.findUnique.mockResolvedValue({
         id: itemId,
         quantityOnHand: 3,
+        restaurantId: user.restaurantId,
       });
 
       await service.adjust(
         itemId,
         { type: AdjustmentType.SALE, quantityDelta: -5 },
-        actorId,
+        user.id,
+        user.restaurantId,
       );
 
       expect(txInventoryItemUpdate).toHaveBeenCalledWith({
@@ -213,8 +280,8 @@ describe('InventoryService', () => {
           type: AdjustmentType.SALE,
           quantityDelta: -5,
           reason: null,
-          performedById: actorId,
-          restaurantId: DEFAULT_RESTAURANT_ID,
+          performedById: user.id,
+          restaurantId: user.restaurantId,
         },
       });
     });
@@ -223,6 +290,7 @@ describe('InventoryService', () => {
       prisma.inventoryItem.findUnique.mockResolvedValue({
         id: itemId,
         quantityOnHand: 10,
+        restaurantId: user.restaurantId,
       });
 
       await service.adjust(
@@ -232,7 +300,8 @@ describe('InventoryService', () => {
           quantityDelta: -1,
           reason: 'Recount',
         },
-        actorId,
+        user.id,
+        user.restaurantId,
       );
 
       expect(txStockAdjustmentCreate).toHaveBeenCalledWith({
@@ -241,8 +310,8 @@ describe('InventoryService', () => {
           type: AdjustmentType.CORRECTION,
           quantityDelta: -1,
           reason: 'Recount',
-          performedById: actorId,
-          restaurantId: DEFAULT_RESTAURANT_ID,
+          performedById: user.id,
+          restaurantId: user.restaurantId,
         },
       });
     });
@@ -254,7 +323,26 @@ describe('InventoryService', () => {
         service.adjust(
           itemId,
           { type: AdjustmentType.RESTOCK, quantityDelta: 5 },
-          actorId,
+          user.id,
+          user.restaurantId,
+        ),
+      ).rejects.toThrow(NotFoundException);
+      expect(prisma.$transaction).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException (not the item) for an item belonging to another restaurant', async () => {
+      prisma.inventoryItem.findUnique.mockResolvedValue({
+        id: itemId,
+        quantityOnHand: 10,
+        restaurantId: 'restaurant-B',
+      });
+
+      await expect(
+        service.adjust(
+          itemId,
+          { type: AdjustmentType.RESTOCK, quantityDelta: 5 },
+          user.id,
+          user.restaurantId,
         ),
       ).rejects.toThrow(NotFoundException);
       expect(prisma.$transaction).not.toHaveBeenCalled();
@@ -268,20 +356,23 @@ describe('InventoryService', () => {
         { id: '2', quantityOnHand: 10, lowStockThreshold: 3 },
       ]);
 
-      const result = await service.findLowStock();
+      const result = await service.findLowStock(user);
 
       expect(result).toHaveLength(1);
       expect(result[0].id).toBe('1');
     });
 
-    it('excludes items with lowStockThreshold = 0 via the where filter', async () => {
+    it('excludes items with lowStockThreshold = 0 via the where filter, scoped by restaurantId', async () => {
       prisma.inventoryItem.findMany.mockResolvedValue([]);
 
-      await service.findLowStock();
+      await service.findLowStock(user);
 
       expect(prisma.inventoryItem.findMany).toHaveBeenCalledWith(
         expect.objectContaining({
-          where: { lowStockThreshold: { gt: 0 } },
+          where: {
+            restaurantId: user.restaurantId,
+            lowStockThreshold: { gt: 0 },
+          },
         }),
       );
     });
@@ -291,7 +382,7 @@ describe('InventoryService', () => {
         { id: '1', quantityOnHand: 0, lowStockThreshold: 3 },
       ]);
 
-      const result = await service.findLowStock();
+      const result = await service.findLowStock(user);
 
       expect(result[0].alertLevel).toBe('CRITICAL');
     });
@@ -301,7 +392,7 @@ describe('InventoryService', () => {
         { id: '1', quantityOnHand: 2, lowStockThreshold: 3 },
       ]);
 
-      const result = await service.findLowStock();
+      const result = await service.findLowStock(user);
 
       expect(result[0].alertLevel).toBe('LOW');
     });
@@ -311,7 +402,7 @@ describe('InventoryService', () => {
         { id: '1', quantityOnHand: 10, lowStockThreshold: 3 },
       ]);
 
-      const result = await service.findLowStock();
+      const result = await service.findLowStock(user);
 
       expect(result).toEqual([]);
     });

--- a/src/inventory/inventory.service.spec.ts
+++ b/src/inventory/inventory.service.spec.ts
@@ -1,6 +1,7 @@
 import { NotFoundException } from '@nestjs/common';
 import { AdjustmentType } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
+import { DEFAULT_RESTAURANT_ID } from '../common/constants/tenancy';
 import { InventoryService } from './inventory.service';
 
 type MockPrisma = {
@@ -82,6 +83,7 @@ describe('InventoryService', () => {
           quantityOnHand: 10,
           lowStockThreshold: 3,
           menuItemId: null,
+          restaurantId: DEFAULT_RESTAURANT_ID,
         },
       });
     });
@@ -98,6 +100,7 @@ describe('InventoryService', () => {
           quantityOnHand: 0,
           lowStockThreshold: 0,
           menuItemId: null,
+          restaurantId: DEFAULT_RESTAURANT_ID,
         },
       });
     });
@@ -211,6 +214,7 @@ describe('InventoryService', () => {
           quantityDelta: -5,
           reason: null,
           performedById: actorId,
+          restaurantId: DEFAULT_RESTAURANT_ID,
         },
       });
     });
@@ -238,6 +242,7 @@ describe('InventoryService', () => {
           quantityDelta: -1,
           reason: 'Recount',
           performedById: actorId,
+          restaurantId: DEFAULT_RESTAURANT_ID,
         },
       });
     });

--- a/src/inventory/inventory.service.ts
+++ b/src/inventory/inventory.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
+import { DEFAULT_RESTAURANT_ID } from '../common/constants/tenancy';
 import { AdjustStockDto } from './dto/adjust-stock.dto';
 import { CreateInventoryItemDto } from './dto/create-inventory-item.dto';
 
@@ -33,6 +34,7 @@ export class InventoryService {
         quantityOnHand: dto.quantityOnHand ?? 0,
         lowStockThreshold: dto.lowStockThreshold ?? 0,
         menuItemId: dto.menuItemId ?? null,
+        restaurantId: DEFAULT_RESTAURANT_ID,
       },
     });
   }
@@ -73,6 +75,7 @@ export class InventoryService {
           quantityDelta: dto.quantityDelta,
           reason: dto.reason ?? null,
           performedById: actorId,
+          restaurantId: DEFAULT_RESTAURANT_ID,
         },
       });
 

--- a/src/inventory/inventory.service.ts
+++ b/src/inventory/inventory.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
+import { AuthUser } from '../auth/decorators/current-user.decorator';
 import { PrismaService } from '../prisma/prisma.service';
-import { DEFAULT_RESTAURANT_ID } from '../common/constants/tenancy';
 import { AdjustStockDto } from './dto/adjust-stock.dto';
 import { CreateInventoryItemDto } from './dto/create-inventory-item.dto';
 
@@ -8,25 +8,26 @@ import { CreateInventoryItemDto } from './dto/create-inventory-item.dto';
 export class InventoryService {
   constructor(private readonly prisma: PrismaService) {}
 
-  findAll() {
+  findAll(user: AuthUser) {
     return this.prisma.inventoryItem.findMany({
+      where: { restaurantId: user.restaurantId },
       include: { menuItem: true },
       orderBy: { name: 'asc' },
     });
   }
 
-  async findOne(id: string) {
+  async findOne(id: string, user: AuthUser) {
     const item = await this.prisma.inventoryItem.findUnique({
       where: { id },
       include: { menuItem: true, adjustments: true },
     });
-    if (!item) {
+    if (!item || item.restaurantId !== user.restaurantId) {
       throw new NotFoundException('Inventory item not found');
     }
     return item;
   }
 
-  create(dto: CreateInventoryItemDto) {
+  create(dto: CreateInventoryItemDto, user: AuthUser) {
     return this.prisma.inventoryItem.create({
       data: {
         name: dto.name,
@@ -34,13 +35,17 @@ export class InventoryService {
         quantityOnHand: dto.quantityOnHand ?? 0,
         lowStockThreshold: dto.lowStockThreshold ?? 0,
         menuItemId: dto.menuItemId ?? null,
-        restaurantId: DEFAULT_RESTAURANT_ID,
+        restaurantId: user.restaurantId,
       },
     });
   }
 
-  async update(id: string, dto: Partial<CreateInventoryItemDto>) {
-    await this.ensureExists(id);
+  async update(
+    id: string,
+    dto: Partial<CreateInventoryItemDto>,
+    user: AuthUser,
+  ) {
+    await this.ensureExists(id, user);
     return this.prisma.inventoryItem.update({
       where: { id },
       data: {
@@ -54,16 +59,25 @@ export class InventoryService {
     });
   }
 
-  async remove(id: string) {
-    await this.ensureExists(id);
+  async remove(id: string, user: AuthUser) {
+    await this.ensureExists(id, user);
     return this.prisma.inventoryItem.delete({ where: { id } });
   }
 
-  async adjust(id: string, dto: AdjustStockDto, actorId: string) {
+  // Takes restaurantId/actorId directly rather than a full AuthUser: this
+  // is also called internally by PaymentsService's best-effort inventory
+  // hook (#51), which acts on behalf of an already-verified order/actor
+  // pair rather than an authenticated HTTP request.
+  async adjust(
+    id: string,
+    dto: AdjustStockDto,
+    actorId: string,
+    restaurantId: string,
+  ) {
     const item = await this.prisma.inventoryItem.findUnique({
       where: { id },
     });
-    if (!item) {
+    if (!item || item.restaurantId !== restaurantId) {
       throw new NotFoundException('Inventory item not found');
     }
 
@@ -75,7 +89,7 @@ export class InventoryService {
           quantityDelta: dto.quantityDelta,
           reason: dto.reason ?? null,
           performedById: actorId,
-          restaurantId: DEFAULT_RESTAURANT_ID,
+          restaurantId,
         },
       });
 
@@ -89,9 +103,9 @@ export class InventoryService {
     });
   }
 
-  async findLowStock() {
+  async findLowStock(user: AuthUser) {
     const items = await this.prisma.inventoryItem.findMany({
-      where: { lowStockThreshold: { gt: 0 } },
+      where: { restaurantId: user.restaurantId, lowStockThreshold: { gt: 0 } },
       orderBy: { name: 'asc' },
     });
     return items
@@ -103,11 +117,11 @@ export class InventoryService {
       }));
   }
 
-  private async ensureExists(id: string) {
+  private async ensureExists(id: string, user: AuthUser) {
     const exists = await this.prisma.inventoryItem.findUnique({
       where: { id },
     });
-    if (!exists) {
+    if (!exists || exists.restaurantId !== user.restaurantId) {
       throw new NotFoundException('Inventory item not found');
     }
   }

--- a/src/menu/categories.controller.ts
+++ b/src/menu/categories.controller.ts
@@ -9,6 +9,10 @@ import {
 } from '@nestjs/common';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { Role } from '@prisma/client';
+import {
+  AuthUser,
+  CurrentUser,
+} from '../auth/decorators/current-user.decorator';
 import { Public } from '../auth/decorators/public.decorator';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { CategoriesService } from './categories.service';
@@ -34,21 +38,25 @@ export class CategoriesController {
   @ApiBearerAuth()
   @Roles(Role.ADMIN)
   @Post()
-  create(@Body() dto: CreateCategoryDto) {
-    return this.categoriesService.create(dto);
+  create(@Body() dto: CreateCategoryDto, @CurrentUser() user: AuthUser) {
+    return this.categoriesService.create(dto, user);
   }
 
   @ApiBearerAuth()
   @Roles(Role.ADMIN)
   @Patch(':id')
-  update(@Param('id') id: string, @Body() dto: UpdateCategoryDto) {
-    return this.categoriesService.update(id, dto);
+  update(
+    @Param('id') id: string,
+    @Body() dto: UpdateCategoryDto,
+    @CurrentUser() user: AuthUser,
+  ) {
+    return this.categoriesService.update(id, dto, user);
   }
 
   @ApiBearerAuth()
   @Roles(Role.ADMIN)
   @Delete(':id')
-  remove(@Param('id') id: string) {
-    return this.categoriesService.remove(id);
+  remove(@Param('id') id: string, @CurrentUser() user: AuthUser) {
+    return this.categoriesService.remove(id, user);
   }
 }

--- a/src/menu/categories.service.spec.ts
+++ b/src/menu/categories.service.spec.ts
@@ -1,0 +1,122 @@
+import { NotFoundException } from '@nestjs/common';
+import { Role } from '@prisma/client';
+import { AuthUser } from '../auth/decorators/current-user.decorator';
+import { PrismaService } from '../prisma/prisma.service';
+import { DEFAULT_RESTAURANT_ID } from '../common/constants/tenancy';
+import { CategoriesService } from './categories.service';
+
+type MockPrisma = {
+  category: {
+    create: jest.Mock;
+    findMany: jest.Mock;
+    findUnique: jest.Mock;
+    update: jest.Mock;
+    delete: jest.Mock;
+  };
+};
+
+function createMockPrisma(): MockPrisma {
+  return {
+    category: {
+      create: jest.fn(),
+      findMany: jest.fn(),
+      findUnique: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    },
+  };
+}
+
+function buildUser(overrides: Partial<AuthUser> = {}): AuthUser {
+  return {
+    id: 'user-1',
+    email: 'admin@restosync.local',
+    role: Role.ADMIN,
+    restaurantId: 'restaurant-A',
+    ...overrides,
+  };
+}
+
+describe('CategoriesService', () => {
+  let service: CategoriesService;
+  let prisma: MockPrisma;
+  const user = buildUser();
+
+  beforeEach(() => {
+    prisma = createMockPrisma();
+    service = new CategoriesService(prisma as unknown as PrismaService);
+  });
+
+  describe('create', () => {
+    it('sets restaurantId from the caller, never from the client', async () => {
+      prisma.category.create.mockResolvedValue({});
+
+      await service.create(
+        {
+          name: 'Burgers',
+          // Simulates a malicious/naive client payload.
+          // @ts-expect-error not part of CreateCategoryDto
+          restaurantId: 'restaurant-EVIL',
+        },
+        user,
+      );
+
+      const { data } = prisma.category.create.mock.calls[0][0];
+      expect(data.restaurantId).toBe(user.restaurantId);
+    });
+  });
+
+  describe('findAll (public endpoint)', () => {
+    it('scopes to the default restaurant (no authenticated caller for public browsing)', async () => {
+      prisma.category.findMany.mockResolvedValue([]);
+
+      await service.findAll();
+
+      expect(prisma.category.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            restaurantId: DEFAULT_RESTAURANT_ID,
+          }),
+        }),
+      );
+    });
+  });
+
+  describe('update / remove', () => {
+    it('throws NotFoundException (404, NOT 403) when updating a category belonging to another restaurant', async () => {
+      prisma.category.findUnique.mockResolvedValue({
+        id: 'cat-1',
+        restaurantId: 'restaurant-B',
+      });
+
+      await expect(
+        service.update('cat-1', { name: 'New name' }, user),
+      ).rejects.toThrow(NotFoundException);
+      expect(prisma.category.update).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException (404, NOT 403) when removing a category belonging to another restaurant', async () => {
+      prisma.category.findUnique.mockResolvedValue({
+        id: 'cat-1',
+        restaurantId: 'restaurant-B',
+      });
+
+      await expect(service.remove('cat-1', user)).rejects.toThrow(
+        NotFoundException,
+      );
+      expect(prisma.category.delete).not.toHaveBeenCalled();
+    });
+
+    it('updates successfully when the category belongs to the caller restaurant', async () => {
+      prisma.category.findUnique.mockResolvedValue({
+        id: 'cat-1',
+        restaurantId: user.restaurantId,
+      });
+      prisma.category.update.mockResolvedValue({ id: 'cat-1', name: 'New' });
+
+      const result = await service.update('cat-1', { name: 'New' }, user);
+
+      expect(result).toEqual({ id: 'cat-1', name: 'New' });
+    });
+  });
+});

--- a/src/menu/categories.service.ts
+++ b/src/menu/categories.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
+import { AuthUser } from '../auth/decorators/current-user.decorator';
 import { PrismaService } from '../prisma/prisma.service';
 import { DEFAULT_RESTAURANT_ID } from '../common/constants/tenancy';
 import { CreateCategoryDto, UpdateCategoryDto } from './dto/category.dto';
@@ -7,43 +8,53 @@ import { CreateCategoryDto, UpdateCategoryDto } from './dto/category.dto';
 export class CategoriesService {
   constructor(private readonly prisma: PrismaService) {}
 
-  create(dto: CreateCategoryDto) {
+  create(dto: CreateCategoryDto, user: AuthUser) {
     return this.prisma.category.create({
-      data: { ...dto, restaurantId: DEFAULT_RESTAURANT_ID },
+      data: { ...dto, restaurantId: user.restaurantId },
     });
   }
 
+  // @Public() endpoint (unauthenticated menu browsing) — there is no
+  // caller restaurantId to scope by yet. Until public multi-tenant menu
+  // browsing gets real tenant resolution (e.g. a restaurant slug/subdomain
+  // — out of this prompt's scope), this scopes to the single default
+  // restaurant, matching the same temporary-default precedent already
+  // established for AuthService.register() in #151.
   findAll(includeInactive = false) {
     return this.prisma.category.findMany({
-      where: includeInactive ? {} : { active: true },
+      where: {
+        restaurantId: DEFAULT_RESTAURANT_ID,
+        ...(includeInactive ? {} : { active: true }),
+      },
       orderBy: [{ sortOrder: 'asc' }, { name: 'asc' }],
     });
   }
 
+  // @Public() endpoint — see findAll's note on DEFAULT_RESTAURANT_ID.
   async findOne(id: string) {
     const category = await this.prisma.category.findUnique({
       where: { id },
       include: { items: true },
     });
-    if (!category) {
+    if (!category || category.restaurantId !== DEFAULT_RESTAURANT_ID) {
       throw new NotFoundException('Category not found');
     }
     return category;
   }
 
-  async update(id: string, dto: UpdateCategoryDto) {
-    await this.ensureExists(id);
+  async update(id: string, dto: UpdateCategoryDto, user: AuthUser) {
+    await this.ensureExists(id, user);
     return this.prisma.category.update({ where: { id }, data: dto });
   }
 
-  async remove(id: string) {
-    await this.ensureExists(id);
+  async remove(id: string, user: AuthUser) {
+    await this.ensureExists(id, user);
     return this.prisma.category.delete({ where: { id } });
   }
 
-  private async ensureExists(id: string) {
+  private async ensureExists(id: string, user: AuthUser) {
     const exists = await this.prisma.category.findUnique({ where: { id } });
-    if (!exists) {
+    if (!exists || exists.restaurantId !== user.restaurantId) {
       throw new NotFoundException('Category not found');
     }
   }

--- a/src/menu/categories.service.ts
+++ b/src/menu/categories.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
+import { DEFAULT_RESTAURANT_ID } from '../common/constants/tenancy';
 import { CreateCategoryDto, UpdateCategoryDto } from './dto/category.dto';
 
 @Injectable()
@@ -7,7 +8,9 @@ export class CategoriesService {
   constructor(private readonly prisma: PrismaService) {}
 
   create(dto: CreateCategoryDto) {
-    return this.prisma.category.create({ data: dto });
+    return this.prisma.category.create({
+      data: { ...dto, restaurantId: DEFAULT_RESTAURANT_ID },
+    });
   }
 
   findAll(includeInactive = false) {

--- a/src/menu/menu-items.controller.ts
+++ b/src/menu/menu-items.controller.ts
@@ -10,6 +10,10 @@ import {
 } from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { Role } from '@prisma/client';
+import {
+  AuthUser,
+  CurrentUser,
+} from '../auth/decorators/current-user.decorator';
 import { Public } from '../auth/decorators/public.decorator';
 import { Roles } from '../auth/decorators/roles.decorator';
 import {
@@ -45,8 +49,8 @@ export class MenuItemsController {
     summary: 'Create a menu item (imageUrl is a public URL, no file upload)',
   })
   @Post()
-  create(@Body() dto: CreateMenuItemDto) {
-    return this.menuItemsService.create(dto);
+  create(@Body() dto: CreateMenuItemDto, @CurrentUser() user: AuthUser) {
+    return this.menuItemsService.create(dto, user);
   }
 
   @ApiBearerAuth()
@@ -55,15 +59,19 @@ export class MenuItemsController {
     summary: 'Associate a public image URL with a product',
   })
   @Patch(':id')
-  update(@Param('id') id: string, @Body() dto: UpdateMenuItemDto) {
-    return this.menuItemsService.update(id, dto);
+  update(
+    @Param('id') id: string,
+    @Body() dto: UpdateMenuItemDto,
+    @CurrentUser() user: AuthUser,
+  ) {
+    return this.menuItemsService.update(id, dto, user);
   }
 
   @ApiBearerAuth()
   @Roles(Role.ADMIN)
   @Delete(':id')
-  remove(@Param('id') id: string) {
-    return this.menuItemsService.remove(id);
+  remove(@Param('id') id: string, @CurrentUser() user: AuthUser) {
+    return this.menuItemsService.remove(id, user);
   }
 
   @ApiBearerAuth()
@@ -72,7 +80,7 @@ export class MenuItemsController {
     summary: 'Deactivate a product (soft delete — preserves order history)',
   })
   @Patch(':id/deactivate')
-  deactivate(@Param('id') id: string) {
-    return this.menuItemsService.deactivate(id);
+  deactivate(@Param('id') id: string, @CurrentUser() user: AuthUser) {
+    return this.menuItemsService.deactivate(id, user);
   }
 }

--- a/src/menu/menu-items.service.spec.ts
+++ b/src/menu/menu-items.service.spec.ts
@@ -1,0 +1,147 @@
+import { NotFoundException } from '@nestjs/common';
+import { Role } from '@prisma/client';
+import { AuthUser } from '../auth/decorators/current-user.decorator';
+import { PrismaService } from '../prisma/prisma.service';
+import { DEFAULT_RESTAURANT_ID } from '../common/constants/tenancy';
+import { MenuItemsService } from './menu-items.service';
+
+type MockPrisma = {
+  menuItem: {
+    create: jest.Mock;
+    findMany: jest.Mock;
+    findUnique: jest.Mock;
+    update: jest.Mock;
+    delete: jest.Mock;
+    count: jest.Mock;
+  };
+  orderItem: {
+    count: jest.Mock;
+  };
+  $transaction: jest.Mock;
+};
+
+function createMockPrisma(): MockPrisma {
+  return {
+    menuItem: {
+      create: jest.fn(),
+      findMany: jest.fn(),
+      findUnique: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+      count: jest.fn(),
+    },
+    orderItem: {
+      count: jest.fn(),
+    },
+    $transaction: jest.fn(),
+  };
+}
+
+function buildUser(overrides: Partial<AuthUser> = {}): AuthUser {
+  return {
+    id: 'user-1',
+    email: 'admin@restosync.local',
+    role: Role.ADMIN,
+    restaurantId: 'restaurant-A',
+    ...overrides,
+  };
+}
+
+describe('MenuItemsService', () => {
+  let service: MenuItemsService;
+  let prisma: MockPrisma;
+  const user = buildUser();
+
+  beforeEach(() => {
+    prisma = createMockPrisma();
+    prisma.$transaction.mockImplementation((ops: Promise<unknown>[]) =>
+      Promise.all(ops),
+    );
+    service = new MenuItemsService(prisma as unknown as PrismaService);
+  });
+
+  describe('create', () => {
+    it('sets restaurantId from the caller, never from the client', async () => {
+      prisma.menuItem.create.mockResolvedValue({});
+
+      await service.create(
+        {
+          name: 'Cheeseburger',
+          priceCents: 1200,
+          categoryId: 'cat-1',
+          // @ts-expect-error simulating a malicious/naive client payload
+          restaurantId: 'restaurant-EVIL',
+        },
+        user,
+      );
+
+      const { data } = prisma.menuItem.create.mock.calls[0][0];
+      expect(data.restaurantId).toBe(user.restaurantId);
+    });
+  });
+
+  describe('findAll (public endpoint)', () => {
+    it('scopes to the default restaurant (no authenticated caller for public browsing)', async () => {
+      prisma.menuItem.findMany.mockResolvedValue([]);
+      prisma.menuItem.count.mockResolvedValue(0);
+
+      await service.findAll({ page: 1, limit: 20 } as any);
+
+      expect(prisma.menuItem.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            restaurantId: DEFAULT_RESTAURANT_ID,
+          }),
+        }),
+      );
+    });
+  });
+
+  describe('update / remove / deactivate', () => {
+    it('throws NotFoundException (404, NOT 403) when updating an item belonging to another restaurant', async () => {
+      prisma.menuItem.findUnique.mockResolvedValue({
+        id: 'item-1',
+        restaurantId: 'restaurant-B',
+      });
+
+      await expect(
+        service.update('item-1', { name: 'New name' }, user),
+      ).rejects.toThrow(NotFoundException);
+      expect(prisma.menuItem.update).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException (404, NOT 403) when removing an item belonging to another restaurant', async () => {
+      prisma.menuItem.findUnique.mockResolvedValue({
+        id: 'item-1',
+        restaurantId: 'restaurant-B',
+      });
+
+      await expect(service.remove('item-1', user)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('throws NotFoundException (404, NOT 403) when deactivating an item belonging to another restaurant', async () => {
+      prisma.menuItem.findUnique.mockResolvedValue({
+        id: 'item-1',
+        restaurantId: 'restaurant-B',
+      });
+
+      await expect(service.deactivate('item-1', user)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('updates successfully when the item belongs to the caller restaurant', async () => {
+      prisma.menuItem.findUnique.mockResolvedValue({
+        id: 'item-1',
+        restaurantId: user.restaurantId,
+      });
+      prisma.menuItem.update.mockResolvedValue({ id: 'item-1', name: 'New' });
+
+      const result = await service.update('item-1', { name: 'New' }, user);
+
+      expect(result).toEqual({ id: 'item-1', name: 'New' });
+    });
+  });
+});

--- a/src/menu/menu-items.service.ts
+++ b/src/menu/menu-items.service.ts
@@ -4,6 +4,7 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
+import { AuthUser } from '../auth/decorators/current-user.decorator';
 import { PrismaService } from '../prisma/prisma.service';
 import { paginate } from '../common/dto/pagination-query.dto';
 import { DEFAULT_RESTAURANT_ID } from '../common/constants/tenancy';
@@ -20,14 +21,19 @@ import {
 export class MenuItemsService {
   constructor(private readonly prisma: PrismaService) {}
 
-  create(dto: CreateMenuItemDto) {
+  create(dto: CreateMenuItemDto, user: AuthUser) {
     return this.prisma.menuItem.create({
-      data: { ...dto, restaurantId: DEFAULT_RESTAURANT_ID },
+      data: { ...dto, restaurantId: user.restaurantId },
     });
   }
 
+  // @Public() endpoint (unauthenticated menu browsing) — see
+  // CategoriesService.findAll's note: scopes to the single default
+  // restaurant until public tenant resolution exists (out of scope here).
   async findAll(query: MenuItemQueryDto) {
-    const where: Prisma.MenuItemWhereInput = {};
+    const where: Prisma.MenuItemWhereInput = {
+      restaurantId: DEFAULT_RESTAURANT_ID,
+    };
     if (query.name) {
       where.name = { contains: query.name, mode: 'insensitive' };
     }
@@ -50,24 +56,25 @@ export class MenuItemsService {
     return paginate(data, total, query.page, query.limit);
   }
 
+  // @Public() endpoint — see findAll's note on DEFAULT_RESTAURANT_ID.
   async findOne(id: string) {
     const item = await this.prisma.menuItem.findUnique({ where: { id } });
-    if (!item) {
+    if (!item || item.restaurantId !== DEFAULT_RESTAURANT_ID) {
       throw new NotFoundException('Menu item not found');
     }
     return item;
   }
 
-  async update(id: string, dto: UpdateMenuItemDto) {
-    await this.findOne(id);
+  async update(id: string, dto: UpdateMenuItemDto, user: AuthUser) {
+    await this.ensureExists(id, user);
     return this.prisma.menuItem.update({ where: { id }, data: dto });
   }
 
-  async remove(id: string) {
-    await this.findOne(id);
+  async remove(id: string, user: AuthUser) {
+    await this.ensureExists(id, user);
 
     const orderItemCount = await this.prisma.orderItem.count({
-      where: { menuItemId: id },
+      where: { menuItemId: id, restaurantId: user.restaurantId },
     });
 
     if (orderItemCount > 0) {
@@ -79,11 +86,18 @@ export class MenuItemsService {
     return this.prisma.menuItem.delete({ where: { id } });
   }
 
-  async deactivate(id: string) {
-    await this.findOne(id);
+  async deactivate(id: string, user: AuthUser) {
+    await this.ensureExists(id, user);
     return this.prisma.menuItem.update({
       where: { id },
       data: { available: false },
     });
+  }
+
+  private async ensureExists(id: string, user: AuthUser) {
+    const item = await this.prisma.menuItem.findUnique({ where: { id } });
+    if (!item || item.restaurantId !== user.restaurantId) {
+      throw new NotFoundException('Menu item not found');
+    }
   }
 }

--- a/src/menu/menu-items.service.ts
+++ b/src/menu/menu-items.service.ts
@@ -6,6 +6,7 @@ import {
 import { Prisma } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { paginate } from '../common/dto/pagination-query.dto';
+import { DEFAULT_RESTAURANT_ID } from '../common/constants/tenancy';
 import {
   CreateMenuItemDto,
   MenuItemQueryDto,
@@ -20,7 +21,9 @@ export class MenuItemsService {
   constructor(private readonly prisma: PrismaService) {}
 
   create(dto: CreateMenuItemDto) {
-    return this.prisma.menuItem.create({ data: dto });
+    return this.prisma.menuItem.create({
+      data: { ...dto, restaurantId: DEFAULT_RESTAURANT_ID },
+    });
   }
 
   async findAll(query: MenuItemQueryDto) {

--- a/src/orders/orders.controller.ts
+++ b/src/orders/orders.controller.ts
@@ -46,8 +46,8 @@ export class OrdersController {
   @ApiResponse({ status: 201, description: 'Order created in DRAFT status' })
   @ApiResponse({ status: 400, description: 'Validation error' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
-  create(@Body() dto: CreateOrderDto, @CurrentUser('id') userId: string) {
-    return this.ordersService.create(dto, userId);
+  create(@Body() dto: CreateOrderDto, @CurrentUser() user: AuthUser) {
+    return this.ordersService.create(dto, user.restaurantId, user.id);
   }
 
   @Get()
@@ -64,8 +64,8 @@ export class OrdersController {
     description: 'List of DRAFT/PENDING orders with totals',
   })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
-  findOpen() {
-    return this.ordersService.findOpen();
+  findOpen(@CurrentUser() user: AuthUser) {
+    return this.ordersService.findOpen(user);
   }
 
   @Get(':id')
@@ -75,8 +75,12 @@ export class OrdersController {
 
   @Roles(Role.ADMIN, Role.STAFF, Role.KITCHEN)
   @Patch(':id/status')
-  updateStatus(@Param('id') id: string, @Body() dto: UpdateOrderStatusDto) {
-    return this.ordersService.updateStatus(id, dto.status);
+  updateStatus(
+    @Param('id') id: string,
+    @Body() dto: UpdateOrderStatusDto,
+    @CurrentUser() user: AuthUser,
+  ) {
+    return this.ordersService.updateStatus(id, dto.status, user);
   }
 
   @ApiBearerAuth()
@@ -96,8 +100,12 @@ export class OrdersController {
   })
   @ApiResponse({ status: 404, description: 'Order or menu item not found' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
-  addItem(@Param('id') id: string, @Body() dto: AddOrderItemDto) {
-    return this.ordersService.addItem(id, dto);
+  addItem(
+    @Param('id') id: string,
+    @Body() dto: AddOrderItemDto,
+    @CurrentUser() user: AuthUser,
+  ) {
+    return this.ordersService.addItem(id, dto, user);
   }
 
   @ApiBearerAuth()
@@ -119,8 +127,9 @@ export class OrdersController {
     @Param('id') id: string,
     @Param('itemId') itemId: string,
     @Body() dto: UpdateOrderItemDto,
+    @CurrentUser() user: AuthUser,
   ) {
-    return this.ordersService.updateItemQuantity(id, itemId, dto);
+    return this.ordersService.updateItemQuantity(id, itemId, dto, user);
   }
 
   @ApiBearerAuth()
@@ -132,8 +141,12 @@ export class OrdersController {
   @ApiResponse({ status: 400, description: 'Order not editable' })
   @ApiResponse({ status: 404, description: 'Order or item not found' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
-  removeItem(@Param('id') id: string, @Param('itemId') itemId: string) {
-    return this.ordersService.removeItem(id, itemId);
+  removeItem(
+    @Param('id') id: string,
+    @Param('itemId') itemId: string,
+    @CurrentUser() user: AuthUser,
+  ) {
+    return this.ordersService.removeItem(id, itemId, user);
   }
 
   @ApiBearerAuth()
@@ -148,8 +161,8 @@ export class OrdersController {
   })
   @ApiResponse({ status: 404, description: 'Order not found' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
-  confirmOrder(@Param('id') id: string) {
-    return this.ordersService.confirmOrder(id);
+  confirmOrder(@Param('id') id: string, @CurrentUser() user: AuthUser) {
+    return this.ordersService.confirmOrder(id, user);
   }
 
   @ApiBearerAuth()
@@ -173,9 +186,9 @@ export class OrdersController {
   applyDiscount(
     @Param('id') id: string,
     @Body() dto: ApplyDiscountDto,
-    @CurrentUser('id') userId: string,
+    @CurrentUser() user: AuthUser,
   ) {
-    return this.ordersService.applyDiscount(id, dto, userId);
+    return this.ordersService.applyDiscount(id, dto, user);
   }
 
   @ApiBearerAuth()
@@ -188,7 +201,7 @@ export class OrdersController {
     description: 'List of audit entries, newest first',
   })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
-  getAuditLog(@Param('id') id: string) {
-    return this.auditService.findByEntity('Order', id);
+  getAuditLog(@Param('id') id: string, @CurrentUser() user: AuthUser) {
+    return this.auditService.findByEntity('Order', id, user.restaurantId);
   }
 }

--- a/src/orders/orders.service.spec.ts
+++ b/src/orders/orders.service.spec.ts
@@ -1,16 +1,19 @@
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { OrderStatus, OrderType, TableStatus } from '@prisma/client';
+import { OrderStatus, OrderType, Role, TableStatus } from '@prisma/client';
 import { OrdersService } from './orders.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { AuditService } from '../audit/audit.service';
 import { RealtimeGateway } from '../realtime/realtime.gateway';
+import { AuthUser } from '../auth/decorators/current-user.decorator';
 
 type MockPrisma = {
   order: {
     findUnique: jest.Mock;
     findFirst: jest.Mock;
+    findMany: jest.Mock;
     update: jest.Mock;
+    count: jest.Mock;
   };
   orderItem: {
     create: jest.Mock;
@@ -21,10 +24,12 @@ type MockPrisma = {
   };
   menuItem: {
     findUnique: jest.Mock;
+    findFirst: jest.Mock;
     findMany: jest.Mock;
   };
   table: {
     findUnique: jest.Mock;
+    findFirst: jest.Mock;
     update: jest.Mock;
   };
   $transaction: jest.Mock;
@@ -35,7 +40,9 @@ function createMockPrisma(): MockPrisma {
     order: {
       findUnique: jest.fn(),
       findFirst: jest.fn(),
+      findMany: jest.fn(),
       update: jest.fn(),
+      count: jest.fn(),
     },
     orderItem: {
       create: jest.fn(),
@@ -46,10 +53,12 @@ function createMockPrisma(): MockPrisma {
     },
     menuItem: {
       findUnique: jest.fn(),
+      findFirst: jest.fn(),
       findMany: jest.fn(),
     },
     table: {
       findUnique: jest.fn(),
+      findFirst: jest.fn(),
       update: jest.fn(),
     },
     $transaction: jest.fn(),
@@ -99,6 +108,16 @@ function createMockConfigService(): MockConfigService {
   };
 }
 
+function buildUser(overrides: Partial<AuthUser> = {}): AuthUser {
+  return {
+    id: 'user-1',
+    email: 'staff@restosync.local',
+    role: Role.WAITER,
+    restaurantId: 'restaurant-A',
+    ...overrides,
+  };
+}
+
 describe('OrdersService', () => {
   let service: OrdersService;
   let prisma: MockPrisma;
@@ -108,11 +127,13 @@ describe('OrdersService', () => {
 
   const orderId = 'order-1';
   const menuItemId = 'menu-item-1';
+  const user = buildUser();
 
   const baseOrder = {
     id: orderId,
     status: OrderStatus.DRAFT,
     type: OrderType.DINE_IN,
+    restaurantId: user.restaurantId,
   };
 
   const availableMenuItem = {
@@ -120,6 +141,7 @@ describe('OrdersService', () => {
     name: 'Classic Cheeseburger',
     priceCents: 1200,
     available: true,
+    restaurantId: user.restaurantId,
   };
 
   beforeEach(() => {
@@ -171,19 +193,29 @@ describe('OrdersService', () => {
     };
 
     it('creates a new order and sets the table OCCUPIED when the table is AVAILABLE', async () => {
-      prisma.table.findUnique.mockResolvedValue({
+      prisma.table.findFirst.mockResolvedValue({
         id: tableId,
         status: TableStatus.AVAILABLE,
       });
 
-      const result = await service.create(dto as any, 'user-1');
+      const result = await service.create(
+        dto as any,
+        user.restaurantId,
+        user.id,
+      );
 
-      expect(prisma.table.findUnique).toHaveBeenCalledWith({
-        where: { id: tableId },
+      expect(prisma.table.findFirst).toHaveBeenCalledWith({
+        where: { id: tableId, restaurantId: user.restaurantId },
+      });
+      expect(prisma.menuItem.findMany).toHaveBeenCalledWith({
+        where: { id: { in: [menuItemId] }, restaurantId: user.restaurantId },
       });
       expect(txOrderCreate).toHaveBeenCalledWith(
         expect.objectContaining({
-          data: expect.objectContaining({ tableId }),
+          data: expect.objectContaining({
+            tableId,
+            restaurantId: user.restaurantId,
+          }),
         }),
       );
       expect(txTableUpdate).toHaveBeenCalledWith({
@@ -194,7 +226,7 @@ describe('OrdersService', () => {
     });
 
     it('returns the existing active order instead of creating a duplicate when the table is OCCUPIED', async () => {
-      prisma.table.findUnique.mockResolvedValue({
+      prisma.table.findFirst.mockResolvedValue({
         id: tableId,
         status: TableStatus.OCCUPIED,
       });
@@ -205,20 +237,121 @@ describe('OrdersService', () => {
       };
       prisma.order.findFirst.mockResolvedValue(existingOrder);
 
-      const result = await service.create(dto as any, 'user-1');
+      const result = await service.create(
+        dto as any,
+        user.restaurantId,
+        user.id,
+      );
 
       expect(result).toBe(existingOrder);
+      expect(prisma.order.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ restaurantId: user.restaurantId }),
+        }),
+      );
       expect(prisma.$transaction).not.toHaveBeenCalled();
       expect(txOrderCreate).not.toHaveBeenCalled();
     });
 
     it('throws NotFoundException for a nonexistent tableId', async () => {
-      prisma.table.findUnique.mockResolvedValue(null);
+      prisma.table.findFirst.mockResolvedValue(null);
 
-      await expect(service.create(dto as any, 'user-1')).rejects.toThrow(
+      await expect(
+        service.create(dto as any, user.restaurantId, user.id),
+      ).rejects.toThrow(NotFoundException);
+      expect(prisma.$transaction).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException (not the table) for a tableId belonging to another restaurant', async () => {
+      // findFirst is itself scoped by restaurantId, so a table owned by a
+      // different restaurant is invisible here — same as a nonexistent id.
+      prisma.table.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.create(dto as any, user.restaurantId, user.id),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it("always uses the restaurantId passed by the controller (the caller's own), never a client-suppliable value", async () => {
+      prisma.table.findFirst.mockResolvedValue({
+        id: tableId,
+        status: TableStatus.AVAILABLE,
+      });
+
+      await service.create(dto as any, 'restaurant-B', user.id);
+
+      const { data } = txOrderCreate.mock.calls[0][0];
+      expect(data.restaurantId).toBe('restaurant-B');
+      expect(data.items.create[0].restaurantId).toBe('restaurant-B');
+    });
+  });
+
+  describe('findAll', () => {
+    it('scopes results to the caller restaurantId', async () => {
+      prisma.$transaction.mockResolvedValue([[], 0]);
+
+      await service.findAll({ page: 1, limit: 20 } as any, user);
+
+      const [[findManyArgs], countArgs] = [
+        prisma.order.findMany.mock.calls,
+        undefined,
+      ];
+      expect(prisma.order.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ restaurantId: user.restaurantId }),
+        }),
+      );
+      void findManyArgs;
+      void countArgs;
+    });
+
+    it('CUSTOMER role additionally scopes by customerId, ON TOP OF restaurantId', async () => {
+      prisma.$transaction.mockResolvedValue([[], 0]);
+      const customer = buildUser({ id: 'customer-1', role: Role.CUSTOMER });
+
+      await service.findAll({ page: 1, limit: 20 } as any, customer);
+
+      expect(prisma.order.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            restaurantId: customer.restaurantId,
+            customerId: customer.id,
+          },
+        }),
+      );
+    });
+  });
+
+  describe('findOne', () => {
+    it('returns the order when it belongs to the caller restaurant', async () => {
+      prisma.order.findUnique.mockResolvedValue({
+        ...baseOrder,
+        customerId: null,
+      });
+
+      const result = await service.findOne(orderId, user);
+
+      expect(result.id).toBe(orderId);
+    });
+
+    it('throws NotFoundException if the order does not exist', async () => {
+      prisma.order.findUnique.mockResolvedValue(null);
+
+      await expect(service.findOne(orderId, user)).rejects.toThrow(
         NotFoundException,
       );
-      expect(prisma.$transaction).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException (404, NOT 403) for an order belonging to another restaurant', async () => {
+      prisma.order.findUnique.mockResolvedValue({
+        ...baseOrder,
+        restaurantId: 'restaurant-B',
+        customerId: null,
+      });
+
+      await expect(service.findOne(orderId, user)).rejects.toThrow(
+        NotFoundException,
+      );
     });
   });
 
@@ -233,7 +366,7 @@ describe('OrdersService', () => {
         status: OrderStatus.CONFIRMED,
       });
 
-      await service.updateStatus(orderId, OrderStatus.CONFIRMED);
+      await service.updateStatus(orderId, OrderStatus.CONFIRMED, user);
 
       expect(realtimeGateway.emitStatusChanged).toHaveBeenCalledWith({
         orderId,
@@ -255,7 +388,11 @@ describe('OrdersService', () => {
         throw new Error('socket server unavailable');
       });
 
-      const result = await service.updateStatus(orderId, OrderStatus.CONFIRMED);
+      const result = await service.updateStatus(
+        orderId,
+        OrderStatus.CONFIRMED,
+        user,
+      );
 
       expect(result.status).toBe(OrderStatus.CONFIRMED);
       expect(realtimeGateway.emitStatusChanged).toHaveBeenCalled();
@@ -268,7 +405,7 @@ describe('OrdersService', () => {
       });
 
       await expect(
-        service.updateStatus(orderId, OrderStatus.CONFIRMED),
+        service.updateStatus(orderId, OrderStatus.CONFIRMED, user),
       ).rejects.toThrow(BadRequestException);
       expect(realtimeGateway.emitStatusChanged).not.toHaveBeenCalled();
     });
@@ -277,15 +414,28 @@ describe('OrdersService', () => {
       prisma.order.findUnique.mockResolvedValue(null);
 
       await expect(
-        service.updateStatus(orderId, OrderStatus.CONFIRMED),
+        service.updateStatus(orderId, OrderStatus.CONFIRMED, user),
       ).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws NotFoundException (404, NOT 403) for an order belonging to another restaurant', async () => {
+      prisma.order.findUnique.mockResolvedValue({
+        ...baseOrder,
+        restaurantId: 'restaurant-B',
+        status: OrderStatus.PENDING,
+      });
+
+      await expect(
+        service.updateStatus(orderId, OrderStatus.CONFIRMED, user),
+      ).rejects.toThrow(NotFoundException);
+      expect(prisma.order.update).not.toHaveBeenCalled();
     });
   });
 
   describe('addItem', () => {
     it('adds an item with the correct price/name snapshot and recalculates totals', async () => {
       prisma.order.findUnique.mockResolvedValue(baseOrder);
-      prisma.menuItem.findUnique.mockResolvedValue(availableMenuItem);
+      prisma.menuItem.findFirst.mockResolvedValue(availableMenuItem);
       prisma.orderItem.create.mockResolvedValue({});
       prisma.orderItem.findMany.mockResolvedValue([
         {
@@ -300,11 +450,15 @@ describe('OrdersService', () => {
         totalCents: 2400,
       });
 
-      const result = await service.addItem(orderId, {
-        menuItemId,
-        quantity: 2,
-      });
+      const result = await service.addItem(
+        orderId,
+        { menuItemId, quantity: 2 },
+        user,
+      );
 
+      expect(prisma.menuItem.findFirst).toHaveBeenCalledWith({
+        where: { id: menuItemId, restaurantId: user.restaurantId },
+      });
       expect(prisma.orderItem.create).toHaveBeenCalledWith({
         data: expect.objectContaining({
           orderId,
@@ -313,6 +467,7 @@ describe('OrdersService', () => {
           priceCents: availableMenuItem.priceCents,
           quantity: 2,
           lineTotalCents: 2400,
+          restaurantId: user.restaurantId,
         }),
       });
       expect(prisma.order.update).toHaveBeenCalledWith(
@@ -326,7 +481,7 @@ describe('OrdersService', () => {
 
     it('emits order.totals_changed with the correct payload via recalculateTotals', async () => {
       prisma.order.findUnique.mockResolvedValue(baseOrder);
-      prisma.menuItem.findUnique.mockResolvedValue(availableMenuItem);
+      prisma.menuItem.findFirst.mockResolvedValue(availableMenuItem);
       prisma.orderItem.create.mockResolvedValue({});
       prisma.orderItem.findMany.mockResolvedValue([
         { priceCents: 1200, quantity: 2 },
@@ -338,7 +493,7 @@ describe('OrdersService', () => {
         totalCents: 2400,
       });
 
-      await service.addItem(orderId, { menuItemId, quantity: 2 });
+      await service.addItem(orderId, { menuItemId, quantity: 2 }, user);
 
       expect(realtimeGateway.emitTotalsChanged).toHaveBeenCalledWith({
         orderId,
@@ -351,7 +506,7 @@ describe('OrdersService', () => {
 
     it('still completes the operation when the gateway emit throws', async () => {
       prisma.order.findUnique.mockResolvedValue(baseOrder);
-      prisma.menuItem.findUnique.mockResolvedValue(availableMenuItem);
+      prisma.menuItem.findFirst.mockResolvedValue(availableMenuItem);
       prisma.orderItem.create.mockResolvedValue({});
       prisma.orderItem.findMany.mockResolvedValue([
         { priceCents: 1200, quantity: 2 },
@@ -366,10 +521,11 @@ describe('OrdersService', () => {
         throw new Error('socket server unavailable');
       });
 
-      const result = await service.addItem(orderId, {
-        menuItemId,
-        quantity: 2,
-      });
+      const result = await service.addItem(
+        orderId,
+        { menuItemId, quantity: 2 },
+        user,
+      );
 
       expect(result.totalCents).toBe(2400);
       expect(realtimeGateway.emitTotalsChanged).toHaveBeenCalled();
@@ -379,7 +535,18 @@ describe('OrdersService', () => {
       prisma.order.findUnique.mockResolvedValue(null);
 
       await expect(
-        service.addItem(orderId, { menuItemId, quantity: 1 }),
+        service.addItem(orderId, { menuItemId, quantity: 1 }, user),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws NotFoundException (404, NOT 403) if the order belongs to another restaurant', async () => {
+      prisma.order.findUnique.mockResolvedValue({
+        ...baseOrder,
+        restaurantId: 'restaurant-B',
+      });
+
+      await expect(
+        service.addItem(orderId, { menuItemId, quantity: 1 }, user),
       ).rejects.toThrow(NotFoundException);
     });
 
@@ -390,28 +557,28 @@ describe('OrdersService', () => {
       });
 
       await expect(
-        service.addItem(orderId, { menuItemId, quantity: 1 }),
+        service.addItem(orderId, { menuItemId, quantity: 1 }, user),
       ).rejects.toThrow(BadRequestException);
     });
 
     it('throws NotFoundException if the menu item does not exist', async () => {
       prisma.order.findUnique.mockResolvedValue(baseOrder);
-      prisma.menuItem.findUnique.mockResolvedValue(null);
+      prisma.menuItem.findFirst.mockResolvedValue(null);
 
       await expect(
-        service.addItem(orderId, { menuItemId, quantity: 1 }),
+        service.addItem(orderId, { menuItemId, quantity: 1 }, user),
       ).rejects.toThrow(NotFoundException);
     });
 
     it('throws NotFoundException if the menu item is not available', async () => {
       prisma.order.findUnique.mockResolvedValue(baseOrder);
-      prisma.menuItem.findUnique.mockResolvedValue({
+      prisma.menuItem.findFirst.mockResolvedValue({
         ...availableMenuItem,
         available: false,
       });
 
       await expect(
-        service.addItem(orderId, { menuItemId, quantity: 1 }),
+        service.addItem(orderId, { menuItemId, quantity: 1 }, user),
       ).rejects.toThrow(NotFoundException);
     });
   });
@@ -438,10 +605,20 @@ describe('OrdersService', () => {
         totalCents: 3600,
       });
 
-      const result = await service.updateItemQuantity(orderId, orderItemId, {
-        quantity: 3,
-      });
+      const result = await service.updateItemQuantity(
+        orderId,
+        orderItemId,
+        { quantity: 3 },
+        user,
+      );
 
+      expect(prisma.orderItem.findFirst).toHaveBeenCalledWith({
+        where: {
+          id: orderItemId,
+          orderId,
+          restaurantId: user.restaurantId,
+        },
+      });
       expect(prisma.orderItem.update).toHaveBeenCalledWith({
         where: { id: orderItemId },
         data: { quantity: 3, lineTotalCents: 3600 },
@@ -456,7 +633,7 @@ describe('OrdersService', () => {
       });
 
       await expect(
-        service.updateItemQuantity(orderId, orderItemId, { quantity: 2 }),
+        service.updateItemQuantity(orderId, orderItemId, { quantity: 2 }, user),
       ).rejects.toThrow(BadRequestException);
     });
 
@@ -465,7 +642,18 @@ describe('OrdersService', () => {
       prisma.orderItem.findFirst.mockResolvedValue(null);
 
       await expect(
-        service.updateItemQuantity(orderId, orderItemId, { quantity: 2 }),
+        service.updateItemQuantity(orderId, orderItemId, { quantity: 2 }, user),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws NotFoundException (404, NOT 403) if the order belongs to another restaurant', async () => {
+      prisma.order.findUnique.mockResolvedValue({
+        ...baseOrder,
+        restaurantId: 'restaurant-B',
+      });
+
+      await expect(
+        service.updateItemQuantity(orderId, orderItemId, { quantity: 2 }, user),
       ).rejects.toThrow(NotFoundException);
     });
   });
@@ -490,7 +678,7 @@ describe('OrdersService', () => {
         totalCents: 0,
       });
 
-      const result = await service.removeItem(orderId, orderItemId);
+      const result = await service.removeItem(orderId, orderItemId, user);
 
       expect(prisma.orderItem.delete).toHaveBeenCalledWith({
         where: { id: orderItemId },
@@ -504,18 +692,29 @@ describe('OrdersService', () => {
         status: OrderStatus.CANCELLED,
       });
 
-      await expect(service.removeItem(orderId, orderItemId)).rejects.toThrow(
-        BadRequestException,
-      );
+      await expect(
+        service.removeItem(orderId, orderItemId, user),
+      ).rejects.toThrow(BadRequestException);
     });
 
     it('throws NotFoundException if the order item is not found', async () => {
       prisma.order.findUnique.mockResolvedValue(baseOrder);
       prisma.orderItem.findFirst.mockResolvedValue(null);
 
-      await expect(service.removeItem(orderId, orderItemId)).rejects.toThrow(
-        NotFoundException,
-      );
+      await expect(
+        service.removeItem(orderId, orderItemId, user),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws NotFoundException (404, NOT 403) if the order belongs to another restaurant', async () => {
+      prisma.order.findUnique.mockResolvedValue({
+        ...baseOrder,
+        restaurantId: 'restaurant-B',
+      });
+
+      await expect(
+        service.removeItem(orderId, orderItemId, user),
+      ).rejects.toThrow(NotFoundException);
     });
   });
 
@@ -531,7 +730,7 @@ describe('OrdersService', () => {
         status: OrderStatus.PENDING,
       });
 
-      const result = await service.confirmOrder(orderId);
+      const result = await service.confirmOrder(orderId, user);
 
       expect(prisma.order.update).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -549,7 +748,7 @@ describe('OrdersService', () => {
         items: [],
       });
 
-      await expect(service.confirmOrder(orderId)).rejects.toThrow(
+      await expect(service.confirmOrder(orderId, user)).rejects.toThrow(
         BadRequestException,
       );
     });
@@ -557,14 +756,74 @@ describe('OrdersService', () => {
     it('throws NotFoundException if the order does not exist', async () => {
       prisma.order.findUnique.mockResolvedValue(null);
 
-      await expect(service.confirmOrder(orderId)).rejects.toThrow(
+      await expect(service.confirmOrder(orderId, user)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('throws NotFoundException (404, NOT 403) if the order belongs to another restaurant', async () => {
+      prisma.order.findUnique.mockResolvedValue({
+        ...baseOrder,
+        restaurantId: 'restaurant-B',
+        status: OrderStatus.DRAFT,
+        items: [{ id: 'item-1' }],
+      });
+
+      await expect(service.confirmOrder(orderId, user)).rejects.toThrow(
         NotFoundException,
       );
     });
   });
 
+  describe('applyDiscount', () => {
+    it('applies the discount and records the audit log with the caller restaurantId', async () => {
+      prisma.order.findUnique.mockResolvedValue(baseOrder);
+      prisma.orderItem.findMany.mockResolvedValue([
+        { priceCents: 1000, quantity: 1 },
+      ]);
+      prisma.order.update.mockResolvedValue({
+        ...baseOrder,
+        subtotalCents: 1000,
+        taxCents: 0,
+        totalCents: 900,
+        discountCents: 100,
+      });
+
+      await service.applyDiscount(
+        orderId,
+        { discountType: 'FIXED' as any, discountCents: 100 },
+        user,
+      );
+
+      expect(auditService.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          entityType: 'Order',
+          entityId: orderId,
+          userId: user.id,
+          restaurantId: user.restaurantId,
+        }),
+      );
+    });
+
+    it('throws NotFoundException (404, NOT 403) if the order belongs to another restaurant', async () => {
+      prisma.order.findUnique.mockResolvedValue({
+        ...baseOrder,
+        restaurantId: 'restaurant-B',
+      });
+
+      await expect(
+        service.applyDiscount(
+          orderId,
+          { discountType: 'FIXED' as any, discountCents: 100 },
+          user,
+        ),
+      ).rejects.toThrow(NotFoundException);
+      expect(auditService.log).not.toHaveBeenCalled();
+    });
+  });
+
   describe('recalculateTotals', () => {
-    it('computes subtotalCents/taxCents/totalCents from the order items', async () => {
+    it('computes subtotalCents/taxCents/totalCents from the order items, scoped by restaurantId', async () => {
       prisma.orderItem.findMany.mockResolvedValue([
         { priceCents: 1200, quantity: 2 },
         { priceCents: 500, quantity: 1 },
@@ -573,8 +832,14 @@ describe('OrdersService', () => {
         Promise.resolve({ ...baseOrder, ...data }),
       );
 
-      const result = await (service as any).recalculateTotals(orderId);
+      const result = await (service as any).recalculateTotals(
+        orderId,
+        user.restaurantId,
+      );
 
+      expect(prisma.orderItem.findMany).toHaveBeenCalledWith({
+        where: { orderId, restaurantId: user.restaurantId },
+      });
       expect(prisma.order.update).toHaveBeenCalledWith({
         where: { id: orderId },
         data: { subtotalCents: 2900, taxCents: 0, totalCents: 2900 },
@@ -590,7 +855,10 @@ describe('OrdersService', () => {
         Promise.resolve({ ...baseOrder, ...data }),
       );
 
-      const result = await (service as any).recalculateTotals(orderId);
+      const result = await (service as any).recalculateTotals(
+        orderId,
+        user.restaurantId,
+      );
 
       expect(result.subtotalCents).toBe(0);
       expect(result.taxCents).toBe(0);
@@ -608,7 +876,10 @@ describe('OrdersService', () => {
         Promise.resolve({ ...baseOrder, ...data }),
       );
 
-      const result = await (service as any).recalculateTotals(orderId);
+      const result = await (service as any).recalculateTotals(
+        orderId,
+        user.restaurantId,
+      );
 
       expect(config.get).toHaveBeenCalledWith('tax.rate');
       // 1000 * 0.18 = 180
@@ -628,7 +899,10 @@ describe('OrdersService', () => {
         Promise.resolve({ ...baseOrder, ...data }),
       );
 
-      const result = await (service as any).recalculateTotals(orderId);
+      const result = await (service as any).recalculateTotals(
+        orderId,
+        user.restaurantId,
+      );
 
       expect(result.taxCents).toBe(0);
       expect(result.totalCents).toBe(1000);
@@ -647,7 +921,10 @@ describe('OrdersService', () => {
         Promise.resolve({ ...baseOrder, ...data }),
       );
 
-      const result = await (service as any).recalculateTotals(orderId);
+      const result = await (service as any).recalculateTotals(
+        orderId,
+        user.restaurantId,
+      );
 
       expect(result.subtotalCents + result.taxCents).toBe(result.totalCents);
     });

--- a/src/orders/orders.service.ts
+++ b/src/orders/orders.service.ts
@@ -20,7 +20,6 @@ import {
   paginate,
   PaginationQueryDto,
 } from '../common/dto/pagination-query.dto';
-import { DEFAULT_RESTAURANT_ID } from '../common/constants/tenancy';
 import { AuthUser } from '../auth/decorators/current-user.decorator';
 import { AuditService } from '../audit/audit.service';
 import { RealtimeGateway } from '../realtime/realtime.gateway';
@@ -53,18 +52,26 @@ export class OrdersService {
     private readonly realtimeGateway: RealtimeGateway,
   ) {}
 
-  async create(dto: CreateOrderDto, customerId?: string) {
+  // restaurantId is passed explicitly (rather than a full AuthUser)
+  // because this is also called internally by ReservationsService on
+  // behalf of an already-verified reservation/table, not only directly
+  // from an authenticated HTTP request.
+  async create(dto: CreateOrderDto, restaurantId: string, customerId?: string) {
     let table: { id: string; status: TableStatus } | null = null;
     if (dto.type === OrderType.DINE_IN) {
-      table = await this.prisma.table.findUnique({
-        where: { id: dto.tableId },
+      table = await this.prisma.table.findFirst({
+        where: { id: dto.tableId, restaurantId },
       });
       if (!table) {
         throw new NotFoundException('Table not found');
       }
       if (table.status === TableStatus.OCCUPIED) {
         const activeOrder = await this.prisma.order.findFirst({
-          where: { tableId: table.id, status: { in: ACTIVE_ORDER_STATUSES } },
+          where: {
+            tableId: table.id,
+            status: { in: ACTIVE_ORDER_STATUSES },
+            restaurantId,
+          },
           include: orderInclude,
           orderBy: { createdAt: 'desc' },
         });
@@ -76,7 +83,7 @@ export class OrdersService {
 
     const itemIds = dto.items.map((i) => i.menuItemId);
     const menuItems = await this.prisma.menuItem.findMany({
-      where: { id: { in: itemIds } },
+      where: { id: { in: itemIds }, restaurantId },
     });
     const byId = new Map(menuItems.map((m) => [m.id, m]));
 
@@ -117,11 +124,11 @@ export class OrdersService {
           totalCents: 0,
           currency,
           notes: dto.notes,
-          restaurantId: DEFAULT_RESTAURANT_ID,
+          restaurantId,
           items: {
             create: orderItems.map((item) => ({
               ...item,
-              restaurantId: DEFAULT_RESTAURANT_ID,
+              restaurantId,
             })),
           },
         },
@@ -138,12 +145,14 @@ export class OrdersService {
       return created;
     });
 
-    return this.recalculateTotals(order.id);
+    return this.recalculateTotals(order.id, restaurantId);
   }
 
   async findAll(query: PaginationQueryDto, user: AuthUser) {
-    const where: Prisma.OrderWhereInput =
-      user.role === Role.CUSTOMER ? { customerId: user.id } : {};
+    const where: Prisma.OrderWhereInput = {
+      restaurantId: user.restaurantId,
+      ...(user.role === Role.CUSTOMER ? { customerId: user.id } : {}),
+    };
 
     const [data, total] = await this.prisma.$transaction([
       this.prisma.order.findMany({
@@ -163,7 +172,7 @@ export class OrdersService {
       where: { id },
       include: orderInclude,
     });
-    if (!order) {
+    if (!order || order.restaurantId !== user.restaurantId) {
       throw new NotFoundException('Order not found');
     }
     if (user.role === Role.CUSTOMER && order.customerId !== user.id) {
@@ -172,17 +181,20 @@ export class OrdersService {
     return order;
   }
 
-  async findOpen() {
+  async findOpen(user: AuthUser) {
     return this.prisma.order.findMany({
-      where: { status: { in: [OrderStatus.DRAFT, OrderStatus.PENDING] } },
+      where: {
+        restaurantId: user.restaurantId,
+        status: { in: [OrderStatus.DRAFT, OrderStatus.PENDING] },
+      },
       include: orderInclude,
       orderBy: { createdAt: 'asc' },
     });
   }
 
-  async updateStatus(id: string, next: OrderStatus) {
+  async updateStatus(id: string, next: OrderStatus, user: AuthUser) {
     const order = await this.prisma.order.findUnique({ where: { id } });
-    if (!order) {
+    if (!order || order.restaurantId !== user.restaurantId) {
       throw new NotFoundException('Order not found');
     }
     if (!canTransition(order.status, next)) {
@@ -208,6 +220,11 @@ export class OrdersService {
     return updated;
   }
 
+  // System-initiated (Stripe webhook confirms payment), not a user-facing
+  // request — there is no caller AuthUser/restaurantId to scope by here.
+  // The order is already uniquely resolved via the Payment's providerRef
+  // before this is called (see PaymentsService.onPaymentSucceeded), so no
+  // additional tenant check applies.
   async markConfirmed(id: string) {
     const order = await this.prisma.order.findUnique({ where: { id } });
     if (!order || !canTransition(order.status, OrderStatus.CONFIRMED)) {
@@ -219,11 +236,11 @@ export class OrdersService {
     });
   }
 
-  async addItem(orderId: string, dto: AddOrderItemDto) {
+  async addItem(orderId: string, dto: AddOrderItemDto, user: AuthUser) {
     const order = await this.prisma.order.findUnique({
       where: { id: orderId },
     });
-    if (!order) {
+    if (!order || order.restaurantId !== user.restaurantId) {
       throw new NotFoundException('Order not found');
     }
     if (!EDITABLE_STATUSES.includes(order.status)) {
@@ -232,8 +249,8 @@ export class OrdersService {
       );
     }
 
-    const menuItem = await this.prisma.menuItem.findUnique({
-      where: { id: dto.menuItemId },
+    const menuItem = await this.prisma.menuItem.findFirst({
+      where: { id: dto.menuItemId, restaurantId: user.restaurantId },
     });
     if (!menuItem || !menuItem.available) {
       throw new NotFoundException('Menu item not found or not available');
@@ -251,22 +268,23 @@ export class OrdersService {
         modifiers: (dto.modifiers ?? null) as Prisma.InputJsonValue,
         notes: dto.notes,
         lineTotalCents,
-        restaurantId: DEFAULT_RESTAURANT_ID,
+        restaurantId: user.restaurantId,
       },
     });
 
-    return this.recalculateTotals(orderId);
+    return this.recalculateTotals(orderId, user.restaurantId);
   }
 
   async updateItemQuantity(
     orderId: string,
     orderItemId: string,
     dto: UpdateOrderItemDto,
+    user: AuthUser,
   ) {
     const order = await this.prisma.order.findUnique({
       where: { id: orderId },
     });
-    if (!order) {
+    if (!order || order.restaurantId !== user.restaurantId) {
       throw new NotFoundException('Order not found');
     }
     if (!EDITABLE_STATUSES.includes(order.status)) {
@@ -276,7 +294,7 @@ export class OrdersService {
     }
 
     const orderItem = await this.prisma.orderItem.findFirst({
-      where: { id: orderItemId, orderId },
+      where: { id: orderItemId, orderId, restaurantId: user.restaurantId },
     });
     if (!orderItem) {
       throw new NotFoundException('Order item not found');
@@ -298,14 +316,14 @@ export class OrdersService {
       data: updateData,
     });
 
-    return this.recalculateTotals(orderId);
+    return this.recalculateTotals(orderId, user.restaurantId);
   }
 
-  async removeItem(orderId: string, orderItemId: string) {
+  async removeItem(orderId: string, orderItemId: string, user: AuthUser) {
     const order = await this.prisma.order.findUnique({
       where: { id: orderId },
     });
-    if (!order) {
+    if (!order || order.restaurantId !== user.restaurantId) {
       throw new NotFoundException('Order not found');
     }
     if (!EDITABLE_STATUSES.includes(order.status)) {
@@ -315,7 +333,7 @@ export class OrdersService {
     }
 
     const orderItem = await this.prisma.orderItem.findFirst({
-      where: { id: orderItemId, orderId },
+      where: { id: orderItemId, orderId, restaurantId: user.restaurantId },
     });
     if (!orderItem) {
       throw new NotFoundException('Order item not found');
@@ -323,15 +341,15 @@ export class OrdersService {
 
     await this.prisma.orderItem.delete({ where: { id: orderItemId } });
 
-    return this.recalculateTotals(orderId);
+    return this.recalculateTotals(orderId, user.restaurantId);
   }
 
-  async confirmOrder(orderId: string) {
+  async confirmOrder(orderId: string, user: AuthUser) {
     const order = await this.prisma.order.findUnique({
       where: { id: orderId },
       include: orderInclude,
     });
-    if (!order) {
+    if (!order || order.restaurantId !== user.restaurantId) {
       throw new NotFoundException('Order not found');
     }
     if (order.items.length === 0) {
@@ -350,12 +368,14 @@ export class OrdersService {
     });
   }
 
-  private async recalculateTotals(orderId: string) {
+  private async recalculateTotals(orderId: string, restaurantId: string) {
     const order = await this.prisma.order.findUnique({
       where: { id: orderId },
       select: { discountCents: true },
     });
-    const items = await this.prisma.orderItem.findMany({ where: { orderId } });
+    const items = await this.prisma.orderItem.findMany({
+      where: { orderId, restaurantId },
+    });
     const subtotalCents = items.reduce(
       (sum, item) => sum + item.priceCents * item.quantity,
       0,
@@ -386,15 +406,11 @@ export class OrdersService {
     return updated;
   }
 
-  async applyDiscount(
-    orderId: string,
-    dto: ApplyDiscountDto,
-    appliedByUserId: string,
-  ) {
+  async applyDiscount(orderId: string, dto: ApplyDiscountDto, user: AuthUser) {
     const order = await this.prisma.order.findUnique({
       where: { id: orderId },
     });
-    if (!order) {
+    if (!order || order.restaurantId !== user.restaurantId) {
       throw new NotFoundException('Order not found');
     }
     if (!EDITABLE_STATUSES.includes(order.status)) {
@@ -404,7 +420,7 @@ export class OrdersService {
     }
 
     const items = await this.prisma.orderItem.findMany({
-      where: { orderId },
+      where: { orderId, restaurantId: user.restaurantId },
     });
     const subtotalCents = items.reduce(
       (sum, item) => sum + item.priceCents * item.quantity,
@@ -429,7 +445,7 @@ export class OrdersService {
           dto.discountType === DiscountType.PERCENTAGE
             ? dto.discountPercent
             : null,
-        discountAppliedBy: appliedByUserId,
+        discountAppliedBy: user.id,
         discountAppliedAt: new Date(),
         discountReason: dto.reason ?? null,
       },
@@ -439,7 +455,8 @@ export class OrdersService {
       entityType: 'Order',
       entityId: orderId,
       action: 'DISCOUNT_APPLIED',
-      userId: appliedByUserId,
+      userId: user.id,
+      restaurantId: user.restaurantId,
       metadata: {
         discountType: dto.discountType,
         discountCents: resolvedDiscountCents,
@@ -451,7 +468,7 @@ export class OrdersService {
       },
     });
 
-    return this.recalculateTotals(orderId);
+    return this.recalculateTotals(orderId, user.restaurantId);
   }
 
   private generateOrderNumber(): string {

--- a/src/orders/orders.service.ts
+++ b/src/orders/orders.service.ts
@@ -20,6 +20,7 @@ import {
   paginate,
   PaginationQueryDto,
 } from '../common/dto/pagination-query.dto';
+import { DEFAULT_RESTAURANT_ID } from '../common/constants/tenancy';
 import { AuthUser } from '../auth/decorators/current-user.decorator';
 import { AuditService } from '../audit/audit.service';
 import { RealtimeGateway } from '../realtime/realtime.gateway';
@@ -116,7 +117,13 @@ export class OrdersService {
           totalCents: 0,
           currency,
           notes: dto.notes,
-          items: { create: orderItems },
+          restaurantId: DEFAULT_RESTAURANT_ID,
+          items: {
+            create: orderItems.map((item) => ({
+              ...item,
+              restaurantId: DEFAULT_RESTAURANT_ID,
+            })),
+          },
         },
         include: orderInclude,
       });
@@ -244,6 +251,7 @@ export class OrdersService {
         modifiers: (dto.modifiers ?? null) as Prisma.InputJsonValue,
         notes: dto.notes,
         lineTotalCents,
+        restaurantId: DEFAULT_RESTAURANT_ID,
       },
     });
 

--- a/src/payments/payments.controller.ts
+++ b/src/payments/payments.controller.ts
@@ -18,7 +18,10 @@ import {
 } from '@nestjs/swagger';
 import { Role } from '@prisma/client';
 import { Request } from 'express';
-import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import {
+  AuthUser,
+  CurrentUser,
+} from '../auth/decorators/current-user.decorator';
 import { Public } from '../auth/decorators/public.decorator';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { CheckoutDto } from './dto/checkout.dto';
@@ -33,8 +36,8 @@ export class PaymentsController {
   @ApiBearerAuth()
   @Post('intent')
   @HttpCode(HttpStatus.CREATED)
-  createIntent(@Body() dto: CreateIntentDto) {
-    return this.paymentsService.createIntent(dto.orderId);
+  createIntent(@Body() dto: CreateIntentDto, @CurrentUser() user: AuthUser) {
+    return this.paymentsService.createIntent(dto.orderId, user);
   }
 
   @ApiBearerAuth()
@@ -52,8 +55,8 @@ export class PaymentsController {
   })
   @ApiResponse({ status: 404, description: 'Order not found' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
-  checkout(@Body() dto: CheckoutDto, @CurrentUser('id') userId: string) {
-    return this.paymentsService.checkout(dto, userId);
+  checkout(@Body() dto: CheckoutDto, @CurrentUser() user: AuthUser) {
+    return this.paymentsService.checkout(dto, user);
   }
 
   @Public()

--- a/src/payments/payments.service.spec.ts
+++ b/src/payments/payments.service.spec.ts
@@ -3,8 +3,10 @@ import {
   OrderStatus,
   PaymentMethod,
   PaymentStatus,
+  Role,
   TableStatus,
 } from '@prisma/client';
+import { AuthUser } from '../auth/decorators/current-user.decorator';
 import { InventoryService } from '../inventory/inventory.service';
 import { OrdersService } from '../orders/orders.service';
 import { PrismaService } from '../prisma/prisma.service';
@@ -20,6 +22,7 @@ type MockPrisma = {
   };
   payment: {
     findFirst: jest.Mock;
+    upsert: jest.Mock;
   };
   inventoryItem: {
     findFirst: jest.Mock;
@@ -40,6 +43,7 @@ function createMockPrisma(): MockPrisma {
     },
     payment: {
       findFirst: jest.fn(),
+      upsert: jest.fn(),
     },
     inventoryItem: {
       findFirst: jest.fn(),
@@ -48,6 +52,16 @@ function createMockPrisma(): MockPrisma {
       update: jest.fn(),
     },
     $transaction: jest.fn(),
+  };
+}
+
+function buildUser(overrides: Partial<AuthUser> = {}): AuthUser {
+  return {
+    id: 'user-1',
+    email: 'staff@restosync.local',
+    role: Role.STAFF,
+    restaurantId: 'restaurant-A',
+    ...overrides,
   };
 }
 
@@ -61,7 +75,7 @@ describe('PaymentsService', () => {
 
   const orderId = 'order-1';
   const sessionId = 'session-1';
-  const actorId = 'user-1';
+  const user = buildUser();
 
   const baseOrder = {
     id: orderId,
@@ -69,6 +83,7 @@ describe('PaymentsService', () => {
     status: OrderStatus.PENDING,
     totalCents: 1200,
     currency: 'usd',
+    restaurantId: user.restaurantId,
     items: [
       {
         id: 'item-1',
@@ -108,8 +123,41 @@ describe('PaymentsService', () => {
     );
   });
 
+  describe('createIntent', () => {
+    it('throws NotFoundException (not the order) for an order belonging to another restaurant', async () => {
+      prisma.order.findUnique.mockResolvedValue({
+        ...baseOrder,
+        restaurantId: 'restaurant-B',
+      });
+
+      await expect(service.createIntent(orderId, user)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('sets restaurantId from the caller, never from the client, on the created payment', async () => {
+      prisma.order.findUnique.mockResolvedValue(baseOrder);
+      const gateway: PaymentGateway = {
+        createPaymentIntent: jest
+          .fn()
+          .mockResolvedValue({ id: 'pi_123', clientSecret: 'secret' }),
+      } as unknown as PaymentGateway;
+      service = new PaymentsService(
+        prisma as unknown as PrismaService,
+        {} as unknown as OrdersService,
+        inventoryService as unknown as InventoryService,
+        gateway,
+      );
+
+      await service.createIntent(orderId, user);
+
+      const { create } = prisma.payment.upsert.mock.calls[0][0];
+      expect(create.restaurantId).toBe(user.restaurantId);
+    });
+  });
+
   describe('checkout', () => {
-    it('creates a CASH payment with correct method and amountCents', async () => {
+    it('creates a CASH payment with correct method and amountCents, scoped to the caller restaurant', async () => {
       prisma.order.findUnique.mockResolvedValue(baseOrder);
       prisma.cashRegisterSession.findFirst.mockResolvedValue(activeSession);
       prisma.payment.findFirst.mockResolvedValue(null);
@@ -120,9 +168,13 @@ describe('PaymentsService', () => {
           method: PaymentMethod.CASH,
           amountPaidCents: 1200,
         },
-        actorId,
+        user,
       );
 
+      expect(prisma.cashRegisterSession.findFirst).toHaveBeenCalledWith({
+        where: { closedAt: null, restaurantId: user.restaurantId },
+        orderBy: { openedAt: 'desc' },
+      });
       expect(txOrderUpdate).toHaveBeenCalledWith({
         where: { id: orderId },
         data: { status: OrderStatus.CONFIRMED },
@@ -138,9 +190,30 @@ describe('PaymentsService', () => {
             status: PaymentStatus.SUCCEEDED,
             sessionId: activeSession.id,
             providerRef: null,
+            restaurantId: user.restaurantId,
           }),
         }),
       );
+    });
+
+    it("ignores a client-supplied restaurantId and always uses the caller's own", async () => {
+      prisma.order.findUnique.mockResolvedValue(baseOrder);
+      prisma.cashRegisterSession.findFirst.mockResolvedValue(activeSession);
+      prisma.payment.findFirst.mockResolvedValue(null);
+
+      await service.checkout(
+        {
+          orderId,
+          method: PaymentMethod.CASH,
+          amountPaidCents: 1200,
+          // @ts-expect-error simulating a malicious/naive client payload
+          restaurantId: 'restaurant-EVIL',
+        },
+        user,
+      );
+
+      const { data } = txPaymentCreate.mock.calls[0][0];
+      expect(data.restaurantId).toBe(user.restaurantId);
     });
 
     it('sets the table back to AVAILABLE after successful payment', async () => {
@@ -155,7 +228,7 @@ describe('PaymentsService', () => {
           method: PaymentMethod.CASH,
           amountPaidCents: 1200,
         },
-        actorId,
+        user,
       );
 
       expect(txTableUpdate).toHaveBeenCalledWith({
@@ -175,7 +248,7 @@ describe('PaymentsService', () => {
           method: PaymentMethod.CASH,
           amountPaidCents: 1200,
         },
-        actorId,
+        user,
       );
 
       expect(txTableUpdate).not.toHaveBeenCalled();
@@ -192,7 +265,7 @@ describe('PaymentsService', () => {
           method: PaymentMethod.CASH,
           amountPaidCents: 1500,
         },
-        actorId,
+        user,
       );
 
       expect(txPaymentCreate).toHaveBeenCalledWith(
@@ -214,7 +287,7 @@ describe('PaymentsService', () => {
       await expect(
         service.checkout(
           { orderId, method: PaymentMethod.CASH, amountPaidCents: 1200 },
-          actorId,
+          user,
         ),
       ).rejects.toThrow(BadRequestException);
     });
@@ -225,9 +298,24 @@ describe('PaymentsService', () => {
       await expect(
         service.checkout(
           { orderId, method: PaymentMethod.CASH, amountPaidCents: 1200 },
-          actorId,
+          user,
         ),
       ).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws NotFoundException (not the order, not 403) for an order belonging to another restaurant', async () => {
+      prisma.order.findUnique.mockResolvedValue({
+        ...baseOrder,
+        restaurantId: 'restaurant-B',
+      });
+
+      await expect(
+        service.checkout(
+          { orderId, method: PaymentMethod.CASH, amountPaidCents: 1200 },
+          user,
+        ),
+      ).rejects.toThrow(NotFoundException);
+      expect(prisma.cashRegisterSession.findFirst).not.toHaveBeenCalled();
     });
 
     it('throws BadRequestException if no active session', async () => {
@@ -237,7 +325,7 @@ describe('PaymentsService', () => {
       await expect(
         service.checkout(
           { orderId, method: PaymentMethod.CASH, amountPaidCents: 1200 },
-          actorId,
+          user,
         ),
       ).rejects.toThrow(BadRequestException);
     });
@@ -250,7 +338,7 @@ describe('PaymentsService', () => {
       await expect(
         service.checkout(
           { orderId, method: PaymentMethod.CASH, amountPaidCents: 1000 },
-          actorId,
+          user,
         ),
       ).rejects.toThrow(BadRequestException);
       expect(prisma.$transaction).not.toHaveBeenCalled();
@@ -269,7 +357,7 @@ describe('PaymentsService', () => {
 
       const result = await service.checkout(
         { orderId, method: PaymentMethod.CASH, amountPaidCents: 1200 },
-        actorId,
+        user,
       );
 
       expect(result).toBe(existingPayment);
@@ -284,7 +372,7 @@ describe('PaymentsService', () => {
       await expect(
         service.checkout(
           { orderId, method: PaymentMethod.CARD, amountPaidCents: 0 },
-          actorId,
+          user,
         ),
       ).resolves.toBeDefined();
 
@@ -300,7 +388,7 @@ describe('PaymentsService', () => {
     });
 
     describe('inventory decrement hook (#51)', () => {
-      it('decrements linked inventory by the correct quantity', async () => {
+      it('decrements linked inventory by the correct quantity, scoped by the order restaurantId', async () => {
         prisma.order.findUnique.mockResolvedValue(baseOrder);
         prisma.cashRegisterSession.findFirst.mockResolvedValue(activeSession);
         prisma.payment.findFirst.mockResolvedValue(null);
@@ -311,11 +399,14 @@ describe('PaymentsService', () => {
 
         await service.checkout(
           { orderId, method: PaymentMethod.CASH, amountPaidCents: 1200 },
-          actorId,
+          user,
         );
 
         expect(prisma.inventoryItem.findFirst).toHaveBeenCalledWith({
-          where: { menuItemId: 'menu-item-1' },
+          where: {
+            menuItemId: 'menu-item-1',
+            restaurantId: baseOrder.restaurantId,
+          },
         });
         expect(inventoryService.adjust).toHaveBeenCalledWith(
           'inv-item-1',
@@ -324,7 +415,8 @@ describe('PaymentsService', () => {
             quantityDelta: -2,
             reason: `Sale from order ${baseOrder.number}`,
           },
-          actorId,
+          user.id,
+          baseOrder.restaurantId,
         );
       });
 
@@ -337,7 +429,7 @@ describe('PaymentsService', () => {
         await expect(
           service.checkout(
             { orderId, method: PaymentMethod.CASH, amountPaidCents: 1200 },
-            actorId,
+            user,
           ),
         ).resolves.toBeDefined();
 
@@ -356,7 +448,7 @@ describe('PaymentsService', () => {
 
         const result = await service.checkout(
           { orderId, method: PaymentMethod.CASH, amountPaidCents: 1200 },
-          actorId,
+          user,
         );
 
         expect(result).toEqual({ id: 'payment-1' });

--- a/src/payments/payments.service.ts
+++ b/src/payments/payments.service.ts
@@ -16,6 +16,7 @@ import { InventoryService } from '../inventory/inventory.service';
 import { canTransition } from '../orders/order-status';
 import { OrdersService } from '../orders/orders.service';
 import { PrismaService } from '../prisma/prisma.service';
+import { DEFAULT_RESTAURANT_ID } from '../common/constants/tenancy';
 import { CheckoutDto } from './dto/checkout.dto';
 import {
   GatewayEvent,
@@ -67,6 +68,7 @@ export class PaymentsService {
         amountCents: order.totalCents,
         currency: order.currency,
         status: PaymentStatus.REQUIRES_PAYMENT,
+        restaurantId: DEFAULT_RESTAURANT_ID,
       },
     });
 
@@ -154,6 +156,7 @@ export class PaymentsService {
           currency: order.currency,
           status: PaymentStatus.SUCCEEDED,
           sessionId: activeSession.id,
+          restaurantId: DEFAULT_RESTAURANT_ID,
         },
         include: { order: true },
       });

--- a/src/payments/payments.service.ts
+++ b/src/payments/payments.service.ts
@@ -12,11 +12,11 @@ import {
   Prisma,
   TableStatus,
 } from '@prisma/client';
+import { AuthUser } from '../auth/decorators/current-user.decorator';
 import { InventoryService } from '../inventory/inventory.service';
 import { canTransition } from '../orders/order-status';
 import { OrdersService } from '../orders/orders.service';
 import { PrismaService } from '../prisma/prisma.service';
-import { DEFAULT_RESTAURANT_ID } from '../common/constants/tenancy';
 import { CheckoutDto } from './dto/checkout.dto';
 import {
   GatewayEvent,
@@ -37,11 +37,11 @@ export class PaymentsService {
     @Inject(PAYMENT_GATEWAY) private readonly gateway: PaymentGateway,
   ) {}
 
-  async createIntent(orderId: string) {
+  async createIntent(orderId: string, user: AuthUser) {
     const order = await this.prisma.order.findUnique({
       where: { id: orderId },
     });
-    if (!order) {
+    if (!order || order.restaurantId !== user.restaurantId) {
       throw new NotFoundException('Order not found');
     }
     if (order.status !== OrderStatus.PENDING) {
@@ -68,7 +68,7 @@ export class PaymentsService {
         amountCents: order.totalCents,
         currency: order.currency,
         status: PaymentStatus.REQUIRES_PAYMENT,
-        restaurantId: DEFAULT_RESTAURANT_ID,
+        restaurantId: user.restaurantId,
       },
     });
 
@@ -82,12 +82,12 @@ export class PaymentsService {
 
   // POS checkout: closes the order, records a payment, and attaches it to
   // the active cash register session — all in a single transaction.
-  async checkout(dto: CheckoutDto, actorId: string) {
+  async checkout(dto: CheckoutDto, user: AuthUser) {
     const order = await this.prisma.order.findUnique({
       where: { id: dto.orderId },
       include: { items: true },
     });
-    if (!order) {
+    if (!order || order.restaurantId !== user.restaurantId) {
       throw new NotFoundException('Order not found');
     }
     if (order.status !== OrderStatus.PENDING) {
@@ -97,7 +97,7 @@ export class PaymentsService {
     }
 
     const activeSession = await this.prisma.cashRegisterSession.findFirst({
-      where: { closedAt: null },
+      where: { closedAt: null, restaurantId: user.restaurantId },
       orderBy: { openedAt: 'desc' },
     });
     if (!activeSession) {
@@ -106,7 +106,11 @@ export class PaymentsService {
 
     // Idempotency: never double-charge an already-paid order.
     const existingPayment = await this.prisma.payment.findFirst({
-      where: { orderId: order.id, status: PaymentStatus.SUCCEEDED },
+      where: {
+        orderId: order.id,
+        status: PaymentStatus.SUCCEEDED,
+        restaurantId: user.restaurantId,
+      },
       include: { order: true },
     });
     if (existingPayment) {
@@ -121,7 +125,7 @@ export class PaymentsService {
       throw new BadRequestException('Insufficient payment amount');
     }
 
-    this.logger.debug(`Checkout for order ${order.id} by user ${actorId}`);
+    this.logger.debug(`Checkout for order ${order.id} by user ${user.id}`);
 
     const payment = await this.prisma.$transaction(async (tx) => {
       if (!canTransition(order.status, OrderStatus.CONFIRMED)) {
@@ -156,7 +160,7 @@ export class PaymentsService {
           currency: order.currency,
           status: PaymentStatus.SUCCEEDED,
           sessionId: activeSession.id,
-          restaurantId: DEFAULT_RESTAURANT_ID,
+          restaurantId: user.restaurantId,
         },
         include: { order: true },
       });
@@ -164,7 +168,7 @@ export class PaymentsService {
 
     // Best-effort, non-blocking: the sale is already confirmed and paid,
     // so an inventory hiccup must never fail or roll back the checkout.
-    await this.decrementInventoryForOrder(order, actorId);
+    await this.decrementInventoryForOrder(order, user.id);
 
     return payment;
   }
@@ -183,7 +187,10 @@ export class PaymentsService {
     for (const item of order.items) {
       try {
         const inventoryItem = await this.prisma.inventoryItem.findFirst({
-          where: { menuItemId: item.menuItemId },
+          where: {
+            menuItemId: item.menuItemId,
+            restaurantId: order.restaurantId,
+          },
         });
         if (!inventoryItem) {
           continue;
@@ -197,6 +204,7 @@ export class PaymentsService {
             reason: `Sale from order ${order.number}`,
           },
           actorId,
+          order.restaurantId,
         );
       } catch (err) {
         this.logger.warn(
@@ -255,6 +263,9 @@ export class PaymentsService {
   }
 
   // Looks up the local payment record and enforces idempotency on event id.
+  // Webhook-driven (system, not a user request) — no caller AuthUser to
+  // scope by; the providerRef (Stripe's own PaymentIntent id) is already
+  // globally unique and resolves to exactly one payment/restaurant.
   private async findPaymentForEvent(event: GatewayEvent) {
     if (!event.paymentIntentId) {
       return null;

--- a/src/prisma/prisma.service.ts
+++ b/src/prisma/prisma.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
 import { PrismaClient } from '@prisma/client';
+import { tenantGuardExtension } from '../common/prisma-tenant-guard.extension';
 
 @Injectable()
 export class PrismaService
@@ -8,6 +9,18 @@ export class PrismaService
 {
   async onModuleInit() {
     await this.$connect();
+    // #152's Prisma Client Extension backstop, wired in after $connect()
+    // so the underlying engine is already live. $extends() returns a new
+    // client-like object rather than mutating `this`, so its own
+    // properties (model delegates, $transaction, etc. — all of which are
+    // own instance properties on a Prisma Client, not prototype methods)
+    // are copied onto `this`. This keeps `this` as the exact same
+    // PrismaService instance everywhere it's already injected (no
+    // constructor changes, no injection-site changes needed across the
+    // app), while every model delegate call — including inside
+    // $transaction() callbacks, since $transaction itself is copied over
+    // too — now runs through the tenant guard.
+    Object.assign(this, this.$extends(tenantGuardExtension));
   }
 
   async onModuleDestroy() {

--- a/src/realtime/realtime.gateway.spec.ts
+++ b/src/realtime/realtime.gateway.spec.ts
@@ -2,7 +2,7 @@ import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
 import { OrderStatus } from '@prisma/client';
 import type { Server, Socket } from 'socket.io';
-import { customerRoom, RealtimeGateway, STAFF_ROOM } from './realtime.gateway';
+import { customerRoom, RealtimeGateway, staffRoom } from './realtime.gateway';
 import { PrismaService } from '../prisma/prisma.service';
 
 type MockJwtService = { verifyAsync: jest.Mock };
@@ -52,6 +52,7 @@ describe('RealtimeGateway', () => {
       sub: 'user-1',
       email: 'cook@restosync.dev',
       role: 'KITCHEN',
+      restaurantId: 'restaurant-A',
     });
 
     const socket = createSocket('valid.token');
@@ -64,6 +65,7 @@ describe('RealtimeGateway', () => {
       userId: 'user-1',
       email: 'cook@restosync.dev',
       role: 'KITCHEN',
+      restaurantId: 'restaurant-A',
     });
     expect(socket.disconnect).not.toHaveBeenCalled();
   });
@@ -87,36 +89,62 @@ describe('RealtimeGateway', () => {
     expect(socket.disconnect).toHaveBeenCalledWith(true);
   });
 
-  describe('room assignment on connection (#159/#156/#155)', () => {
+  describe('room assignment on connection (#159/#156/#155/#173)', () => {
     it.each(['KITCHEN', 'CASHIER', 'ADMIN', 'WAITER', 'MANAGER', 'STAFF'])(
-      'a connection with role %s joins the "staff" room',
+      "a connection with role %s joins its OWN restaurant's staff room",
       async (role) => {
         jwt.verifyAsync.mockResolvedValue({
           sub: 'user-1',
           email: 'staff@restosync.dev',
           role,
+          restaurantId: 'restaurant-A',
         });
 
         const socket = createSocket('valid.token');
         await gateway.handleConnection(socket);
 
-        expect(socket.join).toHaveBeenCalledWith(STAFF_ROOM);
+        expect(socket.join).toHaveBeenCalledWith(staffRoom('restaurant-A'));
         expect(socket.join).toHaveBeenCalledTimes(1);
       },
     );
 
-    it('a connection with role CUSTOMER joins customer:${userId}, not the staff room', async () => {
+    it('two staff connections for different restaurants join different staff rooms', async () => {
+      jwt.verifyAsync.mockResolvedValue({
+        sub: 'user-1',
+        email: 'staff-a@restosync.dev',
+        role: 'ADMIN',
+        restaurantId: 'restaurant-A',
+      });
+      const socketA = createSocket('token-a');
+      await gateway.handleConnection(socketA);
+      expect(socketA.join).toHaveBeenCalledWith(staffRoom('restaurant-A'));
+
+      jwt.verifyAsync.mockResolvedValue({
+        sub: 'user-2',
+        email: 'staff-b@restosync.dev',
+        role: 'ADMIN',
+        restaurantId: 'restaurant-B',
+      });
+      const socketB = createSocket('token-b');
+      await gateway.handleConnection(socketB);
+      expect(socketB.join).toHaveBeenCalledWith(staffRoom('restaurant-B'));
+
+      expect(staffRoom('restaurant-A')).not.toEqual(staffRoom('restaurant-B'));
+    });
+
+    it('a connection with role CUSTOMER joins customer:${userId}, not any staff room', async () => {
       jwt.verifyAsync.mockResolvedValue({
         sub: 'customer-1',
         email: 'diner@restosync.dev',
         role: 'CUSTOMER',
+        restaurantId: 'restaurant-A',
       });
 
       const socket = createSocket('valid.token');
       await gateway.handleConnection(socket);
 
       expect(socket.join).toHaveBeenCalledWith(customerRoom('customer-1'));
-      expect(socket.join).not.toHaveBeenCalledWith(STAFF_ROOM);
+      expect(socket.join).not.toHaveBeenCalledWith(staffRoom('restaurant-A'));
       expect(socket.join).toHaveBeenCalledTimes(1);
     });
 
@@ -125,6 +153,7 @@ describe('RealtimeGateway', () => {
         sub: 'user-1',
         email: 'mystery@restosync.dev',
         role: 'SOME_FUTURE_ROLE',
+        restaurantId: 'restaurant-A',
       });
 
       const socket = createSocket('valid.token');
@@ -141,43 +170,46 @@ describe('RealtimeGateway', () => {
       previousStatus: OrderStatus.PENDING,
     };
 
-    it('emits to both "staff" and the owning customer room when the order has a customerId', async () => {
+    it("emits to both the owning restaurant's staff room and the owning customer room when the order has a customerId", async () => {
       const server = { to: jest.fn().mockReturnThis(), emit: jest.fn() };
       gateway.server = server as unknown as Server;
-      prisma.order.findUnique.mockResolvedValue({ customerId: 'customer-1' });
+      prisma.order.findUnique.mockResolvedValue({
+        restaurantId: 'restaurant-A',
+        customerId: 'customer-1',
+      });
 
       await gateway.emitStatusChanged(payload);
 
       expect(prisma.order.findUnique).toHaveBeenCalledWith({
         where: { id: 'order-1' },
-        select: { customerId: true },
+        select: { restaurantId: true, customerId: true },
       });
-      expect(server.to).toHaveBeenCalledWith(STAFF_ROOM);
+      expect(server.to).toHaveBeenCalledWith(staffRoom('restaurant-A'));
       expect(server.to).toHaveBeenCalledWith(customerRoom('customer-1'));
       expect(server.emit).toHaveBeenCalledWith('order.status_changed', payload);
       expect(server.emit).toHaveBeenCalledTimes(2);
     });
 
-    it('emits ONLY to "staff" when the order has no customerId (walk-in order)', async () => {
+    it("emits ONLY to the owning restaurant's staff room when the order has no customerId (walk-in order)", async () => {
       const server = { to: jest.fn().mockReturnThis(), emit: jest.fn() };
       gateway.server = server as unknown as Server;
-      prisma.order.findUnique.mockResolvedValue({ customerId: null });
+      prisma.order.findUnique.mockResolvedValue({
+        restaurantId: 'restaurant-A',
+        customerId: null,
+      });
 
       await gateway.emitStatusChanged(payload);
 
-      expect(server.to).toHaveBeenCalledWith(STAFF_ROOM);
+      expect(server.to).toHaveBeenCalledWith(staffRoom('restaurant-A'));
       expect(server.to).toHaveBeenCalledTimes(1);
       expect(server.emit).toHaveBeenCalledTimes(1);
     });
 
     it('does not deliver the event to an unrelated customer room (security property)', async () => {
-      // Simulates two independently-tracked "rooms" via separate emit
-      // spies, proving customer B's handler is never invoked for an
-      // event scoped to customer A.
       const customerAHandler = jest.fn();
       const customerBHandler = jest.fn();
       const rooms: Record<string, { emit: jest.Mock }> = {
-        [STAFF_ROOM]: { emit: jest.fn() },
+        [staffRoom('restaurant-A')]: { emit: jest.fn() },
         [customerRoom('customer-A')]: { emit: customerAHandler },
         [customerRoom('customer-B')]: { emit: customerBHandler },
       };
@@ -185,7 +217,10 @@ describe('RealtimeGateway', () => {
         to: jest.fn((room: string) => rooms[room] ?? { emit: jest.fn() }),
       };
       gateway.server = server as unknown as Server;
-      prisma.order.findUnique.mockResolvedValue({ customerId: 'customer-A' });
+      prisma.order.findUnique.mockResolvedValue({
+        restaurantId: 'restaurant-A',
+        customerId: 'customer-A',
+      });
 
       await gateway.emitStatusChanged(payload);
 
@@ -194,6 +229,43 @@ describe('RealtimeGateway', () => {
         payload,
       );
       expect(customerBHandler).not.toHaveBeenCalled();
+    });
+
+    it("#173: does not deliver the event to another restaurant's staff room (security property)", async () => {
+      const staffAHandler = jest.fn();
+      const staffBHandler = jest.fn();
+      const rooms: Record<string, { emit: jest.Mock }> = {
+        [staffRoom('restaurant-A')]: { emit: staffAHandler },
+        [staffRoom('restaurant-B')]: { emit: staffBHandler },
+      };
+      const server = {
+        to: jest.fn((room: string) => rooms[room] ?? { emit: jest.fn() }),
+      };
+      gateway.server = server as unknown as Server;
+      // Order belongs to restaurant A only.
+      prisma.order.findUnique.mockResolvedValue({
+        restaurantId: 'restaurant-A',
+        customerId: null,
+      });
+
+      await gateway.emitStatusChanged(payload);
+
+      expect(staffAHandler).toHaveBeenCalledWith(
+        'order.status_changed',
+        payload,
+      );
+      expect(staffBHandler).not.toHaveBeenCalled();
+    });
+
+    it('emits nothing when the order no longer exists', async () => {
+      const server = { to: jest.fn().mockReturnThis(), emit: jest.fn() };
+      gateway.server = server as unknown as Server;
+      prisma.order.findUnique.mockResolvedValue(null);
+
+      await gateway.emitStatusChanged(payload);
+
+      expect(server.to).not.toHaveBeenCalled();
+      expect(server.emit).not.toHaveBeenCalled();
     });
   });
 
@@ -206,27 +278,33 @@ describe('RealtimeGateway', () => {
       totalCents: 1300,
     };
 
-    it('emits to both "staff" and the owning customer room when the order has a customerId', async () => {
+    it("emits to both the owning restaurant's staff room and the owning customer room when the order has a customerId", async () => {
       const server = { to: jest.fn().mockReturnThis(), emit: jest.fn() };
       gateway.server = server as unknown as Server;
-      prisma.order.findUnique.mockResolvedValue({ customerId: 'customer-1' });
+      prisma.order.findUnique.mockResolvedValue({
+        restaurantId: 'restaurant-A',
+        customerId: 'customer-1',
+      });
 
       await gateway.emitTotalsChanged(payload);
 
-      expect(server.to).toHaveBeenCalledWith(STAFF_ROOM);
+      expect(server.to).toHaveBeenCalledWith(staffRoom('restaurant-A'));
       expect(server.to).toHaveBeenCalledWith(customerRoom('customer-1'));
       expect(server.emit).toHaveBeenCalledWith('order.totals_changed', payload);
       expect(server.emit).toHaveBeenCalledTimes(2);
     });
 
-    it('emits ONLY to "staff" when the order has no customerId (walk-in order)', async () => {
+    it("emits ONLY to the owning restaurant's staff room when the order has no customerId (walk-in order)", async () => {
       const server = { to: jest.fn().mockReturnThis(), emit: jest.fn() };
       gateway.server = server as unknown as Server;
-      prisma.order.findUnique.mockResolvedValue({ customerId: null });
+      prisma.order.findUnique.mockResolvedValue({
+        restaurantId: 'restaurant-A',
+        customerId: null,
+      });
 
       await gateway.emitTotalsChanged(payload);
 
-      expect(server.to).toHaveBeenCalledWith(STAFF_ROOM);
+      expect(server.to).toHaveBeenCalledWith(staffRoom('restaurant-A'));
       expect(server.to).toHaveBeenCalledTimes(1);
       expect(server.emit).toHaveBeenCalledTimes(1);
     });
@@ -235,7 +313,7 @@ describe('RealtimeGateway', () => {
       const customerAHandler = jest.fn();
       const customerBHandler = jest.fn();
       const rooms: Record<string, { emit: jest.Mock }> = {
-        [STAFF_ROOM]: { emit: jest.fn() },
+        [staffRoom('restaurant-A')]: { emit: jest.fn() },
         [customerRoom('customer-A')]: { emit: customerAHandler },
         [customerRoom('customer-B')]: { emit: customerBHandler },
       };
@@ -243,7 +321,10 @@ describe('RealtimeGateway', () => {
         to: jest.fn((room: string) => rooms[room] ?? { emit: jest.fn() }),
       };
       gateway.server = server as unknown as Server;
-      prisma.order.findUnique.mockResolvedValue({ customerId: 'customer-A' });
+      prisma.order.findUnique.mockResolvedValue({
+        restaurantId: 'restaurant-A',
+        customerId: 'customer-A',
+      });
 
       await gateway.emitTotalsChanged(payload);
 
@@ -252,6 +333,31 @@ describe('RealtimeGateway', () => {
         payload,
       );
       expect(customerBHandler).not.toHaveBeenCalled();
+    });
+
+    it("#173: does not deliver the event to another restaurant's staff room (security property)", async () => {
+      const staffAHandler = jest.fn();
+      const staffBHandler = jest.fn();
+      const rooms: Record<string, { emit: jest.Mock }> = {
+        [staffRoom('restaurant-A')]: { emit: staffAHandler },
+        [staffRoom('restaurant-B')]: { emit: staffBHandler },
+      };
+      const server = {
+        to: jest.fn((room: string) => rooms[room] ?? { emit: jest.fn() }),
+      };
+      gateway.server = server as unknown as Server;
+      prisma.order.findUnique.mockResolvedValue({
+        restaurantId: 'restaurant-A',
+        customerId: null,
+      });
+
+      await gateway.emitTotalsChanged(payload);
+
+      expect(staffAHandler).toHaveBeenCalledWith(
+        'order.totals_changed',
+        payload,
+      );
+      expect(staffBHandler).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/realtime/realtime.gateway.ts
+++ b/src/realtime/realtime.gateway.ts
@@ -16,11 +16,13 @@ export interface SocketUser {
   userId: string;
   email: string;
   role: string;
+  restaurantId: string;
 }
 
-// Any staff-facing role sees every order, unfiltered (#156, #154's
-// kitchen display). CUSTOMER is deliberately excluded — customers only
-// join their own per-user room (see joinRooms()).
+// Any staff-facing role sees every order for THEIR restaurant, unfiltered
+// within that scope (#156, #154's kitchen display). CUSTOMER is
+// deliberately excluded — customers only join their own per-user room
+// (see joinRooms()).
 const STAFF_ROLES: string[] = [
   Role.ADMIN,
   Role.WAITER,
@@ -30,7 +32,11 @@ const STAFF_ROLES: string[] = [
   Role.KITCHEN,
 ];
 
-export const STAFF_ROOM = 'staff';
+// #173: scoped per restaurant so staff of Restaurant A never receive
+// real-time order events for Restaurant B.
+export function staffRoom(restaurantId: string): string {
+  return `staff:${restaurantId}`;
+}
 
 export function customerRoom(customerId: string): string {
   return `customer:${customerId}`;
@@ -86,7 +92,7 @@ export class RealtimeGateway implements OnGatewayConnection {
   // receives no events, rather than defaulting to broadcast or staff.
   private joinRooms(client: Socket, user: SocketUser): void {
     if (this.isStaffRole(user.role)) {
-      client.join(STAFF_ROOM);
+      client.join(staffRoom(user.restaurantId));
     } else if (user.role === Role.CUSTOMER) {
       client.join(customerRoom(user.userId));
     }
@@ -116,37 +122,55 @@ export class RealtimeGateway implements OnGatewayConnection {
   }
 
   private toSocketUser(payload: JwtPayload): SocketUser {
-    return { userId: payload.sub, email: payload.email, role: payload.role };
+    return {
+      userId: payload.sub,
+      email: payload.email,
+      role: payload.role,
+      restaurantId: payload.restaurantId,
+    };
   }
 
-  // Staff always see every order (#156). If the order belongs to a
-  // customer, that customer's own room also receives it (#155) — no
-  // other customer ever does.
+  // Staff of the order's OWN restaurant always see it (#156); staff of any
+  // other restaurant never do (#173). If the order belongs to a customer,
+  // that customer's own room also receives it (#155) — no other customer
+  // ever does.
   async emitStatusChanged(payload: StatusChangedPayload): Promise<void> {
-    this.server.to(STAFF_ROOM).emit('order.status_changed', payload);
-    const customerId = await this.findCustomerId(payload.orderId);
-    if (customerId) {
+    const order = await this.findOrderRoomInfo(payload.orderId);
+    if (!order) {
+      return;
+    }
+    this.server
+      .to(staffRoom(order.restaurantId))
+      .emit('order.status_changed', payload);
+    if (order.customerId) {
       this.server
-        .to(customerRoom(customerId))
+        .to(customerRoom(order.customerId))
         .emit('order.status_changed', payload);
     }
   }
 
   async emitTotalsChanged(payload: TotalsChangedPayload): Promise<void> {
-    this.server.to(STAFF_ROOM).emit('order.totals_changed', payload);
-    const customerId = await this.findCustomerId(payload.orderId);
-    if (customerId) {
+    const order = await this.findOrderRoomInfo(payload.orderId);
+    if (!order) {
+      return;
+    }
+    this.server
+      .to(staffRoom(order.restaurantId))
+      .emit('order.totals_changed', payload);
+    if (order.customerId) {
       this.server
-        .to(customerRoom(customerId))
+        .to(customerRoom(order.customerId))
         .emit('order.totals_changed', payload);
     }
   }
 
-  private async findCustomerId(orderId: string): Promise<string | null> {
+  private async findOrderRoomInfo(
+    orderId: string,
+  ): Promise<{ restaurantId: string; customerId: string | null } | null> {
     const order = await this.prisma.order.findUnique({
       where: { id: orderId },
-      select: { customerId: true },
+      select: { restaurantId: true, customerId: true },
     });
-    return order?.customerId ?? null;
+    return order ?? null;
   }
 }

--- a/src/reports/reports.controller.ts
+++ b/src/reports/reports.controller.ts
@@ -7,6 +7,10 @@ import {
 } from '@nestjs/swagger';
 import { Role } from '@prisma/client';
 import type { Response } from 'express';
+import {
+  AuthUser,
+  CurrentUser,
+} from '../auth/decorators/current-user.decorator';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { toCsv } from '../common/utils/csv';
 import { DateQueryDto } from './dto/date-query.dto';
@@ -50,8 +54,12 @@ export class ReportsController {
   async getDailySummary(
     @Query() query: DateQueryDto,
     @Res({ passthrough: true }) res: Response,
+    @CurrentUser() user: AuthUser,
   ) {
-    const result = await this.reportsService.getDailySummary(query.date);
+    const result = await this.reportsService.getDailySummary(
+      query.date,
+      user.restaurantId,
+    );
 
     if (query.format === 'csv') {
       sendCsv(res, `daily-summary-${query.date}.csv`, [result]);
@@ -67,9 +75,11 @@ export class ReportsController {
   async getPaymentMethodBreakdown(
     @Query() query: DateQueryDto,
     @Res({ passthrough: true }) res: Response,
+    @CurrentUser() user: AuthUser,
   ) {
     const result = await this.reportsService.getPaymentMethodBreakdown(
       query.date,
+      user.restaurantId,
     );
 
     if (query.format === 'csv') {
@@ -94,9 +104,11 @@ export class ReportsController {
   async getBestSellingProducts(
     @Query() query: DateQueryDto,
     @Res({ passthrough: true }) res: Response,
+    @CurrentUser() user: AuthUser,
   ) {
     const result = await this.reportsService.getBestSellingProducts(
       query.date,
+      user.restaurantId,
       query.limit ?? 10,
     );
 
@@ -119,10 +131,12 @@ export class ReportsController {
   async getClosedTickets(
     @Query() query: DateRangeQueryDto,
     @Res({ passthrough: true }) res: Response,
+    @CurrentUser() user: AuthUser,
   ) {
     const result = await this.reportsService.getClosedTickets(
       query.startDate,
       query.endDate,
+      user.restaurantId,
     );
 
     if (query.format === 'csv') {
@@ -147,10 +161,12 @@ export class ReportsController {
   async getDailySummaryRange(
     @Query() query: DateRangeQueryDto,
     @Res({ passthrough: true }) res: Response,
+    @CurrentUser() user: AuthUser,
   ) {
     const result = await this.reportsService.getDailySummaryRange(
       query.startDate,
       query.endDate,
+      user.restaurantId,
     );
 
     if (query.format === 'csv') {
@@ -172,10 +188,12 @@ export class ReportsController {
   async getPaymentMethodBreakdownRange(
     @Query() query: DateRangeQueryDto,
     @Res({ passthrough: true }) res: Response,
+    @CurrentUser() user: AuthUser,
   ) {
     const result = await this.reportsService.getPaymentMethodBreakdownRange(
       query.startDate,
       query.endDate,
+      user.restaurantId,
     );
 
     if (query.format === 'csv') {
@@ -204,10 +222,12 @@ export class ReportsController {
   async getTicketCountByDay(
     @Query() query: DateRangeQueryDto,
     @Res({ passthrough: true }) res: Response,
+    @CurrentUser() user: AuthUser,
   ) {
     const result = await this.reportsService.getTicketCountByDay(
       query.startDate,
       query.endDate,
+      user.restaurantId,
     );
 
     if (query.format === 'csv') {

--- a/src/reports/reports.service.spec.ts
+++ b/src/reports/reports.service.spec.ts
@@ -37,6 +37,7 @@ describe('ReportsService', () => {
   const date = '2025-06-30';
   const startDate = '2025-06-01';
   const endDate = '2025-06-30';
+  const restaurantId = 'restaurant-A';
 
   beforeEach(() => {
     prisma = createMockPrisma();
@@ -44,16 +45,17 @@ describe('ReportsService', () => {
   });
 
   describe('getDailySummary', () => {
-    it('returns correct totalSalesCents and ticketCount with averageTicketCents computed', async () => {
+    it('returns correct totalSalesCents and ticketCount with averageTicketCents computed, scoped by restaurantId', async () => {
       prisma.order.aggregate.mockResolvedValue({
         _sum: { totalCents: 5000 },
         _count: 4,
       });
 
-      const result = await service.getDailySummary(date);
+      const result = await service.getDailySummary(date, restaurantId);
 
       expect(prisma.order.aggregate).toHaveBeenCalledWith({
         where: {
+          restaurantId,
           status: { in: [OrderStatus.COMPLETED, OrderStatus.CONFIRMED] },
           createdAt: expect.objectContaining({
             gte: expect.any(Date),
@@ -74,27 +76,46 @@ describe('ReportsService', () => {
         _count: 0,
       });
 
-      const result = await service.getDailySummary(date);
+      const result = await service.getDailySummary(date, restaurantId);
 
       expect(result.totalSalesCents).toBe(0);
       expect(result.ticketCount).toBe(0);
       expect(result.averageTicketCents).toBe(0);
     });
+
+    it('scopes to a different caller restaurantId independently', async () => {
+      prisma.order.aggregate.mockResolvedValue({
+        _sum: { totalCents: 0 },
+        _count: 0,
+      });
+
+      await service.getDailySummary(date, 'restaurant-B');
+
+      expect(prisma.order.aggregate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ restaurantId: 'restaurant-B' }),
+        }),
+      );
+    });
   });
 
   describe('getPaymentMethodBreakdown', () => {
-    it('returns correct amounts per method and excludes methods with 0 amount', async () => {
+    it('returns correct amounts per method and excludes methods with 0 amount, scoped by restaurantId', async () => {
       prisma.payment.groupBy.mockResolvedValue([
         { method: PaymentMethod.CASH, _sum: { amountCents: 3000 } },
         { method: PaymentMethod.CARD, _sum: { amountCents: 0 } },
       ]);
 
-      const result = await service.getPaymentMethodBreakdown(date);
+      const result = await service.getPaymentMethodBreakdown(
+        date,
+        restaurantId,
+      );
 
       expect(prisma.payment.groupBy).toHaveBeenCalledWith(
         expect.objectContaining({
           by: ['method'],
           where: expect.objectContaining({
+            restaurantId,
             status: PaymentStatus.SUCCEEDED,
           }),
         }),
@@ -107,7 +128,7 @@ describe('ReportsService', () => {
   });
 
   describe('getBestSellingProducts', () => {
-    it('returns a ranked list by quantitySold DESC with revenueCents', async () => {
+    it('returns a ranked list by quantitySold DESC with revenueCents, scoped by restaurantId', async () => {
       prisma.orderItem.groupBy.mockResolvedValue([
         {
           menuItemId: 'item-a',
@@ -121,8 +142,17 @@ describe('ReportsService', () => {
         },
       ]);
 
-      const result = await service.getBestSellingProducts(date, 10);
+      const result = await service.getBestSellingProducts(
+        date,
+        restaurantId,
+        10,
+      );
 
+      expect(prisma.orderItem.groupBy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ restaurantId }),
+        }),
+      );
       expect(result).toEqual([
         {
           menuItemId: 'item-a',
@@ -142,7 +172,7 @@ describe('ReportsService', () => {
     it('respects the limit param by passing it to take', async () => {
       prisma.orderItem.groupBy.mockResolvedValue([]);
 
-      await service.getBestSellingProducts(date, 3);
+      await service.getBestSellingProducts(date, restaurantId, 3);
 
       expect(prisma.orderItem.groupBy).toHaveBeenCalledWith(
         expect.objectContaining({ take: 3 }),
@@ -152,7 +182,7 @@ describe('ReportsService', () => {
     it('defaults the limit to 10 when not provided', async () => {
       prisma.orderItem.groupBy.mockResolvedValue([]);
 
-      await service.getBestSellingProducts(date);
+      await service.getBestSellingProducts(date, restaurantId);
 
       expect(prisma.orderItem.groupBy).toHaveBeenCalledWith(
         expect.objectContaining({ take: 10 }),
@@ -161,7 +191,7 @@ describe('ReportsService', () => {
   });
 
   describe('getClosedTickets', () => {
-    it('returns orders in the date range with itemCount', async () => {
+    it('returns orders in the date range with itemCount, scoped by restaurantId', async () => {
       prisma.order.findMany.mockResolvedValue([
         {
           id: 'order-1',
@@ -173,8 +203,17 @@ describe('ReportsService', () => {
         },
       ]);
 
-      const result = await service.getClosedTickets(startDate, endDate);
+      const result = await service.getClosedTickets(
+        startDate,
+        endDate,
+        restaurantId,
+      );
 
+      expect(prisma.order.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ restaurantId }),
+        }),
+      );
       expect(result).toEqual([
         {
           id: 'order-1',
@@ -190,7 +229,7 @@ describe('ReportsService', () => {
     it('filters by COMPLETED/CONFIRMED status only', async () => {
       prisma.order.findMany.mockResolvedValue([]);
 
-      await service.getClosedTickets(startDate, endDate);
+      await service.getClosedTickets(startDate, endDate, restaurantId);
 
       expect(prisma.order.findMany).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -203,15 +242,24 @@ describe('ReportsService', () => {
   });
 
   describe('getTicketCountByDay', () => {
-    it('groups orders by day and returns a sorted array', async () => {
+    it('groups orders by day and returns a sorted array, scoped by restaurantId', async () => {
       prisma.order.findMany.mockResolvedValue([
         { createdAt: new Date('2025-06-02T08:00:00Z') },
         { createdAt: new Date('2025-06-01T09:00:00Z') },
         { createdAt: new Date('2025-06-01T20:00:00Z') },
       ]);
 
-      const result = await service.getTicketCountByDay(startDate, endDate);
+      const result = await service.getTicketCountByDay(
+        startDate,
+        endDate,
+        restaurantId,
+      );
 
+      expect(prisma.order.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ restaurantId }),
+        }),
+      );
       expect(result).toEqual([
         { date: '2025-06-01', ticketCount: 2 },
         { date: '2025-06-02', ticketCount: 1 },
@@ -221,7 +269,11 @@ describe('ReportsService', () => {
     it('returns an empty array when there are no orders', async () => {
       prisma.order.findMany.mockResolvedValue([]);
 
-      const result = await service.getTicketCountByDay(startDate, endDate);
+      const result = await service.getTicketCountByDay(
+        startDate,
+        endDate,
+        restaurantId,
+      );
 
       expect(result).toEqual([]);
     });

--- a/src/reports/reports.service.ts
+++ b/src/reports/reports.service.ts
@@ -11,17 +11,12 @@ const SALE_STATUSES: OrderStatus[] = [
 export class ReportsService {
   constructor(private readonly prisma: PrismaService) {}
 
-  async getDailySummary(
-    date: string,
-    restaurantId?: string,
-    timezone?: string,
-  ) {
-    void restaurantId;
-
+  async getDailySummary(date: string, restaurantId: string, timezone?: string) {
     const { gte, lt } = this.dayRange(date, timezone);
 
     const result = await this.prisma.order.aggregate({
       where: {
+        restaurantId,
         status: { in: SALE_STATUSES },
         createdAt: { gte, lt },
       },
@@ -37,12 +32,17 @@ export class ReportsService {
     return { totalSalesCents, ticketCount, averageTicketCents };
   }
 
-  async getPaymentMethodBreakdown(date: string, timezone?: string) {
+  async getPaymentMethodBreakdown(
+    date: string,
+    restaurantId: string,
+    timezone?: string,
+  ) {
     const { gte, lt } = this.dayRange(date, timezone);
 
     const grouped = await this.prisma.payment.groupBy({
       by: ['method'],
       where: {
+        restaurantId,
         status: PaymentStatus.SUCCEEDED,
         createdAt: { gte, lt },
       },
@@ -61,12 +61,18 @@ export class ReportsService {
     return byMethod;
   }
 
-  async getBestSellingProducts(date: string, limit = 10, timezone?: string) {
+  async getBestSellingProducts(
+    date: string,
+    restaurantId: string,
+    limit = 10,
+    timezone?: string,
+  ) {
     const { gte, lt } = this.dayRange(date, timezone);
 
     const grouped = await this.prisma.orderItem.groupBy({
       by: ['menuItemId', 'nameSnapshot'],
       where: {
+        restaurantId,
         order: {
           status: { in: SALE_STATUSES },
           createdAt: { gte, lt },
@@ -88,6 +94,7 @@ export class ReportsService {
   async getClosedTickets(
     startDate: string,
     endDate: string,
+    restaurantId: string,
     timezone?: string,
   ) {
     const { gte } = this.dayRange(startDate, timezone);
@@ -95,6 +102,7 @@ export class ReportsService {
 
     const orders = await this.prisma.order.findMany({
       where: {
+        restaurantId,
         status: { in: SALE_STATUSES },
         createdAt: { gte, lt },
       },
@@ -122,6 +130,7 @@ export class ReportsService {
   async getDailySummaryRange(
     startDate: string,
     endDate: string,
+    restaurantId: string,
     timezone?: string,
   ) {
     const { gte } = this.dayRange(startDate, timezone);
@@ -129,6 +138,7 @@ export class ReportsService {
 
     const orders = await this.prisma.order.findMany({
       where: {
+        restaurantId,
         status: { in: SALE_STATUSES },
         createdAt: { gte, lt },
       },
@@ -168,6 +178,7 @@ export class ReportsService {
   async getPaymentMethodBreakdownRange(
     startDate: string,
     endDate: string,
+    restaurantId: string,
     timezone?: string,
   ) {
     const { gte } = this.dayRange(startDate, timezone);
@@ -176,6 +187,7 @@ export class ReportsService {
     const grouped = await this.prisma.payment.groupBy({
       by: ['method'],
       where: {
+        restaurantId,
         status: PaymentStatus.SUCCEEDED,
         createdAt: { gte, lt },
       },
@@ -197,6 +209,7 @@ export class ReportsService {
   async getTicketCountByDay(
     startDate: string,
     endDate: string,
+    restaurantId: string,
     timezone?: string,
   ) {
     const { gte } = this.dayRange(startDate, timezone);
@@ -204,6 +217,7 @@ export class ReportsService {
 
     const orders = await this.prisma.order.findMany({
       where: {
+        restaurantId,
         status: { in: SALE_STATUSES },
         createdAt: { gte, lt },
       },

--- a/src/reservations/reservations.controller.ts
+++ b/src/reservations/reservations.controller.ts
@@ -14,7 +14,10 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 import { Role } from '@prisma/client';
-import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import {
+  AuthUser,
+  CurrentUser,
+} from '../auth/decorators/current-user.decorator';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { CreateReservationDto } from './dto/create-reservation.dto';
 import { ListReservationsQueryDto } from './dto/list-reservations-query.dto';
@@ -36,23 +39,26 @@ export class ReservationsController {
   @ApiResponse({ status: 201, description: 'Reservation created' })
   @ApiResponse({ status: 400, description: 'Validation error' })
   @ApiResponse({ status: 404, description: 'Table not found' })
-  create(@Body() dto: CreateReservationDto, @CurrentUser('id') userId: string) {
-    return this.reservationsService.create(dto, userId);
+  create(@Body() dto: CreateReservationDto, @CurrentUser() user: AuthUser) {
+    return this.reservationsService.create(dto, user);
   }
 
   @Get()
   @ApiOperation({ summary: 'List reservations, filterable by status/date' })
   @ApiResponse({ status: 200, description: 'List of reservations' })
-  findAll(@Query() query: ListReservationsQueryDto) {
-    return this.reservationsService.findAll(query);
+  findAll(
+    @Query() query: ListReservationsQueryDto,
+    @CurrentUser() user: AuthUser,
+  ) {
+    return this.reservationsService.findAll(query, user);
   }
 
   @Get(':id')
   @ApiOperation({ summary: 'Get a single reservation' })
   @ApiResponse({ status: 200, description: 'Reservation details' })
   @ApiResponse({ status: 404, description: 'Reservation not found' })
-  findOne(@Param('id') id: string) {
-    return this.reservationsService.findOne(id);
+  findOne(@Param('id') id: string, @CurrentUser() user: AuthUser) {
+    return this.reservationsService.findOne(id, user);
   }
 
   @Patch(':id/confirm')
@@ -63,8 +69,8 @@ export class ReservationsController {
   @ApiResponse({ status: 200, description: 'Reservation confirmed' })
   @ApiResponse({ status: 400, description: 'Reservation not PENDING' })
   @ApiResponse({ status: 404, description: 'Reservation not found' })
-  confirm(@Param('id') id: string, @CurrentUser('id') userId: string) {
-    return this.reservationsService.confirm(id, userId);
+  confirm(@Param('id') id: string, @CurrentUser() user: AuthUser) {
+    return this.reservationsService.confirm(id, user);
   }
 
   @Post(':id/seat')
@@ -81,9 +87,9 @@ export class ReservationsController {
   seat(
     @Param('id') id: string,
     @Body() dto: SeatReservationDto,
-    @CurrentUser('id') userId: string,
+    @CurrentUser() user: AuthUser,
   ) {
-    return this.reservationsService.seat(id, dto, userId);
+    return this.reservationsService.seat(id, dto, user);
   }
 
   @Patch(':id/no-show')
@@ -93,8 +99,8 @@ export class ReservationsController {
   @ApiResponse({ status: 200, description: 'Reservation marked NO_SHOW' })
   @ApiResponse({ status: 400, description: 'Reservation already terminal' })
   @ApiResponse({ status: 404, description: 'Reservation not found' })
-  noShow(@Param('id') id: string) {
-    return this.reservationsService.noShow(id);
+  noShow(@Param('id') id: string, @CurrentUser() user: AuthUser) {
+    return this.reservationsService.noShow(id, user);
   }
 
   @Patch(':id/cancel')
@@ -102,7 +108,7 @@ export class ReservationsController {
   @ApiResponse({ status: 200, description: 'Reservation cancelled' })
   @ApiResponse({ status: 400, description: 'Reservation already terminal' })
   @ApiResponse({ status: 404, description: 'Reservation not found' })
-  cancel(@Param('id') id: string) {
-    return this.reservationsService.cancel(id);
+  cancel(@Param('id') id: string, @CurrentUser() user: AuthUser) {
+    return this.reservationsService.cancel(id, user);
   }
 }

--- a/src/reservations/reservations.service.spec.ts
+++ b/src/reservations/reservations.service.spec.ts
@@ -5,8 +5,10 @@ import {
   OrderType,
   ReservationStatus,
   ReservationType,
+  Role,
   TableStatus,
 } from '@prisma/client';
+import { AuthUser } from '../auth/decorators/current-user.decorator';
 import { OrdersService } from '../orders/orders.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { ReservationsService } from './reservations.service';
@@ -14,6 +16,7 @@ import { ReservationsService } from './reservations.service';
 type MockPrisma = {
   table: {
     findUnique: jest.Mock;
+    findFirst: jest.Mock;
     update: jest.Mock;
   };
   reservation: {
@@ -36,6 +39,7 @@ function createMockPrisma(): MockPrisma {
   const prisma: MockPrisma = {
     table: {
       findUnique: jest.fn(),
+      findFirst: jest.fn(),
       update: jest.fn(),
     },
     reservation: {
@@ -68,6 +72,16 @@ function createMockPrisma(): MockPrisma {
   return prisma;
 }
 
+function buildUser(overrides: Partial<AuthUser> = {}): AuthUser {
+  return {
+    id: 'user-1',
+    email: 'manager@restosync.local',
+    role: Role.MANAGER,
+    restaurantId: 'restaurant-A',
+    ...overrides,
+  };
+}
+
 describe('ReservationsService', () => {
   let service: ReservationsService;
   let prisma: MockPrisma;
@@ -77,12 +91,16 @@ describe('ReservationsService', () => {
   };
   let config: { get: jest.Mock };
 
-  const actorId = 'user-1';
+  const user = buildUser();
   const tableId = 'table-1';
   const reservationId = 'reservation-1';
   const menuItemId = 'menu-item-1';
 
-  const availableTable = { id: tableId, status: TableStatus.AVAILABLE };
+  const availableTable = {
+    id: tableId,
+    status: TableStatus.AVAILABLE,
+    restaurantId: user.restaurantId,
+  };
 
   beforeEach(() => {
     prisma = createMockPrisma();
@@ -123,7 +141,7 @@ describe('ReservationsService', () => {
         reservationType: ReservationType.INFORMAL,
       };
 
-      const result = await service.create(dto as any, actorId);
+      const result = await service.create(dto as any, user);
 
       expect(config.get).toHaveBeenCalledWith('restaurant.timezone');
       // America/Lima is fixed UTC-5 — 14:00 local -> 19:00 UTC.
@@ -131,8 +149,27 @@ describe('ReservationsService', () => {
       expect(result.reservedForLocal).toBe('2026-08-01T14:00:00');
     });
 
+    it('sets restaurantId on the created reservation from the caller, never from the client', async () => {
+      prisma.reservation.create.mockImplementation(({ data }) =>
+        Promise.resolve({ id: reservationId, ...data }),
+      );
+
+      const dto = {
+        ...baseDto,
+        reservationType: ReservationType.INFORMAL,
+        // Simulates a malicious/naive client payload attempting to set
+        // its own restaurantId directly.
+        restaurantId: 'restaurant-EVIL',
+      };
+
+      await service.create(dto as any, user);
+
+      const { data } = prisma.reservation.create.mock.calls[0][0];
+      expect(data.restaurantId).toBe(user.restaurantId);
+    });
+
     it('WITH_PREORDER: computes depositCents as floor(order.totalCents / 2) and creates the pre-order via OrdersService', async () => {
-      prisma.table.findUnique.mockResolvedValue(availableTable);
+      prisma.table.findFirst.mockResolvedValue(availableTable);
       ordersService.create.mockResolvedValue({
         id: 'order-1',
         totalCents: 4501,
@@ -148,25 +185,28 @@ describe('ReservationsService', () => {
         items: [{ menuItemId, quantity: 2 }],
       };
 
-      const result = await service.create(dto as any, actorId);
+      const result = await service.create(dto as any, user);
 
-      expect(prisma.table.findUnique).toHaveBeenCalledWith({
-        where: { id: tableId },
+      expect(prisma.table.findFirst).toHaveBeenCalledWith({
+        where: { id: tableId, restaurantId: user.restaurantId },
       });
-      expect(ordersService.create).toHaveBeenCalledWith({
-        type: OrderType.TAKEAWAY,
-        items: dto.items,
-      });
+      expect(ordersService.create).toHaveBeenCalledWith(
+        {
+          type: OrderType.TAKEAWAY,
+          items: dto.items,
+        },
+        user.restaurantId,
+      );
       // floor(4501 / 2) = 2250
       expect(result.depositCents).toBe(2250);
       expect(result.orderId).toBe('order-1');
       expect(result.tableId).toBe(tableId);
       expect(result.status).toBe(ReservationStatus.PENDING);
-      expect(result.createdBy).toBe(actorId);
+      expect(result.createdBy).toBe(user.id);
     });
 
     it('DEPOSIT_ONLY: uses the configured fixed deposit amount', async () => {
-      prisma.table.findUnique.mockResolvedValue(availableTable);
+      prisma.table.findFirst.mockResolvedValue(availableTable);
       prisma.reservation.create.mockImplementation(({ data }) =>
         Promise.resolve({ id: reservationId, ...data }),
       );
@@ -177,7 +217,7 @@ describe('ReservationsService', () => {
         tableId,
       };
 
-      const result = await service.create(dto as any, actorId);
+      const result = await service.create(dto as any, user);
 
       expect(config.get).toHaveBeenCalledWith('reservations.depositCents');
       expect(result.depositCents).toBe(1000);
@@ -195,9 +235,9 @@ describe('ReservationsService', () => {
         reservationType: ReservationType.INFORMAL,
       };
 
-      const result = await service.create(dto as any, actorId);
+      const result = await service.create(dto as any, user);
 
-      expect(prisma.table.findUnique).not.toHaveBeenCalled();
+      expect(prisma.table.findFirst).not.toHaveBeenCalled();
       expect(ordersService.create).not.toHaveBeenCalled();
       expect(result.depositCents).toBeUndefined();
       expect(result.tableId).toBeUndefined();
@@ -211,7 +251,7 @@ describe('ReservationsService', () => {
         tableId,
       };
 
-      await expect(service.create(dto as any, actorId)).rejects.toThrow(
+      await expect(service.create(dto as any, user)).rejects.toThrow(
         BadRequestException,
       );
     });
@@ -223,13 +263,13 @@ describe('ReservationsService', () => {
         items: [{ menuItemId, quantity: 1 }],
       };
 
-      await expect(service.create(dto as any, actorId)).rejects.toThrow(
+      await expect(service.create(dto as any, user)).rejects.toThrow(
         BadRequestException,
       );
     });
 
     it('rejects DEPOSIT_ONLY reservations that include items', async () => {
-      prisma.table.findUnique.mockResolvedValue(availableTable);
+      prisma.table.findFirst.mockResolvedValue(availableTable);
 
       const dto = {
         ...baseDto,
@@ -238,13 +278,13 @@ describe('ReservationsService', () => {
         items: [{ menuItemId, quantity: 1 }],
       };
 
-      await expect(service.create(dto as any, actorId)).rejects.toThrow(
+      await expect(service.create(dto as any, user)).rejects.toThrow(
         BadRequestException,
       );
     });
 
     it('throws NotFoundException when the table does not exist', async () => {
-      prisma.table.findUnique.mockResolvedValue(null);
+      prisma.table.findFirst.mockResolvedValue(null);
 
       const dto = {
         ...baseDto,
@@ -252,15 +292,32 @@ describe('ReservationsService', () => {
         tableId,
       };
 
-      await expect(service.create(dto as any, actorId)).rejects.toThrow(
+      await expect(service.create(dto as any, user)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('throws NotFoundException (not the table) when the table belongs to another restaurant', async () => {
+      // findFirst is itself scoped by restaurantId, so a table owned by a
+      // different restaurant is invisible here — same as nonexistent.
+      prisma.table.findFirst.mockResolvedValue(null);
+
+      const dto = {
+        ...baseDto,
+        reservationType: ReservationType.DEPOSIT_ONLY,
+        tableId,
+      };
+
+      await expect(service.create(dto as any, user)).rejects.toThrow(
         NotFoundException,
       );
     });
 
     it('throws BadRequestException when the table is not AVAILABLE', async () => {
-      prisma.table.findUnique.mockResolvedValue({
+      prisma.table.findFirst.mockResolvedValue({
         id: tableId,
         status: TableStatus.OCCUPIED,
+        restaurantId: user.restaurantId,
       });
 
       const dto = {
@@ -270,14 +327,14 @@ describe('ReservationsService', () => {
         items: [{ menuItemId, quantity: 1 }],
       };
 
-      await expect(service.create(dto as any, actorId)).rejects.toThrow(
+      await expect(service.create(dto as any, user)).rejects.toThrow(
         BadRequestException,
       );
     });
 
     describe('toleranceMinutes defaults (type-aware, overridable)', () => {
       beforeEach(() => {
-        prisma.table.findUnique.mockResolvedValue(availableTable);
+        prisma.table.findFirst.mockResolvedValue(availableTable);
         prisma.reservation.create.mockImplementation(({ data }) =>
           Promise.resolve({ id: reservationId, ...data }),
         );
@@ -290,7 +347,7 @@ describe('ReservationsService', () => {
       it('defaults to 10 minutes for INFORMAL when omitted', async () => {
         const result = await service.create(
           { ...baseDto, reservationType: ReservationType.INFORMAL } as any,
-          actorId,
+          user,
         );
         expect(result.toleranceMinutes).toBe(10);
       });
@@ -302,7 +359,7 @@ describe('ReservationsService', () => {
             reservationType: ReservationType.DEPOSIT_ONLY,
             tableId,
           } as any,
-          actorId,
+          user,
         );
         expect(result.toleranceMinutes).toBe(20);
       });
@@ -315,7 +372,7 @@ describe('ReservationsService', () => {
             tableId,
             items: [{ menuItemId, quantity: 1 }],
           } as any,
-          actorId,
+          user,
         );
         expect(result.toleranceMinutes).toBe(30);
       });
@@ -327,7 +384,7 @@ describe('ReservationsService', () => {
             reservationType: ReservationType.INFORMAL,
             toleranceMinutes: 999,
           } as any,
-          actorId,
+          user,
         );
         expect(result.toleranceMinutes).toBe(999);
       });
@@ -341,10 +398,58 @@ describe('ReservationsService', () => {
             items: [{ menuItemId, quantity: 1 }],
             toleranceMinutes: 1,
           } as any,
-          actorId,
+          user,
         );
         expect(result.toleranceMinutes).toBe(1);
       });
+    });
+  });
+
+  describe('findAll', () => {
+    it('scopes the query to the caller restaurantId', async () => {
+      prisma.reservation.findMany.mockResolvedValue([]);
+
+      await service.findAll({} as any, user);
+
+      expect(prisma.reservation.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ restaurantId: user.restaurantId }),
+        }),
+      );
+    });
+  });
+
+  describe('findOne', () => {
+    it('returns the reservation when it belongs to the caller restaurant', async () => {
+      prisma.reservation.findUnique.mockResolvedValue({
+        id: reservationId,
+        restaurantId: user.restaurantId,
+        reservedFor: new Date('2026-08-01T19:00:00Z'),
+      });
+
+      const result = await service.findOne(reservationId, user);
+
+      expect(result.id).toBe(reservationId);
+    });
+
+    it('throws NotFoundException if the reservation does not exist', async () => {
+      prisma.reservation.findUnique.mockResolvedValue(null);
+
+      await expect(service.findOne(reservationId, user)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('throws NotFoundException (404, NOT 403) for a reservation belonging to another restaurant', async () => {
+      prisma.reservation.findUnique.mockResolvedValue({
+        id: reservationId,
+        restaurantId: 'restaurant-B',
+        reservedFor: new Date('2026-08-01T19:00:00Z'),
+      });
+
+      await expect(service.findOne(reservationId, user)).rejects.toThrow(
+        NotFoundException,
+      );
     });
   });
 
@@ -352,6 +457,7 @@ describe('ReservationsService', () => {
     it('sets Table.status to RESERVED for WITH_PREORDER/DEPOSIT_ONLY and stamps the deposit confirmation', async () => {
       prisma.reservation.findUnique.mockResolvedValue({
         id: reservationId,
+        restaurantId: user.restaurantId,
         status: ReservationStatus.PENDING,
         reservationType: ReservationType.DEPOSIT_ONLY,
         tableId,
@@ -360,7 +466,7 @@ describe('ReservationsService', () => {
       const txReservationUpdate = jest.fn().mockResolvedValue({
         id: reservationId,
         status: ReservationStatus.CONFIRMED,
-        depositConfirmedBy: actorId,
+        depositConfirmedBy: user.id,
       });
       prisma.$transaction.mockImplementationOnce((cb) =>
         cb({
@@ -369,7 +475,7 @@ describe('ReservationsService', () => {
         }),
       );
 
-      const result = await service.confirm(reservationId, actorId);
+      const result = await service.confirm(reservationId, user);
 
       expect(txTableUpdate).toHaveBeenCalledWith({
         where: { id: tableId },
@@ -379,7 +485,7 @@ describe('ReservationsService', () => {
         where: { id: reservationId },
         data: expect.objectContaining({
           status: ReservationStatus.CONFIRMED,
-          depositConfirmedBy: actorId,
+          depositConfirmedBy: user.id,
         }),
       });
       expect(result.status).toBe(ReservationStatus.CONFIRMED);
@@ -388,6 +494,7 @@ describe('ReservationsService', () => {
     it('does NOT touch the table for INFORMAL reservations', async () => {
       prisma.reservation.findUnique.mockResolvedValue({
         id: reservationId,
+        restaurantId: user.restaurantId,
         status: ReservationStatus.PENDING,
         reservationType: ReservationType.INFORMAL,
         tableId: null,
@@ -397,7 +504,7 @@ describe('ReservationsService', () => {
         status: ReservationStatus.CONFIRMED,
       });
 
-      const result = await service.confirm(reservationId, actorId);
+      const result = await service.confirm(reservationId, user);
 
       expect(prisma.$transaction).not.toHaveBeenCalled();
       expect(prisma.reservation.update).toHaveBeenCalledWith({
@@ -410,11 +517,12 @@ describe('ReservationsService', () => {
     it('throws BadRequestException if the reservation is not PENDING', async () => {
       prisma.reservation.findUnique.mockResolvedValue({
         id: reservationId,
+        restaurantId: user.restaurantId,
         status: ReservationStatus.CONFIRMED,
         reservationType: ReservationType.INFORMAL,
       });
 
-      await expect(service.confirm(reservationId, actorId)).rejects.toThrow(
+      await expect(service.confirm(reservationId, user)).rejects.toThrow(
         BadRequestException,
       );
     });
@@ -422,7 +530,20 @@ describe('ReservationsService', () => {
     it('throws NotFoundException if the reservation does not exist', async () => {
       prisma.reservation.findUnique.mockResolvedValue(null);
 
-      await expect(service.confirm(reservationId, actorId)).rejects.toThrow(
+      await expect(service.confirm(reservationId, user)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('throws NotFoundException (404, NOT 403) if the reservation belongs to another restaurant', async () => {
+      prisma.reservation.findUnique.mockResolvedValue({
+        id: reservationId,
+        restaurantId: 'restaurant-B',
+        status: ReservationStatus.PENDING,
+        reservationType: ReservationType.INFORMAL,
+      });
+
+      await expect(service.confirm(reservationId, user)).rejects.toThrow(
         NotFoundException,
       );
     });
@@ -432,6 +553,7 @@ describe('ReservationsService', () => {
     it('WITH_PREORDER: links the existing order to the table and sets it OCCUPIED', async () => {
       prisma.reservation.findUnique.mockResolvedValue({
         id: reservationId,
+        restaurantId: user.restaurantId,
         status: ReservationStatus.CONFIRMED,
         reservationType: ReservationType.WITH_PREORDER,
         orderId: 'order-1',
@@ -445,7 +567,7 @@ describe('ReservationsService', () => {
         items: [],
       });
 
-      const result = await service.seat(reservationId, {}, actorId);
+      const result = await service.seat(reservationId, {}, user);
 
       expect(prisma.table.update).toHaveBeenCalledWith({
         where: { id: tableId },
@@ -467,6 +589,7 @@ describe('ReservationsService', () => {
     it('DEPOSIT_ONLY: creates a new (empty) order via OrdersService.create and links it, WITHOUT applying the discount yet', async () => {
       prisma.reservation.findUnique.mockResolvedValue({
         id: reservationId,
+        restaurantId: user.restaurantId,
         status: ReservationStatus.CONFIRMED,
         reservationType: ReservationType.DEPOSIT_ONLY,
         tableId,
@@ -480,13 +603,16 @@ describe('ReservationsService', () => {
       // auto-applied here.
       ordersService.create.mockResolvedValue({ id: 'order-2', items: [] });
 
-      const result = await service.seat(reservationId, {}, actorId);
+      const result = await service.seat(reservationId, {}, user);
 
-      expect(ordersService.create).toHaveBeenCalledWith({
-        type: OrderType.DINE_IN,
-        tableId,
-        items: [],
-      });
+      expect(ordersService.create).toHaveBeenCalledWith(
+        {
+          type: OrderType.DINE_IN,
+          tableId,
+          items: [],
+        },
+        user.restaurantId,
+      );
       expect(prisma.reservation.update).toHaveBeenCalledWith({
         where: { id: reservationId },
         data: { orderId: 'order-2', status: ReservationStatus.SEATED },
@@ -498,6 +624,7 @@ describe('ReservationsService', () => {
     it('DEPOSIT_ONLY: auto-applies the deposit discount once the order already has items (subtotalCents > 0)', async () => {
       prisma.reservation.findUnique.mockResolvedValue({
         id: reservationId,
+        restaurantId: user.restaurantId,
         status: ReservationStatus.CONFIRMED,
         reservationType: ReservationType.DEPOSIT_ONLY,
         tableId,
@@ -512,7 +639,7 @@ describe('ReservationsService', () => {
         discountCents: 1000,
       });
 
-      const result = await service.seat(reservationId, {}, actorId);
+      const result = await service.seat(reservationId, {}, user);
 
       expect(ordersService.applyDiscount).toHaveBeenCalledWith(
         'order-2',
@@ -521,7 +648,7 @@ describe('ReservationsService', () => {
           discountCents: 1000,
           reason: 'Reservation deposit applied',
         },
-        actorId,
+        user,
       );
       expect(result.discountCents).toBe(1000);
     });
@@ -529,6 +656,7 @@ describe('ReservationsService', () => {
     it('DEPOSIT_ONLY: skips discount application when depositCents is 0, even if the order has items', async () => {
       prisma.reservation.findUnique.mockResolvedValue({
         id: reservationId,
+        restaurantId: user.restaurantId,
         status: ReservationStatus.CONFIRMED,
         reservationType: ReservationType.DEPOSIT_ONLY,
         tableId,
@@ -539,7 +667,7 @@ describe('ReservationsService', () => {
         items: [{ priceCents: 5000, quantity: 1 }],
       });
 
-      await service.seat(reservationId, {}, actorId);
+      await service.seat(reservationId, {}, user);
 
       expect(ordersService.applyDiscount).not.toHaveBeenCalled();
     });
@@ -547,12 +675,13 @@ describe('ReservationsService', () => {
     it('INFORMAL: requires a staff-chosen tableId in the request body', async () => {
       prisma.reservation.findUnique.mockResolvedValue({
         id: reservationId,
+        restaurantId: user.restaurantId,
         status: ReservationStatus.CONFIRMED,
         reservationType: ReservationType.INFORMAL,
         tableId: null,
       });
 
-      await expect(service.seat(reservationId, {}, actorId)).rejects.toThrow(
+      await expect(service.seat(reservationId, {}, user)).rejects.toThrow(
         BadRequestException,
       );
       expect(ordersService.create).not.toHaveBeenCalled();
@@ -561,6 +690,7 @@ describe('ReservationsService', () => {
     it('INFORMAL: creates the order on the staff-chosen table and links it', async () => {
       prisma.reservation.findUnique.mockResolvedValue({
         id: reservationId,
+        restaurantId: user.restaurantId,
         status: ReservationStatus.CONFIRMED,
         reservationType: ReservationType.INFORMAL,
         tableId: null,
@@ -570,14 +700,17 @@ describe('ReservationsService', () => {
       const result = await service.seat(
         reservationId,
         { tableId: 'table-9' },
-        actorId,
+        user,
       );
 
-      expect(ordersService.create).toHaveBeenCalledWith({
-        type: OrderType.DINE_IN,
-        tableId: 'table-9',
-        items: [],
-      });
+      expect(ordersService.create).toHaveBeenCalledWith(
+        {
+          type: OrderType.DINE_IN,
+          tableId: 'table-9',
+          items: [],
+        },
+        user.restaurantId,
+      );
       expect(prisma.reservation.update).toHaveBeenCalledWith({
         where: { id: reservationId },
         data: {
@@ -593,13 +726,28 @@ describe('ReservationsService', () => {
     it('throws BadRequestException if the reservation is not CONFIRMED', async () => {
       prisma.reservation.findUnique.mockResolvedValue({
         id: reservationId,
+        restaurantId: user.restaurantId,
         status: ReservationStatus.PENDING,
         reservationType: ReservationType.INFORMAL,
       });
 
       await expect(
-        service.seat(reservationId, { tableId: 'table-9' }, actorId),
+        service.seat(reservationId, { tableId: 'table-9' }, user),
       ).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws NotFoundException (404, NOT 403) if the reservation belongs to another restaurant', async () => {
+      prisma.reservation.findUnique.mockResolvedValue({
+        id: reservationId,
+        restaurantId: 'restaurant-B',
+        status: ReservationStatus.CONFIRMED,
+        reservationType: ReservationType.INFORMAL,
+      });
+
+      await expect(
+        service.seat(reservationId, { tableId: 'table-9' }, user),
+      ).rejects.toThrow(NotFoundException);
+      expect(ordersService.create).not.toHaveBeenCalled();
     });
   });
 
@@ -607,6 +755,7 @@ describe('ReservationsService', () => {
     it('noShow releases a RESERVED table back to AVAILABLE and does not touch the deposit', async () => {
       prisma.reservation.findUnique.mockResolvedValue({
         id: reservationId,
+        restaurantId: user.restaurantId,
         status: ReservationStatus.CONFIRMED,
         tableId,
         depositCents: 1000,
@@ -626,7 +775,7 @@ describe('ReservationsService', () => {
         }),
       );
 
-      const result = await service.noShow(reservationId);
+      const result = await service.noShow(reservationId, user);
 
       expect(txTableUpdate).toHaveBeenCalledWith({
         where: { id: tableId },
@@ -644,6 +793,7 @@ describe('ReservationsService', () => {
     it('cancel releases the table only if it is currently RESERVED', async () => {
       prisma.reservation.findUnique.mockResolvedValue({
         id: reservationId,
+        restaurantId: user.restaurantId,
         status: ReservationStatus.PENDING,
         tableId,
         depositCents: 0,
@@ -663,7 +813,7 @@ describe('ReservationsService', () => {
         }),
       );
 
-      await service.cancel(reservationId);
+      await service.cancel(reservationId, user);
 
       // Table was still AVAILABLE (deposit never confirmed) — nothing to release.
       expect(txTableUpdate).not.toHaveBeenCalled();
@@ -672,12 +822,39 @@ describe('ReservationsService', () => {
     it('rejects cancelling a reservation that is already SEATED/terminal', async () => {
       prisma.reservation.findUnique.mockResolvedValue({
         id: reservationId,
+        restaurantId: user.restaurantId,
         status: ReservationStatus.SEATED,
         tableId,
       });
 
-      await expect(service.cancel(reservationId)).rejects.toThrow(
+      await expect(service.cancel(reservationId, user)).rejects.toThrow(
         BadRequestException,
+      );
+    });
+
+    it('cancel throws NotFoundException (404, NOT 403) for a reservation belonging to another restaurant', async () => {
+      prisma.reservation.findUnique.mockResolvedValue({
+        id: reservationId,
+        restaurantId: 'restaurant-B',
+        status: ReservationStatus.PENDING,
+        tableId,
+      });
+
+      await expect(service.cancel(reservationId, user)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('noShow throws NotFoundException (404, NOT 403) for a reservation belonging to another restaurant', async () => {
+      prisma.reservation.findUnique.mockResolvedValue({
+        id: reservationId,
+        restaurantId: 'restaurant-B',
+        status: ReservationStatus.CONFIRMED,
+        tableId,
+      });
+
+      await expect(service.noShow(reservationId, user)).rejects.toThrow(
+        NotFoundException,
       );
     });
   });

--- a/src/reservations/reservations.service.ts
+++ b/src/reservations/reservations.service.ts
@@ -13,6 +13,7 @@ import {
   TableStatus,
 } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
+import { DEFAULT_RESTAURANT_ID } from '../common/constants/tenancy';
 import { CreateOrderDto } from '../orders/dto/create-order.dto';
 import { OrdersService } from '../orders/orders.service';
 import { localToUtc, utcToLocalDisplay } from '../common/utils/local-time';
@@ -373,6 +374,7 @@ export class ReservationsService {
       reservationType: dto.reservationType,
       status: ReservationStatus.PENDING,
       createdBy: actorId,
+      restaurantId: DEFAULT_RESTAURANT_ID,
     };
   }
 

--- a/src/reservations/reservations.service.ts
+++ b/src/reservations/reservations.service.ts
@@ -12,8 +12,8 @@ import {
   ReservationType,
   TableStatus,
 } from '@prisma/client';
+import { AuthUser } from '../auth/decorators/current-user.decorator';
 import { PrismaService } from '../prisma/prisma.service';
-import { DEFAULT_RESTAURANT_ID } from '../common/constants/tenancy';
 import { CreateOrderDto } from '../orders/dto/create-order.dto';
 import { OrdersService } from '../orders/orders.service';
 import { localToUtc, utcToLocalDisplay } from '../common/utils/local-time';
@@ -48,7 +48,7 @@ export class ReservationsService {
     private readonly config: ConfigService,
   ) {}
 
-  async create(dto: CreateReservationDto, actorId: string) {
+  async create(dto: CreateReservationDto, user: AuthUser) {
     if (dto.reservationType === ReservationType.INFORMAL) {
       if (dto.tableId || dto.items) {
         throw new BadRequestException(
@@ -56,15 +56,15 @@ export class ReservationsService {
         );
       }
       const reservation = await this.prisma.reservation.create({
-        data: this.baseReservationData(dto, actorId),
+        data: this.baseReservationData(dto, user),
       });
       return this.withReservedForLocal(reservation);
     }
 
     // WITH_PREORDER and DEPOSIT_ONLY both commit a specific table once the
     // deposit is confirmed later — but the table stays AVAILABLE right now.
-    const table = await this.prisma.table.findUnique({
-      where: { id: dto.tableId },
+    const table = await this.prisma.table.findFirst({
+      where: { id: dto.tableId, restaurantId: user.restaurantId },
     });
     if (!table) {
       throw new NotFoundException('Table not found');
@@ -82,10 +82,13 @@ export class ReservationsService {
       // Reuse OrdersService.create() entirely (price-snapshot logic lives
       // there) — pass type TAKEAWAY so no table gets committed yet; the
       // Reservation's own `tableId` tracks the desired table separately.
-      const order = await this.ordersService.create({
-        type: OrderType.TAKEAWAY,
-        items: dto.items,
-      } as CreateOrderDto);
+      const order = await this.ordersService.create(
+        {
+          type: OrderType.TAKEAWAY,
+          items: dto.items,
+        } as CreateOrderDto,
+        user.restaurantId,
+      );
       orderId = order.id;
       depositCents = Math.floor(order.totalCents / 2);
     } else {
@@ -100,7 +103,7 @@ export class ReservationsService {
 
     const reservation = await this.prisma.reservation.create({
       data: {
-        ...this.baseReservationData(dto, actorId),
+        ...this.baseReservationData(dto, user),
         tableId: dto.tableId,
         orderId,
         depositCents,
@@ -109,8 +112,10 @@ export class ReservationsService {
     return this.withReservedForLocal(reservation);
   }
 
-  async findAll(query: ListReservationsQueryDto) {
-    const where: Prisma.ReservationWhereInput = {};
+  async findAll(query: ListReservationsQueryDto, user: AuthUser) {
+    const where: Prisma.ReservationWhereInput = {
+      restaurantId: user.restaurantId,
+    };
     if (query.status) {
       where.status = query.status;
     }
@@ -131,18 +136,18 @@ export class ReservationsService {
     );
   }
 
-  async findOne(id: string) {
+  async findOne(id: string, user: AuthUser) {
     const reservation = await this.prisma.reservation.findUnique({
       where: { id },
     });
-    if (!reservation) {
+    if (!reservation || reservation.restaurantId !== user.restaurantId) {
       throw new NotFoundException('Reservation not found');
     }
     return this.withReservedForLocal(reservation);
   }
 
-  async confirm(id: string, actorId: string) {
-    const reservation = await this.findOne(id);
+  async confirm(id: string, user: AuthUser) {
+    const reservation = await this.findOne(id, user);
     if (reservation.status !== ReservationStatus.PENDING) {
       throw new BadRequestException(
         `Cannot confirm a reservation with status ${reservation.status}`,
@@ -159,7 +164,11 @@ export class ReservationsService {
 
     // WITH_PREORDER / DEPOSIT_ONLY: the deposit has just been confirmed
     // received by staff — this is the moment the table is actually
-    // committed (AVAILABLE -> RESERVED).
+    // committed (AVAILABLE -> RESERVED). reservation.tableId was already
+    // verified to belong to this restaurant when the reservation was
+    // created (see create()), and `reservation` itself was just verified
+    // above via findOne(), so no further cross-tenant check is needed
+    // before mutating the table by its already-scoped id.
     const updated = await this.prisma.$transaction(async (tx) => {
       if (reservation.tableId) {
         await tx.table.update({
@@ -171,7 +180,7 @@ export class ReservationsService {
         where: { id },
         data: {
           status: ReservationStatus.CONFIRMED,
-          depositConfirmedBy: actorId,
+          depositConfirmedBy: user.id,
           depositConfirmedAt: new Date(),
         },
       });
@@ -179,8 +188,8 @@ export class ReservationsService {
     return this.withReservedForLocal(updated);
   }
 
-  async seat(id: string, dto: SeatReservationDto, actorId: string) {
-    const reservation = await this.findOne(id);
+  async seat(id: string, dto: SeatReservationDto, user: AuthUser) {
+    const reservation = await this.findOne(id, user);
     if (reservation.status !== ReservationStatus.CONFIRMED) {
       throw new BadRequestException(
         `Reservation must be CONFIRMED before seating (current: ${reservation.status})`,
@@ -191,9 +200,9 @@ export class ReservationsService {
       case ReservationType.WITH_PREORDER:
         return this.seatWithPreorder(reservation);
       case ReservationType.DEPOSIT_ONLY:
-        return this.seatDepositOnly(reservation, actorId);
+        return this.seatDepositOnly(reservation, user);
       case ReservationType.INFORMAL:
-        return this.seatInformal(reservation, dto);
+        return this.seatInformal(reservation, dto, user);
       default:
         throw new BadRequestException('Unknown reservation type');
     }
@@ -235,7 +244,7 @@ export class ReservationsService {
       tableId: string | null;
       depositCents: number;
     },
-    actorId: string,
+    user: AuthUser,
   ) {
     if (!reservation.tableId) {
       throw new BadRequestException('Reservation has no table assigned');
@@ -243,11 +252,14 @@ export class ReservationsService {
 
     // Reuses OrdersService.create()'s existing table-occupied-check logic
     // (throws if the table went away, sets it OCCUPIED in one transaction).
-    const order = await this.ordersService.create({
-      type: OrderType.DINE_IN,
-      tableId: reservation.tableId,
-      items: [],
-    } as CreateOrderDto);
+    const order = await this.ordersService.create(
+      {
+        type: OrderType.DINE_IN,
+        tableId: reservation.tableId,
+        items: [],
+      } as CreateOrderDto,
+      user.restaurantId,
+    );
 
     await this.prisma.reservation.update({
       where: { id: reservation.id },
@@ -279,7 +291,7 @@ export class ReservationsService {
           discountCents: reservation.depositCents,
           reason: 'Reservation deposit applied',
         },
-        actorId,
+        user,
       );
     }
 
@@ -289,6 +301,7 @@ export class ReservationsService {
   private async seatInformal(
     reservation: { id: string },
     dto: SeatReservationDto,
+    user: AuthUser,
   ) {
     if (!dto.tableId) {
       throw new BadRequestException(
@@ -296,11 +309,14 @@ export class ReservationsService {
       );
     }
 
-    const order = await this.ordersService.create({
-      type: OrderType.DINE_IN,
-      tableId: dto.tableId,
-      items: [],
-    } as CreateOrderDto);
+    const order = await this.ordersService.create(
+      {
+        type: OrderType.DINE_IN,
+        tableId: dto.tableId,
+        items: [],
+      } as CreateOrderDto,
+      user.restaurantId,
+    );
 
     await this.prisma.reservation.update({
       where: { id: reservation.id },
@@ -314,18 +330,22 @@ export class ReservationsService {
     return order;
   }
 
-  async noShow(id: string) {
-    return this.terminate(id, ReservationStatus.NO_SHOW);
+  async noShow(id: string, user: AuthUser) {
+    return this.terminate(id, ReservationStatus.NO_SHOW, user);
   }
 
-  async cancel(id: string) {
-    return this.terminate(id, ReservationStatus.CANCELLED);
+  async cancel(id: string, user: AuthUser) {
+    return this.terminate(id, ReservationStatus.CANCELLED, user);
   }
 
   // Deposits (if any) are intentionally NOT refunded or reapplied here —
   // they're simply forfeited, left as a historical record on the row.
-  private async terminate(id: string, nextStatus: ReservationStatus) {
-    const reservation = await this.findOne(id);
+  private async terminate(
+    id: string,
+    nextStatus: ReservationStatus,
+    user: AuthUser,
+  ) {
+    const reservation = await this.findOne(id, user);
     if (!TERMINABLE_STATUSES.includes(reservation.status)) {
       throw new BadRequestException(
         `Cannot mark reservation as ${nextStatus} from status ${reservation.status}`,
@@ -354,7 +374,7 @@ export class ReservationsService {
 
   private baseReservationData(
     dto: CreateReservationDto,
-    actorId: string,
+    user: AuthUser,
   ): Prisma.ReservationUncheckedCreateInput {
     return {
       customerName: dto.customerName,
@@ -373,8 +393,8 @@ export class ReservationsService {
       specialOccasion: dto.specialOccasion,
       reservationType: dto.reservationType,
       status: ReservationStatus.PENDING,
-      createdBy: actorId,
-      restaurantId: DEFAULT_RESTAURANT_ID,
+      createdBy: user.id,
+      restaurantId: user.restaurantId,
     };
   }
 

--- a/src/restaurants/dto/create-restaurant.dto.ts
+++ b/src/restaurants/dto/create-restaurant.dto.ts
@@ -1,0 +1,17 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
+
+export class CreateRestaurantDto {
+  @ApiProperty({ example: 'El Buen Filo' })
+  @IsString()
+  @IsNotEmpty()
+  name!: string;
+
+  @ApiPropertyOptional({
+    default: 'America/Lima',
+    description: 'IANA timezone used to interpret restaurant-local times',
+  })
+  @IsOptional()
+  @IsString()
+  timezone?: string;
+}

--- a/src/restaurants/restaurants.controller.ts
+++ b/src/restaurants/restaurants.controller.ts
@@ -1,0 +1,34 @@
+import { Body, Controller, Get, Post } from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { Role } from '@prisma/client';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { CreateRestaurantDto } from './dto/create-restaurant.dto';
+import { RestaurantsService } from './restaurants.service';
+
+@ApiTags('restaurants')
+@ApiBearerAuth()
+@Roles(Role.ADMIN)
+@Controller('restaurants')
+export class RestaurantsController {
+  constructor(private readonly restaurantsService: RestaurantsService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'List all restaurants' })
+  @ApiResponse({ status: 200, description: 'List of restaurants' })
+  findAll() {
+    return this.restaurantsService.findAll();
+  }
+
+  @Post()
+  @ApiOperation({ summary: 'Create a new restaurant (empty isolated space)' })
+  @ApiResponse({ status: 201, description: 'Restaurant created' })
+  @ApiResponse({ status: 400, description: 'Validation error' })
+  create(@Body() dto: CreateRestaurantDto) {
+    return this.restaurantsService.create(dto);
+  }
+}

--- a/src/restaurants/restaurants.module.ts
+++ b/src/restaurants/restaurants.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { RestaurantsController } from './restaurants.controller';
+import { RestaurantsService } from './restaurants.service';
+
+@Module({
+  controllers: [RestaurantsController],
+  providers: [RestaurantsService],
+  exports: [RestaurantsService],
+})
+export class RestaurantsModule {}

--- a/src/restaurants/restaurants.service.spec.ts
+++ b/src/restaurants/restaurants.service.spec.ts
@@ -1,0 +1,80 @@
+import { PrismaService } from '../prisma/prisma.service';
+import { RestaurantsService } from './restaurants.service';
+
+type MockPrisma = {
+  restaurant: {
+    create: jest.Mock;
+    findMany: jest.Mock;
+  };
+};
+
+function createMockPrisma(): MockPrisma {
+  return {
+    restaurant: {
+      create: jest.fn(),
+      findMany: jest.fn(),
+    },
+  };
+}
+
+describe('RestaurantsService', () => {
+  let service: RestaurantsService;
+  let prisma: MockPrisma;
+
+  beforeEach(() => {
+    prisma = createMockPrisma();
+    service = new RestaurantsService(prisma as unknown as PrismaService);
+  });
+
+  describe('create', () => {
+    it('creates a Restaurant with the given name and timezone', async () => {
+      const created = {
+        id: 'restaurant-1',
+        name: 'La Mar',
+        timezone: 'Europe/Madrid',
+      };
+      prisma.restaurant.create.mockResolvedValue(created);
+
+      const result = await service.create({
+        name: 'La Mar',
+        timezone: 'Europe/Madrid',
+      });
+
+      expect(prisma.restaurant.create).toHaveBeenCalledWith({
+        data: { name: 'La Mar', timezone: 'Europe/Madrid' },
+      });
+      expect(result).toBe(created);
+    });
+
+    it('defaults timezone to "America/Lima" when not provided', async () => {
+      prisma.restaurant.create.mockResolvedValue({
+        id: 'restaurant-2',
+        name: 'La Mar',
+        timezone: 'America/Lima',
+      });
+
+      await service.create({ name: 'La Mar' });
+
+      expect(prisma.restaurant.create).toHaveBeenCalledWith({
+        data: { name: 'La Mar', timezone: 'America/Lima' },
+      });
+    });
+  });
+
+  describe('findAll', () => {
+    it('returns all restaurants ordered by name', async () => {
+      const restaurants = [
+        { id: 'r1', name: 'El Buen Filo' },
+        { id: 'r2', name: 'La Mar' },
+      ];
+      prisma.restaurant.findMany.mockResolvedValue(restaurants);
+
+      const result = await service.findAll();
+
+      expect(prisma.restaurant.findMany).toHaveBeenCalledWith({
+        orderBy: { name: 'asc' },
+      });
+      expect(result).toBe(restaurants);
+    });
+  });
+});

--- a/src/restaurants/restaurants.service.ts
+++ b/src/restaurants/restaurants.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateRestaurantDto } from './dto/create-restaurant.dto';
+
+@Injectable()
+export class RestaurantsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  // Restaurant is the tenant root — it does not itself belong to another
+  // restaurant, so no restaurantId scoping applies here (unlike every
+  // other service in this codebase).
+  create(dto: CreateRestaurantDto) {
+    return this.prisma.restaurant.create({
+      data: {
+        name: dto.name,
+        timezone: dto.timezone ?? 'America/Lima',
+      },
+    });
+  }
+
+  findAll() {
+    return this.prisma.restaurant.findMany({
+      orderBy: { name: 'asc' },
+    });
+  }
+}

--- a/src/tables/tables.controller.ts
+++ b/src/tables/tables.controller.ts
@@ -14,6 +14,10 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 import { Role } from '@prisma/client';
+import {
+  AuthUser,
+  CurrentUser,
+} from '../auth/decorators/current-user.decorator';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { CreateTableDto } from './dto/create-table.dto';
 import { UpdateTableDto } from './dto/update-table.dto';
@@ -32,16 +36,16 @@ export class TablesController {
     description:
       'List of tables; OCCUPIED tables include a summary of the active order',
   })
-  findAll() {
-    return this.tablesService.findAll();
+  findAll(@CurrentUser() user: AuthUser) {
+    return this.tablesService.findAll(user);
   }
 
   @Get(':id')
   @ApiOperation({ summary: 'Get a single table' })
   @ApiResponse({ status: 200, description: 'Table details' })
   @ApiResponse({ status: 404, description: 'Table not found' })
-  findOne(@Param('id') id: string) {
-    return this.tablesService.findOne(id);
+  findOne(@Param('id') id: string, @CurrentUser() user: AuthUser) {
+    return this.tablesService.findOne(id, user);
   }
 
   @Post()
@@ -49,8 +53,8 @@ export class TablesController {
   @ApiOperation({ summary: 'Create a new table' })
   @ApiResponse({ status: 201, description: 'Table created' })
   @ApiResponse({ status: 400, description: 'Validation error' })
-  create(@Body() dto: CreateTableDto) {
-    return this.tablesService.create(dto);
+  create(@Body() dto: CreateTableDto, @CurrentUser() user: AuthUser) {
+    return this.tablesService.create(dto, user);
   }
 
   @Patch(':id')
@@ -58,8 +62,12 @@ export class TablesController {
   @ApiOperation({ summary: 'Update a table name/capacity' })
   @ApiResponse({ status: 200, description: 'Table updated' })
   @ApiResponse({ status: 404, description: 'Table not found' })
-  update(@Param('id') id: string, @Body() dto: UpdateTableDto) {
-    return this.tablesService.update(id, dto);
+  update(
+    @Param('id') id: string,
+    @Body() dto: UpdateTableDto,
+    @CurrentUser() user: AuthUser,
+  ) {
+    return this.tablesService.update(id, dto, user);
   }
 
   @Delete(':id')
@@ -68,7 +76,7 @@ export class TablesController {
   @ApiResponse({ status: 200, description: 'Table deleted' })
   @ApiResponse({ status: 400, description: 'Table is currently occupied' })
   @ApiResponse({ status: 404, description: 'Table not found' })
-  remove(@Param('id') id: string) {
-    return this.tablesService.remove(id);
+  remove(@Param('id') id: string, @CurrentUser() user: AuthUser) {
+    return this.tablesService.remove(id, user);
   }
 }

--- a/src/tables/tables.service.spec.ts
+++ b/src/tables/tables.service.spec.ts
@@ -1,0 +1,176 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { Role, TableStatus } from '@prisma/client';
+import { AuthUser } from '../auth/decorators/current-user.decorator';
+import { PrismaService } from '../prisma/prisma.service';
+import { TablesService } from './tables.service';
+
+type MockPrisma = {
+  table: {
+    findMany: jest.Mock;
+    findUnique: jest.Mock;
+    create: jest.Mock;
+    update: jest.Mock;
+    delete: jest.Mock;
+  };
+  order: {
+    findFirst: jest.Mock;
+  };
+};
+
+function createMockPrisma(): MockPrisma {
+  return {
+    table: {
+      findMany: jest.fn(),
+      findUnique: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    },
+    order: {
+      findFirst: jest.fn(),
+    },
+  };
+}
+
+function buildUser(overrides: Partial<AuthUser> = {}): AuthUser {
+  return {
+    id: 'user-1',
+    email: 'manager@restosync.local',
+    role: Role.MANAGER,
+    restaurantId: 'restaurant-A',
+    ...overrides,
+  };
+}
+
+describe('TablesService', () => {
+  let service: TablesService;
+  let prisma: MockPrisma;
+  const user = buildUser();
+
+  beforeEach(() => {
+    prisma = createMockPrisma();
+    service = new TablesService(prisma as unknown as PrismaService);
+  });
+
+  describe('findAll', () => {
+    it('scopes the query to the caller restaurantId', async () => {
+      prisma.table.findMany.mockResolvedValue([
+        { id: 't1', status: TableStatus.AVAILABLE },
+      ]);
+
+      await service.findAll(user);
+
+      expect(prisma.table.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { restaurantId: user.restaurantId },
+        }),
+      );
+    });
+
+    it("scopes each OCCUPIED table's activeOrder lookup by the caller restaurantId too", async () => {
+      prisma.table.findMany.mockResolvedValue([
+        { id: 't1', status: TableStatus.OCCUPIED },
+      ]);
+      prisma.order.findFirst.mockResolvedValue(null);
+
+      await service.findAll(user);
+
+      expect(prisma.order.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ restaurantId: user.restaurantId }),
+        }),
+      );
+    });
+  });
+
+  describe('findOne', () => {
+    it('throws NotFoundException if the table does not exist', async () => {
+      prisma.table.findUnique.mockResolvedValue(null);
+
+      await expect(service.findOne('t1', user)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('throws NotFoundException (404, NOT 403) for a table belonging to another restaurant', async () => {
+      prisma.table.findUnique.mockResolvedValue({
+        id: 't1',
+        status: TableStatus.AVAILABLE,
+        restaurantId: 'restaurant-B',
+      });
+
+      await expect(service.findOne('t1', user)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('returns the table when it belongs to the caller restaurant', async () => {
+      prisma.table.findUnique.mockResolvedValue({
+        id: 't1',
+        status: TableStatus.AVAILABLE,
+        restaurantId: user.restaurantId,
+      });
+
+      const result = await service.findOne('t1', user);
+
+      expect(result.id).toBe('t1');
+    });
+  });
+
+  describe('create', () => {
+    it('sets restaurantId from the caller, never from the client', async () => {
+      prisma.table.create.mockResolvedValue({});
+
+      await service.create(
+        {
+          name: 'Mesa 1',
+          // @ts-expect-error simulating a malicious/naive client payload
+          restaurantId: 'restaurant-EVIL',
+        },
+        user,
+      );
+
+      const { data } = prisma.table.create.mock.calls[0][0];
+      expect(data.restaurantId).toBe(user.restaurantId);
+    });
+  });
+
+  describe('update / remove', () => {
+    it('throws NotFoundException (404, NOT 403) when updating a table belonging to another restaurant', async () => {
+      prisma.table.findUnique.mockResolvedValue({
+        id: 't1',
+        restaurantId: 'restaurant-B',
+      });
+
+      await expect(
+        service.update('t1', { name: 'New name' }, user),
+      ).rejects.toThrow(NotFoundException);
+      expect(prisma.table.update).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException (404, NOT 403) when removing a table belonging to another restaurant', async () => {
+      prisma.table.findUnique.mockResolvedValue({
+        id: 't1',
+        status: TableStatus.AVAILABLE,
+        restaurantId: 'restaurant-B',
+      });
+
+      await expect(service.remove('t1', user)).rejects.toThrow(
+        NotFoundException,
+      );
+      expect(prisma.table.delete).not.toHaveBeenCalled();
+    });
+
+    it('throws BadRequestException when removing an OCCUPIED table belonging to the caller restaurant', async () => {
+      prisma.table.findUnique.mockResolvedValue({
+        id: 't1',
+        status: TableStatus.OCCUPIED,
+        restaurantId: user.restaurantId,
+      });
+
+      await expect(service.remove('t1', user)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+  });
+});

--- a/src/tables/tables.service.ts
+++ b/src/tables/tables.service.ts
@@ -5,6 +5,7 @@ import {
 } from '@nestjs/common';
 import { OrderStatus, TableStatus } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
+import { DEFAULT_RESTAURANT_ID } from '../common/constants/tenancy';
 import { CreateTableDto } from './dto/create-table.dto';
 import { UpdateTableDto } from './dto/update-table.dto';
 
@@ -34,6 +35,7 @@ export class TablesService {
       data: {
         name: dto.name,
         capacity: dto.capacity ?? null,
+        restaurantId: DEFAULT_RESTAURANT_ID,
       },
     });
   }

--- a/src/tables/tables.service.ts
+++ b/src/tables/tables.service.ts
@@ -4,8 +4,8 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { OrderStatus, TableStatus } from '@prisma/client';
+import { AuthUser } from '../auth/decorators/current-user.decorator';
 import { PrismaService } from '../prisma/prisma.service';
-import { DEFAULT_RESTAURANT_ID } from '../common/constants/tenancy';
 import { CreateTableDto } from './dto/create-table.dto';
 import { UpdateTableDto } from './dto/update-table.dto';
 
@@ -18,30 +18,33 @@ const ACTIVE_ORDER_STATUSES: OrderStatus[] = Object.values(OrderStatus).filter(
 export class TablesService {
   constructor(private readonly prisma: PrismaService) {}
 
-  async findAll() {
+  async findAll(user: AuthUser) {
     const tables = await this.prisma.table.findMany({
+      where: { restaurantId: user.restaurantId },
       orderBy: { name: 'asc' },
     });
-    return Promise.all(tables.map((table) => this.withActiveOrder(table)));
+    return Promise.all(
+      tables.map((table) => this.withActiveOrder(table, user)),
+    );
   }
 
-  async findOne(id: string) {
-    const table = await this.ensureExists(id);
-    return this.withActiveOrder(table);
+  async findOne(id: string, user: AuthUser) {
+    const table = await this.ensureExists(id, user);
+    return this.withActiveOrder(table, user);
   }
 
-  create(dto: CreateTableDto) {
+  create(dto: CreateTableDto, user: AuthUser) {
     return this.prisma.table.create({
       data: {
         name: dto.name,
         capacity: dto.capacity ?? null,
-        restaurantId: DEFAULT_RESTAURANT_ID,
+        restaurantId: user.restaurantId,
       },
     });
   }
 
-  async update(id: string, dto: UpdateTableDto) {
-    await this.ensureExists(id);
+  async update(id: string, dto: UpdateTableDto, user: AuthUser) {
+    await this.ensureExists(id, user);
     return this.prisma.table.update({
       where: { id },
       data: {
@@ -51,17 +54,17 @@ export class TablesService {
     });
   }
 
-  async remove(id: string) {
-    const table = await this.ensureExists(id);
+  async remove(id: string, user: AuthUser) {
+    const table = await this.ensureExists(id, user);
     if (table.status === TableStatus.OCCUPIED) {
       throw new BadRequestException('Cannot delete an occupied table');
     }
     return this.prisma.table.delete({ where: { id } });
   }
 
-  private async ensureExists(id: string) {
+  private async ensureExists(id: string, user: AuthUser) {
     const table = await this.prisma.table.findUnique({ where: { id } });
-    if (!table) {
+    if (!table || table.restaurantId !== user.restaurantId) {
       throw new NotFoundException('Table not found');
     }
     return table;
@@ -69,13 +72,18 @@ export class TablesService {
 
   private async withActiveOrder<T extends { id: string; status: TableStatus }>(
     table: T,
+    user: AuthUser,
   ) {
     if (table.status !== TableStatus.OCCUPIED) {
       return { ...table, activeOrder: null };
     }
 
     const activeOrder = await this.prisma.order.findFirst({
-      where: { tableId: table.id, status: { in: ACTIVE_ORDER_STATUSES } },
+      where: {
+        tableId: table.id,
+        status: { in: ACTIVE_ORDER_STATUSES },
+        restaurantId: user.restaurantId,
+      },
       orderBy: { createdAt: 'desc' },
       select: { id: true, number: true, totalCents: true },
     });

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -1,6 +1,10 @@
 import { Controller, Get, Param, Query } from '@nestjs/common';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { Role } from '@prisma/client';
+import {
+  AuthUser,
+  CurrentUser,
+} from '../auth/decorators/current-user.decorator';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { PaginationQueryDto } from '../common/dto/pagination-query.dto';
 import { UsersService } from './users.service';
@@ -13,12 +17,12 @@ export class UsersController {
   constructor(private readonly usersService: UsersService) {}
 
   @Get()
-  findAll(@Query() query: PaginationQueryDto) {
-    return this.usersService.findAll(query);
+  findAll(@Query() query: PaginationQueryDto, @CurrentUser() user: AuthUser) {
+    return this.usersService.findAll(query, user);
   }
 
   @Get(':id')
-  findOne(@Param('id') id: string) {
-    return this.usersService.findOne(id);
+  findOne(@Param('id') id: string, @CurrentUser() user: AuthUser) {
+    return this.usersService.findOne(id, user);
   }
 }

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -1,0 +1,112 @@
+import { NotFoundException } from '@nestjs/common';
+import { Role } from '@prisma/client';
+import { AuthUser } from '../auth/decorators/current-user.decorator';
+import { PrismaService } from '../prisma/prisma.service';
+import { UsersService } from './users.service';
+
+type MockPrisma = {
+  user: {
+    findMany: jest.Mock;
+    findUnique: jest.Mock;
+    count: jest.Mock;
+  };
+  $transaction: jest.Mock;
+};
+
+function createMockPrisma(): MockPrisma {
+  return {
+    user: {
+      findMany: jest.fn(),
+      findUnique: jest.fn(),
+      count: jest.fn(),
+    },
+    $transaction: jest.fn(),
+  };
+}
+
+function buildUser(overrides: Partial<AuthUser> = {}): AuthUser {
+  return {
+    id: 'admin-1',
+    email: 'admin@restosync.local',
+    role: Role.ADMIN,
+    restaurantId: 'restaurant-A',
+    ...overrides,
+  };
+}
+
+describe('UsersService', () => {
+  let service: UsersService;
+  let prisma: MockPrisma;
+  const user = buildUser();
+
+  beforeEach(() => {
+    prisma = createMockPrisma();
+    prisma.$transaction.mockImplementation((ops: Promise<unknown>[]) =>
+      Promise.all(ops),
+    );
+    service = new UsersService(prisma as unknown as PrismaService);
+  });
+
+  describe('findAll', () => {
+    it('scopes the query to the caller restaurantId', async () => {
+      prisma.user.findMany.mockResolvedValue([]);
+      prisma.user.count.mockResolvedValue(0);
+
+      await service.findAll({ page: 1, limit: 20 } as any, user);
+
+      expect(prisma.user.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { restaurantId: user.restaurantId },
+        }),
+      );
+      expect(prisma.user.count).toHaveBeenCalledWith({
+        where: { restaurantId: user.restaurantId },
+      });
+    });
+  });
+
+  describe('findOne', () => {
+    it('returns the user (without restaurantId) when they belong to the caller restaurant', async () => {
+      prisma.user.findUnique.mockResolvedValue({
+        id: 'target-1',
+        email: 'staff@restosync.local',
+        firstName: null,
+        lastName: null,
+        role: Role.WAITER,
+        active: true,
+        createdAt: new Date('2026-01-01'),
+        restaurantId: user.restaurantId,
+      });
+
+      const result = await service.findOne('target-1', user);
+
+      expect(result).not.toHaveProperty('restaurantId');
+      expect(result.id).toBe('target-1');
+    });
+
+    it('throws NotFoundException if the user does not exist', async () => {
+      prisma.user.findUnique.mockResolvedValue(null);
+
+      await expect(service.findOne('target-1', user)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('throws NotFoundException (404, NOT 403) for a user belonging to another restaurant', async () => {
+      prisma.user.findUnique.mockResolvedValue({
+        id: 'target-1',
+        email: 'staff@other.local',
+        firstName: null,
+        lastName: null,
+        role: Role.WAITER,
+        active: true,
+        createdAt: new Date('2026-01-01'),
+        restaurantId: 'restaurant-B',
+      });
+
+      await expect(service.findOne('target-1', user)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+});

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
+import { AuthUser } from '../auth/decorators/current-user.decorator';
 import { PrismaService } from '../prisma/prisma.service';
 import {
   paginate,
@@ -20,27 +21,31 @@ const safeSelect = {
 export class UsersService {
   constructor(private readonly prisma: PrismaService) {}
 
-  async findAll(query: PaginationQueryDto) {
+  async findAll(query: PaginationQueryDto, user: AuthUser) {
+    const where: Prisma.UserWhereInput = { restaurantId: user.restaurantId };
     const [data, total] = await this.prisma.$transaction([
       this.prisma.user.findMany({
+        where,
         select: safeSelect,
         skip: query.skip,
         take: query.limit,
         orderBy: { createdAt: 'desc' },
       }),
-      this.prisma.user.count(),
+      this.prisma.user.count({ where }),
     ]);
     return paginate(data, total, query.page, query.limit);
   }
 
-  async findOne(id: string) {
-    const user = await this.prisma.user.findUnique({
+  async findOne(id: string, user: AuthUser) {
+    const target = await this.prisma.user.findUnique({
       where: { id },
-      select: safeSelect,
+      select: { ...safeSelect, restaurantId: true },
     });
-    if (!user) {
+    if (!target || target.restaurantId !== user.restaurantId) {
       throw new NotFoundException('User not found');
     }
-    return user;
+    const { restaurantId: _omitted, ...safeUser } = target;
+    void _omitted;
+    return safeUser;
   }
 }

--- a/test/restaurants.e2e-spec.ts
+++ b/test/restaurants.e2e-spec.ts
@@ -1,0 +1,114 @@
+import { ValidationPipe, INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import request from 'supertest';
+import { AppModule } from '../src/app.module';
+
+// Covers #148: onboarding a new restaurant. The Restaurant row is the
+// tenant root — creating one provisions an empty, isolated data space
+// (enforced by the #152 restaurantId scoping already in every service);
+// no child data is auto-provisioned.
+describe('Restaurants (e2e)', () => {
+  let app: INestApplication;
+  let adminToken: string;
+  let cashierToken: string;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication({ rawBody: true });
+    app.setGlobalPrefix('api', { exclude: ['health'] });
+    app.useGlobalPipes(
+      new ValidationPipe({ whitelist: true, transform: true }),
+    );
+    await app.init();
+
+    const adminLogin = await request(app.getHttpServer())
+      .post('/api/auth/login')
+      .send({ email: 'admin@restosync.local', password: 'Admin123!' })
+      .expect(200);
+    adminToken = adminLogin.body.accessToken;
+
+    const cashierLogin = await request(app.getHttpServer())
+      .post('/api/auth/login')
+      .send({ email: 'cashier@restosync.local', password: 'Cashier123!' })
+      .expect(200);
+    cashierToken = cashierLogin.body.accessToken;
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe('POST /restaurants', () => {
+    it('ADMIN creates a new restaurant', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/api/restaurants')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ name: `La Mar ${Date.now()}` })
+        .expect(201);
+
+      expect(res.body.id).toBeDefined();
+      expect(res.body.name).toContain('La Mar');
+      expect(res.body.timezone).toBe('America/Lima');
+    });
+
+    it('ADMIN can create a restaurant with a custom timezone', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/api/restaurants')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ name: `Madrid ${Date.now()}`, timezone: 'Europe/Madrid' })
+        .expect(201);
+
+      expect(res.body.timezone).toBe('Europe/Madrid');
+    });
+
+    it('rejects a missing name with 400', async () => {
+      await request(app.getHttpServer())
+        .post('/api/restaurants')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ timezone: 'America/Lima' })
+        .expect(400);
+    });
+
+    it('non-admin role (CASHIER) is rejected with 403', async () => {
+      await request(app.getHttpServer())
+        .post('/api/restaurants')
+        .set('Authorization', `Bearer ${cashierToken}`)
+        .send({ name: 'Nope' })
+        .expect(403);
+    });
+
+    it('unauthenticated request is rejected with 401', async () => {
+      await request(app.getHttpServer())
+        .post('/api/restaurants')
+        .send({ name: 'Nope' })
+        .expect(401);
+    });
+  });
+
+  describe('GET /restaurants', () => {
+    it('ADMIN can list all restaurants', async () => {
+      const res = await request(app.getHttpServer())
+        .get('/api/restaurants')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .expect(200);
+
+      expect(Array.isArray(res.body)).toBe(true);
+      // At minimum the default "El Buen Filo" restaurant from #149 exists.
+      expect(res.body.length).toBeGreaterThan(0);
+    });
+
+    it('non-admin role (CASHIER) is rejected with 403', async () => {
+      await request(app.getHttpServer())
+        .get('/api/restaurants')
+        .set('Authorization', `Bearer ${cashierToken}`)
+        .expect(403);
+    });
+
+    it('unauthenticated request is rejected with 401', async () => {
+      await request(app.getHttpServer()).get('/api/restaurants').expect(401);
+    });
+  });
+});

--- a/test/tenant-isolation.e2e-spec.ts
+++ b/test/tenant-isolation.e2e-spec.ts
@@ -1,0 +1,447 @@
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { Role } from '@prisma/client';
+import * as bcrypt from 'bcryptjs';
+import request from 'supertest';
+import { io, Socket } from 'socket.io-client';
+import { AppModule } from '../src/app.module';
+import { PrismaService } from '../src/prisma/prisma.service';
+
+// #153: end-to-end proof that cross-tenant isolation holds through the REAL
+// HTTP + WebSocket stack. Two real restaurants, two real staff accounts,
+// and real data created via the public API (not mocks). Each scenario
+// asserts the specific expected status code (404) AND the specific absence
+// of data — explicitly proving the wrong thing did NOT happen, not just
+// that the right thing did.
+
+const EVENT_TIMEOUT_MS = 5000;
+const NO_EVENT_WINDOW_MS = 1000;
+
+function waitForEvent<T = unknown>(
+  socket: Socket,
+  event: string,
+  timeoutMs = EVENT_TIMEOUT_MS,
+): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const cleanup = () => {
+      clearTimeout(timer);
+      socket.off(event, onEvent);
+    };
+    const onEvent = (data: T) => {
+      cleanup();
+      resolve(data);
+    };
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error(`Timed out waiting for socket event '${event}'`));
+    }, timeoutMs);
+    socket.on(event, onEvent);
+  });
+}
+
+function waitForNoEvent(
+  socket: Socket,
+  event: string,
+  timeoutMs = NO_EVENT_WINDOW_MS,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const cleanup = () => {
+      clearTimeout(timer);
+      socket.off(event, onEvent);
+    };
+    const onEvent = () => {
+      settled = true;
+      cleanup();
+      reject(new Error(`Did not expect socket event '${event}'`));
+    };
+    const timer = setTimeout(() => {
+      if (settled) return;
+      cleanup();
+      resolve();
+    }, timeoutMs);
+    socket.on(event, onEvent);
+  });
+}
+
+function connect(port: number, token?: string): Socket {
+  return io(`http://127.0.0.1:${port}`, {
+    auth: token ? { token } : {},
+    transports: ['websocket'],
+    forceNew: true,
+    reconnection: false,
+  });
+}
+
+describe('Tenant Isolation (e2e)', () => {
+  let app: INestApplication;
+  let prisma: PrismaService;
+  let port: number;
+
+  let adminToken: string;
+  let staffAToken: string;
+  let staffBToken: string;
+
+  let restaurantAId: string;
+  let restaurantBId: string;
+  let menuItemAId: string;
+  let menuItemBId: string;
+
+  const sockets: Socket[] = [];
+  const ts = Date.now();
+
+  const auth = (token: string) => ({ Authorization: `Bearer ${token}` });
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication({ rawBody: true });
+    app.setGlobalPrefix('api', { exclude: ['health'] });
+    app.useGlobalPipes(
+      new ValidationPipe({ whitelist: true, transform: true }),
+    );
+    await app.init();
+    await app.listen(0, '127.0.0.1');
+
+    prisma = app.get(PrismaService);
+    port = app.getHttpServer().address().port;
+
+    // Seeded platform admin (used only to onboard restaurants via #148).
+    const adminLogin = await request(app.getHttpServer())
+      .post('/api/auth/login')
+      .send({ email: 'admin@restosync.local', password: 'Admin123!' })
+      .expect(200);
+    adminToken = adminLogin.body.accessToken;
+
+    // Two real restaurants.
+    const resA = await request(app.getHttpServer())
+      .post('/api/restaurants')
+      .set(auth(adminToken))
+      .send({ name: `Tenant A ${ts}` })
+      .expect(201);
+    restaurantAId = resA.body.id;
+
+    const resB = await request(app.getHttpServer())
+      .post('/api/restaurants')
+      .set(auth(adminToken))
+      .send({ name: `Tenant B ${ts}` })
+      .expect(201);
+    restaurantBId = resB.body.id;
+
+    // register() still assigns the default restaurant, so staff accounts
+    // are created directly via Prisma with an explicit restaurantId.
+    const staffAEmail = `tenant_a_${ts}@example.com`;
+    const staffBEmail = `tenant_b_${ts}@example.com`;
+    await prisma.user.create({
+      data: {
+        email: staffAEmail,
+        passwordHash: await bcrypt.hash('TenantA123!', 10),
+        role: Role.ADMIN,
+        restaurantId: restaurantAId,
+        firstName: 'Tenant',
+        lastName: 'A',
+      },
+    });
+    await prisma.user.create({
+      data: {
+        email: staffBEmail,
+        passwordHash: await bcrypt.hash('TenantB123!', 10),
+        role: Role.ADMIN,
+        restaurantId: restaurantBId,
+        firstName: 'Tenant',
+        lastName: 'B',
+      },
+    });
+
+    const loginA = await request(app.getHttpServer())
+      .post('/api/auth/login')
+      .send({ email: staffAEmail, password: 'TenantA123!' })
+      .expect(200);
+    staffAToken = loginA.body.accessToken;
+
+    const loginB = await request(app.getHttpServer())
+      .post('/api/auth/login')
+      .send({ email: staffBEmail, password: 'TenantB123!' })
+      .expect(200);
+    staffBToken = loginB.body.accessToken;
+
+    // Menu fixtures scoped to each restaurant (menu-item creation is
+    // ADMIN-only via HTTP and the seeded admin lives in the default
+    // restaurant, so fixtures are created directly here).
+    const categoryA = await prisma.category.create({
+      data: { name: `Cat A ${ts}`, restaurantId: restaurantAId },
+    });
+    const categoryB = await prisma.category.create({
+      data: { name: `Cat B ${ts}`, restaurantId: restaurantBId },
+    });
+    const itemA = await prisma.menuItem.create({
+      data: {
+        name: `Burger A ${ts}`,
+        priceCents: 1200,
+        categoryId: categoryA.id,
+        restaurantId: restaurantAId,
+      },
+    });
+    const itemB = await prisma.menuItem.create({
+      data: {
+        name: `Burger B ${ts}`,
+        priceCents: 1200,
+        categoryId: categoryB.id,
+        restaurantId: restaurantBId,
+      },
+    });
+    menuItemAId = itemA.id;
+    menuItemBId = itemB.id;
+  });
+
+  afterEach(() => {
+    for (const socket of sockets.splice(0)) {
+      socket.close();
+    }
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe('(a) Restaurant B staff cannot read Restaurant A data', () => {
+    it('A creates Order/Table/Reservation/InventoryItem; B sees 404 by id and absence in lists', async () => {
+      const table = await request(app.getHttpServer())
+        .post('/api/tables')
+        .set(auth(staffAToken))
+        .send({ name: `TblA ${ts}` })
+        .expect(201);
+
+      const inventory = await request(app.getHttpServer())
+        .post('/api/inventory')
+        .set(auth(staffAToken))
+        .send({ name: `InvA ${ts}`, unit: 'kg', quantityOnHand: 10 })
+        .expect(201);
+
+      const reservation = await request(app.getHttpServer())
+        .post('/api/reservations')
+        .set(auth(staffAToken))
+        .send({
+          customerName: 'Jane Doe',
+          customerPhone: '+51999999999',
+          partySize: 2,
+          reservedFor: '2099-01-01T14:00:00',
+          reservationType: 'INFORMAL',
+        })
+        .expect(201);
+
+      const order = await request(app.getHttpServer())
+        .post('/api/orders')
+        .set(auth(staffAToken))
+        .send({ type: 'TAKEAWAY', items: [{ menuItemId: menuItemAId, quantity: 1 }] })
+        .expect(201);
+
+      // B cannot fetch any of A's records by id — 404, not 403, not data.
+      await request(app.getHttpServer())
+        .get(`/api/tables/${table.body.id}`)
+        .set(auth(staffBToken))
+        .expect(404);
+      await request(app.getHttpServer())
+        .get(`/api/inventory/${inventory.body.id}`)
+        .set(auth(staffBToken))
+        .expect(404);
+      await request(app.getHttpServer())
+        .get(`/api/reservations/${reservation.body.id}`)
+        .set(auth(staffBToken))
+        .expect(404);
+      await request(app.getHttpServer())
+        .get(`/api/orders/${order.body.id}`)
+        .set(auth(staffBToken))
+        .expect(404);
+
+      // B's lists do not contain A's records.
+      const tablesB = await request(app.getHttpServer())
+        .get('/api/tables')
+        .set(auth(staffBToken))
+        .expect(200);
+      expect(tablesB.body.map((t: { id: string }) => t.id)).not.toContain(
+        table.body.id,
+      );
+
+      const inventoryB = await request(app.getHttpServer())
+        .get('/api/inventory')
+        .set(auth(staffBToken))
+        .expect(200);
+      expect(inventoryB.body.map((i: { id: string }) => i.id)).not.toContain(
+        inventory.body.id,
+      );
+
+      const reservationsB = await request(app.getHttpServer())
+        .get('/api/reservations')
+        .set(auth(staffBToken))
+        .expect(200);
+      expect(reservationsB.body.map((r: { id: string }) => r.id)).not.toContain(
+        reservation.body.id,
+      );
+
+      const ordersB = await request(app.getHttpServer())
+        .get('/api/orders')
+        .set(auth(staffBToken))
+        .expect(200);
+      expect(ordersB.body.data.map((o: { id: string }) => o.id)).not.toContain(
+        order.body.id,
+      );
+
+      // Positive control: A CAN still see its own records.
+      await request(app.getHttpServer())
+        .get(`/api/tables/${table.body.id}`)
+        .set(auth(staffAToken))
+        .expect(200);
+    });
+  });
+
+  describe('(b) Restaurant A staff cannot fetch Restaurant B record by id', () => {
+    it('returns 404, not 403, not the actual data', async () => {
+      const tableB = await request(app.getHttpServer())
+        .post('/api/tables')
+        .set(auth(staffBToken))
+        .send({ name: `TblB ${ts}` })
+        .expect(201);
+
+      await request(app.getHttpServer())
+        .get(`/api/tables/${tableB.body.id}`)
+        .set(auth(staffAToken))
+        .expect(404);
+    });
+  });
+
+  describe('(c) Restaurant A staff cannot update/delete Restaurant B record', () => {
+    it('returns 404 for both update and delete, and no mutation occurs', async () => {
+      const tableB = await request(app.getHttpServer())
+        .post('/api/tables')
+        .set(auth(staffBToken))
+        .send({ name: `TblB Mut ${ts}`, capacity: 4 })
+        .expect(201);
+
+      // A tries to mutate B's table — both must 404.
+      await request(app.getHttpServer())
+        .patch(`/api/tables/${tableB.body.id}`)
+        .set(auth(staffAToken))
+        .send({ name: 'HACKED' })
+        .expect(404);
+
+      await request(app.getHttpServer())
+        .delete(`/api/tables/${tableB.body.id}`)
+        .set(auth(staffAToken))
+        .expect(404);
+
+      // Prove no mutation occurred: B still sees its own, unmodified table.
+      const stillThere = await request(app.getHttpServer())
+        .get(`/api/tables/${tableB.body.id}`)
+        .set(auth(staffBToken))
+        .expect(200);
+      expect(stillThere.body.name).toBe(`TblB Mut ${ts}`);
+      expect(stillThere.body.capacity).toBe(4);
+    });
+  });
+
+  describe('(d) create() ignores client-supplied restaurantId', () => {
+    it('a record created by A staff is scoped to A even when the body tries to force B', async () => {
+      const sneaky = await request(app.getHttpServer())
+        .post('/api/tables')
+        .set(auth(staffAToken))
+        .send({ name: `Sneaky ${ts}`, restaurantId: restaurantBId })
+        .expect(201);
+
+      // The record must belong to A (caller's own restaurant), never B.
+      await request(app.getHttpServer())
+        .get(`/api/tables/${sneaky.body.id}`)
+        .set(auth(staffAToken))
+        .expect(200);
+
+      await request(app.getHttpServer())
+        .get(`/api/tables/${sneaky.body.id}`)
+        .set(auth(staffBToken))
+        .expect(404);
+    });
+  });
+
+  describe('(e) WebSocket isolation: A staff does not receive B order events', () => {
+    it('B\'s order status change reaches B staff but never A staff', async () => {
+      const orderB = await request(app.getHttpServer())
+        .post('/api/orders')
+        .set(auth(staffBToken))
+        .send({ type: 'TAKEAWAY', items: [{ menuItemId: menuItemBId, quantity: 1 }] })
+        .expect(201);
+
+      const staffA = connect(port, staffAToken);
+      const staffB = connect(port, staffBToken);
+      sockets.push(staffA, staffB);
+      await Promise.all([
+        waitForEvent(staffA, 'connect'),
+        waitForEvent(staffB, 'connect'),
+      ]);
+
+      const staffBEvent = waitForEvent(staffB, 'order.status_changed');
+      const staffANone = waitForNoEvent(staffA, 'order.status_changed');
+
+      await request(app.getHttpServer())
+        .patch(`/api/orders/${orderB.body.id}/status`)
+        .set(auth(staffBToken))
+        .send({ status: 'PENDING' })
+        .expect(200);
+
+      // Prove delivery to B first, then prove exclusion from A.
+      const bPayload = await staffBEvent;
+      expect(bPayload).toMatchObject({
+        orderId: orderB.body.id,
+        status: 'PENDING',
+      });
+      await staffANone;
+    });
+  });
+
+  describe('(f) Audit log isolation', () => {
+    it('an audit entry written by A is not visible to B', async () => {
+      const orderA = await request(app.getHttpServer())
+        .post('/api/orders')
+        .set(auth(staffAToken))
+        .send({ type: 'TAKEAWAY', items: [{ menuItemId: menuItemAId, quantity: 1 }] })
+        .expect(201);
+
+      // Applying a discount writes an AuditLog entry scoped to A.
+      await request(app.getHttpServer())
+        .patch(`/api/orders/${orderA.body.id}/discount`)
+        .set(auth(staffAToken))
+        .send({ discountType: 'FIXED', discountCents: 100, reason: 'test' })
+        .expect(200);
+
+      // A sees its own audit entry.
+      const aLog = await request(app.getHttpServer())
+        .get(`/api/orders/${orderA.body.id}/audit-log`)
+        .set(auth(staffAToken))
+        .expect(200);
+      expect(aLog.body.length).toBeGreaterThan(0);
+
+      // B sees nothing (empty list, not the entry).
+      const bLog = await request(app.getHttpServer())
+        .get(`/api/orders/${orderA.body.id}/audit-log`)
+        .set(auth(staffBToken))
+        .expect(200);
+      expect(bLog.body).toEqual([]);
+    });
+  });
+
+  describe('(g) Prisma Extension backstop', () => {
+    it('throws when a tenant-owned model query is missing a restaurantId filter', async () => {
+      // Well-behaved services never trigger this — a raw, deliberately
+      // unfiltered query proves the defense-in-depth layer actually fires.
+      await expect(
+        prisma.order.findMany({ where: { status: 'DRAFT' } }),
+      ).rejects.toThrow(/Tenant guard: Order\.findMany\(\)/);
+    });
+
+    it('does NOT throw for a properly scoped query (control)', async () => {
+      await expect(
+        prisma.order.findMany({ where: { restaurantId: restaurantAId } }),
+      ).resolves.toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
Closes #149,
Closes #151,
Closes #147,
Closes #152,
Closes #173,
Closes #146,
Closes #148,
Closes #153 

## Summary
Implements epic #9 — full multi-restaurant data isolation. Every
tenant-owned entity is now scoped to a Restaurant, enforced at the
service layer with a Prisma Client Extension backstop, carried through
JWT auth, and verified end-to-end (including the WebSocket layer built
in epic #8).

## Changes

### Schema & migration (#149)
- New Restaurant model (name, timezone)
- Direct restaurantId column on every tenant-owned entity: User,
  Category, MenuItem, Order, OrderItem, Table, InventoryItem,
  StockAdjustment, Reservation, CashRegisterSession, Payment, AuditLog
- Two-step migration (nullable → backfill → NOT NULL) to safely
  migrate existing data
- Backfill creates a default "El Buen Filo" restaurant for all
  pre-existing rows

### Auth (#151, #147)
- restaurantId carried in JWT payload and AuthUser
- register() assigns the default restaurant (temporary, until #148's
  real onboarding is wired into registration)

### Isolation enforcement (#152, #173, #146)
- Every service (orders, tables, reservations, inventory, cash
  register, payments, reports, audit, menu) scoped by the caller's
  restaurantId
- Prisma Client Extension backstop: throws if a query to a
  tenant-owned model is missing a restaurantId filter — validates,
  does not silently inject
- Cross-restaurant access returns 404 consistently (not 403) —
  doesn't reveal that a record exists in another tenant
- create() always uses the caller's own restaurantId, ignoring any
  client-supplied value
- RealtimeGateway (#8) now scopes staff-room events per-restaurant
  instead of one global room

### Onboarding (#148)
- POST /restaurants (ADMIN only) — create a new restaurant
- GET /restaurants — list restaurants

### Tests (#153)
- Full e2e suite proving isolation across two real restaurants:
  cross-restaurant 404 on reads/updates/deletes, create() scoping,
  WebSocket event isolation, audit log isolation, and a direct proof
  that the Prisma Extension backstop throws on an unscoped query

## Design decisions made during Crítica (see linked issues for full
rationale)
- Direct restaurantId columns on every entity (not inherited via
  relation) — chosen for query simplicity and to minimize missed-JOIN
  risk
- Shared DB + restaurantId filtering, not schema-per-tenant (#150,
  documented as an ADR on the issue)
- 404 (not 403) fixed as the consistent response for cross-tenant access
- Prisma middleware corrected to Prisma Client Extensions ($use() was
  removed in Prisma 6.14)
- New #173 sub-issue added — the WebSocket gateway from epic #8 wasn't
  originally scoped for multi-tenancy; found during Crítica

## Tests
267+ unit tests, 7 e2e suites / 111 e2e tests (full suite run twice
after a clean `prisma migrate reset` to rule out flakiness from
accumulated dev data).