### PR TITLE
feat(seed): make the demo seed runnable in the deployed container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,5 +46,6 @@ jobs:
       - run: npx prisma db seed
       - run: npm run lint
       - run: npm run build
+      - run: npm run build:seed
       - run: npm run test:cov
       - run: npm run test:e2e

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,9 @@ COPY prisma ./prisma
 RUN npm ci
 
 COPY . .
-RUN npx prisma generate && npm run build
+# build the app, then compile the demo seed to dist/prisma/seed.js so it can
+# be run in the runtime image (which has no ts-node): `npm run seed:prod`
+RUN npx prisma generate && npm run build && npm run build:seed
 
 # --- Runtime stage ---
 FROM node:22-alpine AS runner
@@ -24,6 +26,7 @@ RUN npm ci --omit=dev && npx prisma generate
 
 COPY --from=builder /app/dist ./dist
 RUN test -f dist/main.js || (echo "dist/main.js missing — nest build produced no output" && exit 1)
+RUN test -f dist/prisma/seed.js || (echo "dist/prisma/seed.js missing — build:seed produced no output" && exit 1)
 
 EXPOSE 3000
 CMD ["node", "dist/main"]

--- a/README.md
+++ b/README.md
@@ -77,6 +77,20 @@ GitHub Actions authenticates with the existing `FLY_API_TOKEN` repo secret.
 Browser origins allowed to call the API are set via `CORS_ORIGINS` in
 `infra/fly.toml` (see `src/common/cors.ts`).
 
+### Seeding the deployed database
+
+`prisma/seed.ts` is compiled into the image (`dist/prisma/seed.js`, via
+`build:seed`) so it can run in the runtime container, which has no `ts-node`.
+It's fully idempotent (upserts) — safe to re-run. Creates the default
+restaurant **"El Buen Filo"** (`00000000-0000-4000-8000-000000000001` — the
+`DEFAULT_RESTAURANT_ID` every request is currently scoped to), the demo users
+(`admin@restosync.local` / `Admin123!`, plus cashier/waiter/manager), a Peruvian
+demo menu, tables and sample orders.
+
+```bash
+flyctl ssh console -a restosync-api -C "npm run seed:prod"
+```
+
 ## API docs & client publishing
 
 The OpenAPI spec is the **contract** shared with consumers (e.g. `restosync-web`). On every

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
   "name": "restosync-api",
   "version": "0.1.9",
-  "description": "NestJS REST API for restaurant management — menu, orders, payments",
+  "description": "NestJS REST API for restaurant management \u2014 menu, orders, payments",
   "author": "Carlos Sandoval Montoya",
   "private": true,
   "license": "UNLICENSED",
   "scripts": {
     "build": "nest build",
+    "build:seed": "tsc -p prisma/tsconfig.seed.json",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",
     "start:dev": "nest start --watch",
@@ -22,6 +23,7 @@
     "prisma:deploy": "prisma migrate deploy",
     "prisma:studio": "prisma studio",
     "prisma:seed": "ts-node prisma/seed.ts",
+    "seed:prod": "node dist/prisma/seed.js",
     "openapi:generate": "ts-node -r tsconfig-paths/register scripts/generate-openapi.ts"
   },
   "prisma": {

--- a/prisma/tsconfig.seed.json
+++ b/prisma/tsconfig.seed.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": false,
+    "incremental": false,
+    "sourceMap": false,
+    "outDir": "../dist",
+    "rootDir": ".."
+  },
+  "include": ["seed.ts"]
+}


### PR DESCRIPTION
Empareja con la necesidad de tener datos en el ambiente cloud.

`prisma/seed.ts` usa `ts-node` (devDependency, ausente en la imagen runtime). Se compila a `dist/prisma/seed.js` durante el build de Docker (`build:seed`) para poder seedear el ambiente desplegado:

```
flyctl ssh console -a restosync-api -C "npm run seed:prod"
```

Idempotente (upserts). Crea:
- restaurante **"El Buen Filo"** (`00000000-0000-4000-8000-000000000001` = `DEFAULT_RESTAURANT_ID`, al que el API escopa **toda** request hoy)
- usuarios demo: `admin@restosync.local` / `Admin123!` (+ cashier/waiter/manager)
- menú demo peruano (5 categorías, ~13 platos, modifiers), mesas, órdenes de ejemplo

- `prisma/tsconfig.seed.json` — compila solo `seed.ts`
- `Dockerfile` — corre `build:seed`, valida que exista `dist/prisma/seed.js`
- `ci.yml` — `build:seed` en CI para atrapar errores de compilación

## Sobre "la empresa por defecto"

El API **ya** escopa todo a `DEFAULT_RESTAURANT_ID` (ver `src/common/constants/tenancy.ts`). El web no necesita enviar nada — cuando aterrice el multi-tenancy real por request (#151/#152), ahí el web mandará el contexto de restaurante.

https://claude.ai/code/session_014T7zSHJrPY3mh7fz9m2t64