### PR TITLE
fix(openapi): include page/limit in the spec for paginated list endpoints

### DIFF
--- a/src/common/dto/pagination-query.dto.ts
+++ b/src/common/dto/pagination-query.dto.ts
@@ -3,14 +3,18 @@ import { Type } from 'class-transformer';
 import { IsInt, IsOptional, Max, Min } from 'class-validator';
 
 export class PaginationQueryDto {
-  @ApiPropertyOptional({ default: 1, minimum: 1 })
+  // `type: Number` is required: openapi:generate runs under ts-node without the
+  // @nestjs/swagger CLI plugin, so it can't infer the type of an inherited
+  // property with a default value — without it, `page`/`limit` are dropped from
+  // the spec of every DTO that extends this one (menu items, reservations, …).
+  @ApiPropertyOptional({ type: Number, default: 1, minimum: 1 })
   @IsOptional()
   @Type(() => Number)
   @IsInt()
   @Min(1)
   page = 1;
 
-  @ApiPropertyOptional({ default: 20, minimum: 1, maximum: 100 })
+  @ApiPropertyOptional({ type: Number, default: 20, minimum: 1, maximum: 100 })
   @IsOptional()
   @Type(() => Number)
   @IsInt()


### PR DESCRIPTION
`MenuItemQueryDto` / `ListReservationsQueryDto` extend `PaginationQueryDto`, but `openapi:generate` runs under ts-node (no @nestjs/swagger CLI plugin) so it can't infer the type of the **inherited** `page`/`limit` properties with default values → they were silently missing from the generated spec. So the generated `restosync-web` client had no `page` param and couldn't do server-side pagination.

Fix: explicit `type: Number` on both. Now `/menu/items` and `/reservations` expose `page`/`limit`.

On merge, the Docs workflow republishes the spec and dispatches `update-openapi-client` to restosync-web.

29 tests pass.

https://claude.ai/code/session_014T7zSHJrPY3mh7fz9m2t64